### PR TITLE
Change Generated Type for cds.Date et al. to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 - Support for `array of` syntax
 
+### Fixes
+- Generate `string` type for date-related types in CDS definitions
+
 
 ## Version 0.4.0 - 2023-07-06
 ### Added

--- a/lib/components/resolver.js
+++ b/lib/components/resolver.js
@@ -52,10 +52,11 @@ const Builtins = {
     Float: 'number',
     Double: 'number',
     Boolean: 'boolean',
-    Date: 'Date',
-    DateTime: 'Date',
-    Time: 'Date',
-    Timestamp: 'Date',
+    // note: the date-related types _can_ be Date in some cases, but let's start with string
+    Date: 'string',  // yyyy-mm-dd
+    DateTime: 'string', // yyyy-mm-dd + time + TZ (precision: seconds
+    Time: 'string',
+    Timestamp: 'string', // yyy-mm-dd + time + TZ (ms precision)
     //
     Composition: 'Array',
     Association: 'Array'

--- a/test/unit/output.test.js
+++ b/test/unit/output.test.js
@@ -119,9 +119,9 @@ describe('Compilation', () => {
             expect(ast.exists('_EAspect', 'integer64', m => m.type.keyword === 'number')).toBeTruthy()
             expect(ast.exists('_EAspect', 'dec', m => m.type.keyword === 'number')).toBeTruthy()
             expect(ast.exists('_EAspect', 'doub', m => m.type.keyword === 'number')).toBeTruthy()
-            expect(ast.exists('_EAspect', 'd', m => m.type.name === 'Date')).toBeTruthy()
-            expect(ast.exists('_EAspect', 'dt', m => m.type.name === 'Date')).toBeTruthy()
-            expect(ast.exists('_EAspect', 'ts', m => m.type.name === 'Date')).toBeTruthy()
+            expect(ast.exists('_EAspect', 'd', m => m.type.keyword === 'string')).toBeTruthy()
+            expect(ast.exists('_EAspect', 'dt', m => m.type.keyword === 'string')).toBeTruthy()
+            expect(ast.exists('_EAspect', 'ts', m => m.type.keyword === 'string')).toBeTruthy()
         })
     })
 


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/18