### PR TITLE
Add NPM Scripts to Generate Doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 @types
-
+doc/
 coverage
 .vscode
 test/**/output

--- a/package.json
+++ b/package.json
@@ -17,7 +17,13 @@
     "test:all": "jest",
     "test": "npm run test:unit",
     "lint": "eslint",
-    "cli": "node lib/cli.js"
+    "cli": "node lib/cli.js",
+    "doc:clean": "rm -rf ./doc",
+    "doc:prepare": "npm run doc:clean && mkdir -p doc/types",
+    "doc:typegen": "./node_modules/.bin/tsc ./lib/*.js  --skipLibCheck --declaration --allowJs --emitDeclarationOnly --outDir doc/types && cd doc/types && tsc --init",
+    "doc:html": "npm run doc:typegen && echo 'FILES' && ./node_modules/.bin/typedoc 'doc/types/**/*.d.ts' --entryPointStrategy expand --out doc/html --tsconfig doc/types/tsconfig.json",
+    "doc:cli": "npm run cli -- --help > ./doc/cli.txt",
+    "doc:full": "npm run doc:prepare && npm run doc:html && npm run doc:cli"
   },
   "files": [
     "lib/",
@@ -39,6 +45,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^29",
+    "typedoc": "^0.24.8",
     "typescript": ">=4.6.4"
   },
   "jest": {


### PR DESCRIPTION
Generates HTML typedoc to `doc/html/` and the help text to `doc/cli.txt`. 