### PR TITLE
Prefix Unused Parameter in Base Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Support for `event` syntax
 
 
+### Fixed
+- Add leading underscore to appease `noUnusedParameters` in strict tsconfigs
+
 ## Version 0.5.0 - 2023-07-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 - Initialise bound actions with stubs to support `"strict":true` in _tsconfig.json_
-
-### Fixed
 - Add leading underscore to appease `noUnusedParameters` in strict tsconfigs
 
 ## Version 0.5.0 - 2023-07-25

--- a/lib/file.js
+++ b/lib/file.js
@@ -488,7 +488,7 @@ export namespace Composition {
 }
 
 export class Entity {
-    static data<T extends Entity> (this:T, input:Object) : T {
+    static data<T extends Entity> (this:T, _input:Object) : T {
         return {} as T // mock
     }
 }


### PR DESCRIPTION
Setting `noUnusedParameters` in a project's tsconfig.json would bring up an error in a generated base type, which had to be stubbed. This PR prefixes said parameter to make sure `tsc` won't complain about this.