### PR TITLE
Do not inflect type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Support for `event` syntax
 
 
+### Fixed
+- No longer inflect `type` definitions when they are referenced within entities or other type definitions
+
 ## Version 0.5.0 - 2023-07-25
 
 ### Changed
@@ -18,7 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 - Support for `array of` syntax
 
-### Fixes
+### Fixed
 - Generate `string` type for date-related types in CDS definitions
 - Generate `Buffer | string` type for the CDS type `LargeBinary`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 - Initialise bound actions with stubs to support `"strict":true` in _tsconfig.json_
 - Add leading underscore to appease `noUnusedParameters` in strict tsconfigs
-
-### Fixed
 - No longer inflect `type` definitions when they are referenced within entities or other type definitions
 
 ## Version 0.5.0 - 2023-07-25

--- a/lib/components/resolver.js
+++ b/lib/components/resolver.js
@@ -131,6 +131,7 @@ class Resolver {
      * - explicit annotation by the user in the CSN
      * - implicitly derived inflection based on simple grammar rules
      * - collisions between singular and plural name (resolved by appending a '_' suffix)
+     * - type definitions, which are not inflected
      * - inline type definitions, which don't really have a linguistic plural,
      *   but need to expressed as array type to be consumable by the likes of Composition.of.many<T>
      * @param {import('./resolver').TypeResolveInfo} typeInfo information about the type gathered so far.
@@ -138,6 +139,16 @@ class Resolver {
      * @returns {Inflection}
      */
     inflect(typeInfo, namespace) {
+        // TODO: handle builtins here as well?
+        // guard: types don't get inflected
+        if (typeInfo.csn?.kind === 'type') {
+            return { 
+                singular: typeInfo.plainName,
+                plural: typeInfo.plainName,
+                typeName: typeInfo.plainName,
+            }
+        }
+
         let typeName
         let singular
         let plural

--- a/test/unit/files/type/model.cds
+++ b/test/unit/files/type/model.cds
@@ -1,0 +1,11 @@
+namespace type_test;
+type IntAlias: Integer;
+type Points: { x: Integer; y: Integer }
+type Lines: Array of Points;
+
+entity Persons {
+    id: IntAlias;
+    pos: Points;
+    history: Array of Points;
+    line: Lines;
+}

--- a/test/unit/type.test.js
+++ b/test/unit/type.test.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const fs = require('fs').promises
+const path = require('path')
+const cds2ts = require('../../lib/compile')
+const { ASTWrapper } = require('../ast')
+const { locations } = require('../util')
+
+const dir = locations.testOutput('type_test')
+
+
+describe('type Definitions', () => {
+    let ast
+
+    beforeEach(async () => await fs.unlink(dir).catch(err => {}))
+    beforeAll(async () => {
+        const paths = await cds2ts
+            .compileFromFile(locations.unit.files('type/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
+            // eslint-disable-next-line no-console
+            .catch((err) => console.error(err))
+        ast = new ASTWrapper(path.join(paths[1], 'index.ts'))
+    })
+    
+    test('All Definitions Present', async () => {
+        expect(ast.tree.find(({name, nodeType}) => name === 'IntAlias' && nodeType === 'typeAliasDeclaration')).toBeTruthy()
+        expect(ast.tree.find(({name, nodeType}) => name === 'Points' && nodeType === 'typeAliasDeclaration')).toBeTruthy()
+        expect(ast.tree.find(({name, nodeType}) => name === 'Lines' && nodeType === 'typeAliasDeclaration')).toBeTruthy()
+    })
+
+    test('Types as Properties', async () => {
+        const members = ast.tree.find(def => def.name === '_PersonAspect').body[0].members
+        expect(members.find(({name, type}) => name === 'id' && type.full === 'IntAlias'))
+        expect(members.find(({name, type}) => name === 'pos' && type.full === 'Points'))
+        expect(members.find(({name, type}) => name === 'history' && type.full === 'Array' && type.args[0].full === 'Points'))
+        expect(members.find(({name, type}) => name === 'line' && type.full === 'Array' && type.args[0].full === 'Points'))
+    })
+})


### PR DESCRIPTION
When referencing `type` definitions, their name is no longer inflected, since no singular/ plural forms are generated for them.

```cds
type Points: { x: Integer; y: Integer }
type Lines: array of Points;
```

```ts 
export class Points { ... }  // only 'Points', no 'Point'
export class Lines {
  points: Array<Points>  // not 'Point'
}