### PR TITLE
Support `array of` Syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.4.1 - TBD
 
+### Added
+- Support for `array of` syntax
+
+
 ## Version 0.4.0 - 2023-07-06
 ### Added
 - Support for enums when they are defined separately (not inline in the property type of an entity)

--- a/lib/components/resolver.js
+++ b/lib/components/resolver.js
@@ -212,13 +212,14 @@ class Resolver {
                 {
                     Association: [createToOneAssociation, createToManyAssociation],
                     Composition: [createCompositionOfOne, createCompositionOfMany],
+                    array: [createArrayOf, createArrayOf]
                 }[element.constructor.name] ?? []
 
             if (toOne && toMany) {
-                const target = typeof element.target === 'string' ? { type: element.target } : element.target
+                const target = element.items ?? (typeof element.target === 'string' ? { type: element.target } : element.target)
                 const { singular, plural } = this.resolveAndRequire(target, file).typeInfo.inflection
                 typeName =
-                    cardinality > 1 ? toMany(plural) : toOne(this.visitor.isSelfReference(element.target) ? 'this' : singular)
+                    cardinality > 1 ? toMany(plural) : toOne(this.visitor.isSelfReference(target) ? 'this' : singular)
                 file.addImport(baseDefinitions.path)
             }
         } else {
@@ -258,8 +259,17 @@ class Resolver {
             typeInfo.inflection = this.inflect(typeInfo)
         }
 
+        /*
         if (typeInfo.isArray === true) {
             typeName = createArrayOf(typeName)
+        }
+        */
+
+        // add fallback inflection. Mainly needed for array-of with builtin types.
+        // (array-of relies on inflection being present, which is not the case in builtin)
+        typeInfo.inflection ??= {
+            singular: typeName,
+            plural: typeName
         }
 
         // FIXME: typeName could probably just become part of typeInfo
@@ -348,6 +358,7 @@ class Resolver {
         if (element?.items) {
             // FIXME: builtin = true? arrays are kinda builtin
             result.isArray = true
+            result.isBuiltin = true
             this.resolveType(element.items, file)
             //delete element.items
         } else if (element?.elements && !element?.type) {

--- a/lib/components/resolver.js
+++ b/lib/components/resolver.js
@@ -259,12 +259,6 @@ class Resolver {
             typeInfo.inflection = this.inflect(typeInfo)
         }
 
-        /*
-        if (typeInfo.isArray === true) {
-            typeName = createArrayOf(typeName)
-        }
-        */
-
         // add fallback inflection. Mainly needed for array-of with builtin types.
         // (array-of relies on inflection being present, which is not the case in builtin)
         typeInfo.inflection ??= {
@@ -356,7 +350,6 @@ class Resolver {
 
         // objects and arrays
         if (element?.items) {
-            // FIXME: builtin = true? arrays are kinda builtin
             result.isArray = true
             result.isBuiltin = true
             this.resolveType(element.items, file)

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -318,7 +318,7 @@ class Visitor {
     /**
      * A self reference is a property that references the class it appears in.
      * They need to be detected on CDS level, as the emitted TS types will try to
-     * refer to refer to types via their alias that hides the aspectification.
+     * refer to types via their alias that hides the aspectification.
      * If we attempt to directly refer to this alias while it has not been fully created,
      * that will result in a TS error.
      * @param {String} entityName

--- a/test/ast.js
+++ b/test/ast.js
@@ -261,7 +261,7 @@ class ASTWrapper {
         sourceFile.forEachChild(c => { 
             const slim = visit(c)
             // ignore top-level keywords, like 'export', etc.
-            if (slim.nodeType !== kinds.Keyword) {
+            if (slim?.nodeType !== kinds.Keyword) {
                 this.tree.push(slim) 
             }
         })

--- a/test/unit/arrayof.test.js
+++ b/test/unit/arrayof.test.js
@@ -21,41 +21,55 @@ describe('array of', () => {
         ast = new ASTWrapper(path.join(paths[1], 'index.ts'))
     })
 
-    test('String', async () => {
-        const paths = await cds2ts
-            .compileFromFile(locations.unit.files('arrayof/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
-            // eslint-disable-next-line no-console
-            .catch((err) => console.error(err))
-        //const ast = new ASTWrapper(path.join(paths[1], 'index.ts'))
+    describe('Entity Properties', () => {
+        let aspect
+        beforeAll(async () => aspect = ast.tree.find(n => n.name === '_EAspect').body[0])
+
+        test('array of String', async () => {
+            expect(aspect.members.find(m => m.name === 'stringz' 
+                && m.type.full === 'Array' 
+                && m.type.args[0].keyword === 'string')).toBeTruthy()
+        })
+    
+        test('many Integer', async () => {
+            expect(aspect.members.find(m => m.name === 'numberz' 
+                && m.type.full === 'Array' 
+                && m.type.args[0].keyword === 'number')).toBeTruthy()
+        })
+    
+        test('array of locally defined type', async () => {
+            expect(aspect.members.find(m => m.name === 'tz' 
+                && m.type.full === 'Array' 
+                && m.type.args[0].full === 'T')).toBeTruthy()
+        })
+    
+        test('array of externally defined type', async () => {
+            expect(aspect.members.find(m => m.name === 'extz' 
+                && m.type.full === 'Array' 
+                && m.type.args[0].full === '_elsewhere.ExternalType')).toBeTruthy()
+        })
+    
+        test('array of inline type type', async () => {
+            expect(aspect.members.find(m => m.name === 'inlinez' 
+                && m.type.full === 'Array' 
+                && m.type.args[0].keyword === 'typeliteral'
+                && m.type.args[0].members.length === 2)).toBeTruthy()
+        })
     })
 
-    test('Local Type', async () => {
-        const fn = ast.tree[0]
+    describe('Function', () => {
+        let func
+        beforeAll(async () => func = ast.tree.find(n => n.name === 'fn'))
+
+        test('Returning array of String', async () => {
+            expect(func.type.type.full === 'Array' && func.type.type.args[0].keyword === 'string').toBeTruthy()
+        })
+
         /*
-        expect(fn.nodeType).toBe('variableStatement')
-        expect(fn.name).toBe('f1')
-        const res = fn.type.type
-        expect(res.members.length).toBe(1)
-        // FIXME: what do they look like with arrays?
-        expect(res.members[0].name).toBe('a')
-        expect(res.members[1].name).toBe('b')
+        // should re-enable these at some point. Needs to do proper function parsing in AST.
+        test('Taking array of Number as Parameter', async () => {
+            expect(func.type.type.full === 'Array' && func.type.type.args[0].keyword === 'string').toBeTruthy()
+        })
         */
     })
-
-    test('Imported Type', async () => {
-        const paths = await cds2ts
-            .compileFromFile(locations.unit.files('arrayof/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
-            // eslint-disable-next-line no-console
-            .catch((err) => console.error(err))
-        const ast = new ASTWrapper(path.join(paths[1], 'index.ts'))
-    })
-
-    test('Inline Struct', async () => {
-        const paths = await cds2ts
-            .compileFromFile(locations.unit.files('arrayof/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
-            // eslint-disable-next-line no-console
-            .catch((err) => console.error(err))
-        const ast = new ASTWrapper(path.join(paths[2], 'index.ts'))
-    })
-
 })

--- a/test/unit/files/arrayof/model.cds
+++ b/test/unit/files/arrayof/model.cds
@@ -4,11 +4,11 @@ using elsewhere.ExternalType from './elsewhere';
 type T {}
 
 entity E {
-    xs: array of String;
-    ys: many Integer;
+    stringz: array of String;
+    numberz: many Integer;
+    tz: array of T;
+    extz: array of ExternalType;
+    inlinez: array of { a: String; b: Integer; }
 }
 
-function f1 () returns array of String;
-function f2 () returns array of T;
-function f3 () returns array of ExternalType;
-function f4 () returns array of { a: String; b: Integer; };
+function fn (xs: array of Integer) returns array of String;

--- a/test/unit/files/arrayof/model.cds
+++ b/test/unit/files/arrayof/model.cds
@@ -3,6 +3,11 @@ using elsewhere.ExternalType from './elsewhere';
 
 type T {}
 
+entity E {
+    xs: array of String;
+    ys: many Integer;
+}
+
 function f1 () returns array of String;
 function f2 () returns array of T;
 function f3 () returns array of ExternalType;


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/20

Allows the use of 

```cds
entity A { ... }

entity B {
  x: array of A;
  y: many A;
}
```