### PR TITLE
Support `$self` Syntax in Bound Action Parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 
 ### Added
+- Support for `[many] $self` syntax in bound action parameters
 
 ### Fixed
 ## Version 0.6.1 - 2023-08-10

--- a/lib/components/resolver.js
+++ b/lib/components/resolver.js
@@ -445,6 +445,10 @@ class Resolver {
             result.path = new Path(path) // FIXME: relative to current file
             result.csn = this.csn.definitions[t]
             result.plainName = this.trimNamespace(t)
+        } else if (t === '$self') {
+            result.type = 'this'
+            result.isBuiltin = true
+            result.plainName = 'this'
         } else {
             // type offered by some library
             const lib = this.libraries.find((lib) => lib.offers(t))

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -8,6 +8,7 @@ const { locations } = require('../util')
 
 const dir = locations.testOutput('actions_test')
 
+// FIXME: need to parse the function args from the AST to test them
 describe('Actions', () => {
     beforeEach(async () => await fs.unlink(dir).catch(err => {}))
 
@@ -83,6 +84,20 @@ describe('Actions', () => {
         expect(fn2.name).toBe('free3')
         const res2 = fn2.type.type
         expect(res2.full).toBe('_.ExternalInRoot')
+    })
+
+    test('Bound Expecting $self Arguments', async () => {
+        const paths = await cds2ts
+            .compileFromFile(locations.unit.files('actions/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
+            // eslint-disable-next-line no-console
+            .catch((err) => console.error(err))
+        const ast = new ASTWrapper(path.join(paths[1], 'index.ts'))
+        expect(ast.exists('_EAspect', 's1', 
+            m => m.type.keyword === 'functiontype'
+        )).toBeTruthy()  
+        expect(ast.exists('_EAspect', 'sn', 
+            m => m.type.keyword === 'functiontype'
+        )).toBeTruthy()  
     })
 
 })

--- a/test/unit/files/actions/model.cds
+++ b/test/unit/files/actions/model.cds
@@ -11,6 +11,8 @@ service S {
             action h () returns { a: Integer; b: String };
             action k () returns ExternalType;
             action l () returns ExternalInRoot;
+            action s1 (x: $self);
+            action sn (x: many $self);
         }
 }
 


### PR DESCRIPTION
```cds
entity Foo {}
actions {
  action bar (x: many $self) 
  action baz (x: $self)
}
```