### PR TITLE
Maintain Foreign Keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 - Support for `[many] $self` syntax in bound action parameters
+- Foreign keys are now present in the generated types in addition to the resolved property
 
 ### Fixed
 ## Version 0.6.1 - 2023-08-10

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -59,7 +59,6 @@ class Visitor {
      * @param {VisitorOptions} options
      */
     constructor(csn, options = {}, logger = new Logger()) {
-        util.fixCSN(csn)
         this.options = { ...defaults, ...options }
         this.logger = logger
         this.csn = csn
@@ -130,6 +129,10 @@ class Visitor {
         buffer.indent()
         for (const [ename, element] of Object.entries(entity.elements ?? {})) {
             this.visitElement(ename, element, file, buffer)
+            // make foreign keys explicit
+            for (const [fkname, fkelement] of Object.entries(element.foreignKeys ?? {})) {
+                this.visitElement(`${ename}_${fkname}`, fkelement, file, buffer)
+            }
         }
         for (const [aname, action] of Object.entries(entity.actions ?? {})) {
             buffer.add(

--- a/test/unit/files/references/model.cds
+++ b/test/unit/files/references/model.cds
@@ -1,6 +1,9 @@
 namespace references;
 
-entity Foo {}
+entity Foo {
+    key first_key: UUID;
+    key second_key: String;
+}
 
 entity Bar {
     key id: Integer;  // required for composition of many ... to work.

--- a/test/unit/references.test.js
+++ b/test/unit/references.test.js
@@ -34,6 +34,12 @@ describe('References', () => {
                 && m.type.name === 'many'
                 && m.type.args[0].name === 'Foo_'
         )).toBeTruthy()
+        expect(ast.exists('_BarAspect', 'assoc_one_first_key', m => true
+                && m.type.keyword === 'string'
+        )).toBeTruthy()
+        expect(ast.exists('_BarAspect', 'assoc_one_second_key', m => true
+                && m.type.keyword === 'string'
+        )).toBeTruthy()
     })
 
     test('Inline', async () => {


### PR DESCRIPTION
```cds
entity Foo {
  key first_key: UUID;
  key second_key: String;
}

entity Bar {
  key id: Integer;  // required for composition of many ... to work.
  assoc_one: Association to one Foo;
};
```

now results in

```ts
class Foo { 
  first_key?: string
  second_key?: string
}

class Bar {
  id?: number
  assoc_one?: Association.to<Foo>
  assoc_one_first_key?: string  // new ✨
  assoc_one_second_key?: string  // new ✨
}
```
(more or less)