### PR TITLE
Strict Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.4.1 - TBD
 
+### Changed
+- Facilitate strict property checks. Note: `checkJs: true` must be present in the project's _jsconfig.json_ or _tsconfig.json_ respectively for this feature to become effective
+
 ### Added
 - Support for `array of` syntax
 

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -124,7 +124,7 @@ class Visitor {
         })
 
         // CLASS ASPECT
-        buffer.add(`export function ${identAspect(clean)}<TBase extends new (...args: any[]) => any>(Base: TBase) {`)
+        buffer.add(`export function ${identAspect(clean)}<TBase extends new (...args: any[]) => object>(Base: TBase) {`)
         buffer.indent()
         buffer.add(`return class ${clean} extends Base {`)
         buffer.indent()


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/19

If the project's _[j|t]sconfig.json_ contains `checkJs: true`, accessing properties of generated types that are not explicitly declared will cause an error.

```cds
entity Books { ID: UUID; title: String; }
```
```ts
const { Book } = require('...')

service.before('CREATE', Book, ({data}) => {
  data.ID  // fine
  data.title  // fine
  data.numberOfPages // not part of model definition, causes an error
})
```