### PR TITLE
Support `event` Syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.5.1 - TBD
 
+### Added
+- Support for `event` syntax
+
+
 ## Version 0.5.0 - 2023-07-25
 
 ### Changed

--- a/lib/components/inline.js
+++ b/lib/components/inline.js
@@ -142,7 +142,7 @@ class FlatInlineDeclarationResolver extends InlineDeclarationResolver {
     flatten(prefix, type) {
         return type.typeInfo.structuredType
             ? Object.entries(type.typeInfo.structuredType).map(([k,v]) => this.flatten(`${this.prefix(prefix)}${k}`, v))
-            : [`${prefix} ${this.getPropertyTypeSeparator()} ${type.typeName}`]
+            : [`${prefix}${this.getPropertyTypeSeparator()} ${type.typeName}`]
     }
 
     printInlineType(name, type, buffer) {
@@ -185,7 +185,7 @@ class StructuredInlineDeclarationResolver extends InlineDeclarationResolver {
         this.printDepth++
         const lineEnding = this.printDepth > 1 ? ',' : statementEnd
         if (type.typeInfo.structuredType) {
-            const prefix = name ? `${name} ${this.getPropertyTypeSeparator()}`: ''
+            const prefix = name ? `${name}${this.getPropertyTypeSeparator()}`: ''
             buffer.add(`${prefix} {`)
             buffer.indent()
             for (const [n, t] of Object.entries(type.typeInfo.structuredType)) {
@@ -194,7 +194,7 @@ class StructuredInlineDeclarationResolver extends InlineDeclarationResolver {
             buffer.outdent()
             buffer.add(`}${lineEnding}`)
         } else {
-            buffer.add(`${name} ${this.getPropertyTypeSeparator()} ${type.typeName}${lineEnding}`)
+            buffer.add(`${name}${this.getPropertyTypeSeparator()} ${type.typeName}${lineEnding}`)
         }
         this.printDepth--
         return buffer

--- a/lib/components/resolver.js
+++ b/lib/components/resolver.js
@@ -116,7 +116,7 @@ class Resolver {
         let qualifier = parts.join('.')
         while (
             this.csn.definitions[qualifier] &&
-            ['entity', 'type', 'aspect'].includes(this.csn.definitions[qualifier].kind)
+            ['entity', 'type', 'aspect', 'event'].includes(this.csn.definitions[qualifier].kind)
         ) {
             parts.pop()
             qualifier = parts.join('.')

--- a/lib/file.js
+++ b/lib/file.js
@@ -99,8 +99,8 @@ class SourceFile extends File {
         this.imports = {}
         /** @type {Buffer} */
         this.preamble = new Buffer()
-        /** @type {Buffer} */
-        this.events = new Buffer()
+        /** @type {{ buffer: Buffer, fqs: {name: string, fq: string}[]}} */
+        this.events = { buffer: new Buffer(), fqs: []} 
         /** @type {Buffer} */
         this.types = new Buffer()
         /** @type {{ buffer: Buffer, fqs: {name: string, fq: string}[]}} */
@@ -198,6 +198,7 @@ class SourceFile extends File {
         // and a type containing all disctinct values.
         // We can get away with this as TS doesn't feature nominal typing, so the structure
         // is all we care about.
+        // FIXME: this really should be in visitor, as File should not contain logic of this kind
         this.enums.fqs.push({ name, fq })
         const bu = this.enums.buffer
         bu.add('// enum')
@@ -226,9 +227,14 @@ class SourceFile extends File {
         this.classNames[clean] = fq
     }
 
-    addEvent(clean, event) {
-
-
+    /**
+     * Adds an event to this file.
+     * are supposed to be present in this file. 
+     * @param {string} name cleaned name of the event
+     * @param {string} fq fully qualified name, including the namespace
+     */
+    addEvent(name, fq) {
+        this.events.fqs.push({ name, fq })
     }
 
     /**
@@ -295,7 +301,7 @@ class SourceFile extends File {
             namespaces.join(),
             this.aspects.join(), // needs to be before classes
             this.classes.join(),
-            this.events.join(),
+            this.events.buffer.join(),
             this.actions.buffer.join(),
         ].filter(Boolean).join('\n')
     }
@@ -319,7 +325,7 @@ class SourceFile extends File {
                     ])))
             ) // singular -> plural aliases
             .concat(['// events'])
-            // FIXME: events
+            .concat(this.events.fqs.map(({fq, name}) => `module.exports.${name} = '${fq}'`))
             .concat(['// actions'])
             .concat(this.actions.names.map(name => `module.exports.${name} = '${name}'`))
             .concat(['// enums'])

--- a/lib/file.js
+++ b/lib/file.js
@@ -100,6 +100,8 @@ class SourceFile extends File {
         /** @type {Buffer} */
         this.preamble = new Buffer()
         /** @type {Buffer} */
+        this.events = new Buffer()
+        /** @type {Buffer} */
         this.types = new Buffer()
         /** @type {{ buffer: Buffer, fqs: {name: string, fq: string}[]}} */
         this.enums = { buffer: new Buffer(), fqs: [] }
@@ -210,7 +212,6 @@ class SourceFile extends File {
         bu.add('}')
         bu.add(`export type ${name} = ${[...vals].join(' | ')}`)
         bu.add('')
-        
     }
 
     /**
@@ -223,6 +224,11 @@ class SourceFile extends File {
      */
     addClass(clean, fq) {
         this.classNames[clean] = fq
+    }
+
+    addEvent(clean, event) {
+
+
     }
 
     /**
@@ -289,6 +295,7 @@ class SourceFile extends File {
             namespaces.join(),
             this.aspects.join(), // needs to be before classes
             this.classes.join(),
+            this.events.join(),
             this.actions.buffer.join(),
         ].filter(Boolean).join('\n')
     }
@@ -311,6 +318,8 @@ class SourceFile extends File {
                         `module.exports.${original} = csn.${original}`
                     ])))
             ) // singular -> plural aliases
+            .concat(['// events'])
+            // FIXME: events
             .concat(['// actions'])
             .concat(this.actions.names.map(name => `module.exports.${name} = '${name}'`))
             .concat(['// enums'])

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -295,7 +295,7 @@ class Visitor {
         file.addEvent(clean, name)
         const buffer = file.events.buffer
         buffer.add('// event')
-        buffer.add(`class ${clean} {`)
+        buffer.add(`export class ${clean} {`)
         buffer.indent()
         const propOpt = this.options.propertiesOptional
         this.options.propertiesOptional = false

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -287,6 +287,23 @@ class Visitor {
         this._aspectify(name, aspect, file.aspects, clean)
     }
 
+    #printEvent(name, event) {
+        this.logger.debug(`Printing event ${name}`)
+        const clean = this.resolver.trimNamespace(name)
+        const ns = this.resolver.resolveNamespace(name.split('.'))
+        const file = this.getNamespaceFile(ns)
+        file.addClass(clean, name)
+        const buffer = file.events
+        buffer.add('// event')
+        buffer.add(`class ${clean} {`)
+        buffer.indent()
+        for (const [ename, element] of Object.entries(event.elements ?? {})) {
+            this.visitElement(ename, element, file, buffer)
+        }
+        buffer.outdent()
+        buffer.add('}')
+    }
+
     /**
      * Visits a single entity from the CSN's definition field.
      * Will call #printEntity or #printAction based on the entity's kind.
@@ -309,6 +326,9 @@ class Visitor {
                 break
             case 'aspect':
                 this.#printAspect(name, entity)
+                break
+            case 'event':
+                this.#printEvent(name, entity)
                 break
             default:
                 this.logger.error(`Unhandled entity kind '${entity.kind}'.`)

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -292,8 +292,8 @@ class Visitor {
         const clean = this.resolver.trimNamespace(name)
         const ns = this.resolver.resolveNamespace(name.split('.'))
         const file = this.getNamespaceFile(ns)
-        file.addClass(clean, name)
-        const buffer = file.events
+        file.addEvent(clean, name)
+        const buffer = file.events.buffer
         buffer.add('// event')
         buffer.add(`class ${clean} {`)
         buffer.indent()

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -297,9 +297,12 @@ class Visitor {
         buffer.add('// event')
         buffer.add(`class ${clean} {`)
         buffer.indent()
+        const propOpt = this.options.propertiesOptional
+        this.options.propertiesOptional = false
         for (const [ename, element] of Object.entries(event.elements ?? {})) {
             this.visitElement(ename, element, file, buffer)
         }
+        this.options.propertiesOptional = propOpt
         buffer.outdent()
         buffer.add('}')
     }

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -22,13 +22,12 @@ describe('events', () => {
     })
 
     describe('Event Type Present', () => {
-        let aspect
-        beforeAll(async () => aspect = ast.tree.find(n => n.name === '_EAspect').body[0])
-
         test('Top Level Event', async () => {
-            expect(aspect.members.find(m => m.name === 'stringz' 
-                && m.type.full === 'Array' 
-                && m.type.args[0].keyword === 'string')).toBeTruthy()
-        })    
+            expect(ast.tree.find(cls => cls.name === 'Bar' 
+                && cls.members.length === 2
+                && cls.members[0].name === 'id' && cls.members[0].type.keyword === 'number'
+                && cls.members[1].name === 'name' && cls.members[1].type.keyword === 'indexedaccesstype'
+            )).toBeTruthy()
+        })
     })
 })

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const fs = require('fs').promises
+const path = require('path')
+const cds2ts = require('../../lib/compile')
+const { ASTWrapper } = require('../ast')
+const { locations } = require('../util')
+
+const dir = locations.testOutput('events_test')
+
+
+describe('events', () => {
+    let ast
+
+    beforeEach(async () => await fs.unlink(dir).catch(err => {}))
+    beforeAll(async () => {
+        const paths = await cds2ts
+            .compileFromFile(locations.unit.files('events/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
+            // eslint-disable-next-line no-console
+            .catch((err) => console.error(err))
+        ast = new ASTWrapper(path.join(paths[1], 'index.ts'))
+    })
+
+    describe('Event Type Present', () => {
+        let aspect
+        beforeAll(async () => aspect = ast.tree.find(n => n.name === '_EAspect').body[0])
+
+        test('Top Level Event', async () => {
+            expect(aspect.members.find(m => m.name === 'stringz' 
+                && m.type.full === 'Array' 
+                && m.type.args[0].keyword === 'string')).toBeTruthy()
+        })    
+    })
+})

--- a/test/unit/files/events/model.cds
+++ b/test/unit/files/events/model.cds
@@ -1,0 +1,7 @@
+namespace events;
+
+entity Foo {
+    name: String;
+}
+
+event Bar: { id: Integer; name: Foo:name };


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/32

Supports the syntax

```cds
event Foo: { id: Integer; name: String }
```

and converts it into a class _with attached properties_

```ts
class Foo {
  id: number
  name: string
}
```
