### PR TITLE
Initialise Bound Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 - Support for `event` syntax
 
+### Fixed
+- Initialise bound actions with stubs to support `"strict":true` in _tsconfig.json_
 
 ## Version 0.5.0 - 2023-07-25
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -121,8 +121,24 @@ class SourceFile extends File {
         this.inflections = []
     }
 
-    static stringifyLambda(name, parameters = [], returns = 'any') {
-        return `${name}: (${parameters.map(([n, t]) => `${n}: ${t}`).join(', ')}) => ${returns}`
+    /**
+     * Stringifies a lambda expression.
+     * @param {{name: string, parameters: [string, string][], returns: string, initialiser: string}} - name, parameters, return type, and initialiser expression
+     * @returns {string} - the stringified lambda
+     * @example
+     * ```js
+     * stringifyLambda({parameters: [['p','T']]}  // (p: T) => any
+     * stringifyLambda({name: 'f', parameters: [['p','T']]}  // f: (p: T) => any
+     * stringifyLambda({name: 'f', parameters: [['p','T']], returns: 'number'}  // f: (p: T) => number
+     * stringifyLambda({name: 'f', parameters: [['p','T']], returns: 'number', initialiser: '_ => 42'}  // f: (p: T) => string = _ => 42
+     * 
+     * ```
+     */
+    static stringifyLambda({name, parameters=[], returns='any', initialiser}) {
+        const signature = `(${parameters.map(([n, t]) => `${n}: ${t}`).join(', ')}) => ${returns}`
+        const prefix = name ? `${name}: `: ''
+        const suffix = initialiser ? ` = ${initialiser}` : ''
+        return prefix + signature + suffix
     }
 
     /**
@@ -141,27 +157,25 @@ class SourceFile extends File {
     /**
      * Adds a function definition in form of a arrow function to the file.
      * @param {string} name name of the function
-     * @param {{relative: string | undefined, local: boolean, posix: boolean}} params list of parameters, passed as [name, type] pairs
+     * @param {{relative: string | undefined, local: boolean, posix: boolean}} parameters list of parameters, passed as [name, type] pairs
      * @param returns the return type of the function
      */
-    addFunction(name, params, returns) {
+    addFunction(name, parameters, returns) {
         // FIXME: use different buffers for buffers and actions, or at least rename buffer to the more general category "functions"?
         this.actions.buffer.add("// function")
-        this.actions.buffer.add(`export declare const ${SourceFile.stringifyLambda(name, params, returns)};`)
+        this.actions.buffer.add(`export declare const ${SourceFile.stringifyLambda({name, parameters, returns})};`)
         this.actions.names.push(name)
     }
 
     /**
      * Adds an action definition in form of a arrow function to the file.
      * @param {string} name name of the action
-     * @param {{relative: string | undefined, local: boolean, posix: boolean}} params list of parameters, passed as [name, type] pairs
+     * @param {{relative: string | undefined, local: boolean, posix: boolean}} parameters list of parameters, passed as [name, type] pairs
      * @param returns the return type of the action
      */
-    addAction(name, params, returns) {
-        //const ps = params.map(([n, t]) => `${n}: ${t}`).join(', ')
+    addAction(name, parameters, returns) {
         this.actions.buffer.add("// action")
-        //this.actions.buffer.add(`export declare const ${name}: ( args: { ${ps} }) => ${returns};`)
-        this.actions.buffer.add(`export declare const ${SourceFile.stringifyLambda(name, params, returns)};`)
+        this.actions.buffer.add(`export declare const ${SourceFile.stringifyLambda({name, parameters, returns})};`)
         this.actions.names.push(name)
     }
 

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -132,17 +132,18 @@ class Visitor {
             this.visitElement(ename, element, file, buffer)
         }
         for (const [aname, action] of Object.entries(entity.actions ?? {})) {
+            const lambdaString = 
             buffer.add(
-                SourceFile.stringifyLambda(
-                    aname,
-                    Object.entries(action.params ?? {}).map(([n, t]) => [
+                SourceFile.stringifyLambda({
+                    name: aname,
+                    parameters: Object.entries(action.params ?? {}).map(([n, t]) => [
                         n,
                         this.resolver.resolveAndRequire(t, file).typeName,
                     ]),
-                    action.returns ? this.resolver.resolveAndRequire(action.returns, file).typeName : 'any'
-                )
+                    returns: action.returns ? this.resolver.resolveAndRequire(action.returns, file).typeName : 'any',
+                    initialiser: `undefined as unknown as this['${aname}']`
+                })
             )
-            //this.visitEntity(aname, action, file, buffer)
         }
         buffer.outdent()
         buffer.add('};')


### PR DESCRIPTION
Bound actions before only had their type definitions generated. They now also generate an initialiser stub to appease `tsc` when `"strict": true` is set in the project's _tsconfig.json_.

```cds
entity Books as projection on my.Books actions {
  function getDetails(test : String) returns { test : String };
}
```

```ts
export function _BookAspect<TBase extends new (...args: any[]) => object>(Base: TBase) {
  return class Book extends Base {
    ...
    getDetails: (test: string) => { test?: string; } = undefined as unknown as this['getDetails']  
    //                                              /
    //                                            new
  }
}
```