### PR TITLE
Generate Inherited Key Properties 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 ### Fixed
+- Foreign keys that are inherited via aspects are now also generated in addition to the resolved property (see 0.7.0)
 
 ## Version 0.7.0 - 2023-08-22
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -201,6 +201,24 @@ const parseCommandlineArgs = (argv, validFlags) => {
 * when removing an annotation which we also check.
 */
 function fixCSN(csn) {
+    for (const element of Object.values(csn.definitions)) {
+        Object.defineProperty(element, 'keys', {
+            get: function () {
+                // cached access to all immediately defined _and_ inherited keys.
+                // They need to be explicitly accessible in subclasses to generate
+                // foreign key fields from Associations/ Compositions.
+                if (!Object.hasOwn(this, '__keys')) {
+                    const ownKeys = Object.fromEntries(Object.entries(this.elements ?? {}).filter(([,el]) => el.key === true))
+                    const inheritedKeys = this.includes?.flatMap(parent => csn.definitions[parent].keys) ?? []
+                    this.__keys = inheritedKeys.reduce((ks, ps) => ({...ps, ...ks}), ownKeys)
+                }
+                return this.__keys
+            }
+        })
+    }
+
+    // FIXME: delete after merge with draft-enablement PR
+    return
     const erase = (entity, parent, attr) => {
         if (attr in entity) {
             const ea = entity[attr]

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -59,6 +59,7 @@ class Visitor {
      * @param {VisitorOptions} options
      */
     constructor(csn, options = {}, logger = new Logger()) {
+        util.fixCSN(csn)
         this.options = { ...defaults, ...options }
         this.logger = logger
         this.csn = csn
@@ -130,8 +131,10 @@ class Visitor {
         for (const [ename, element] of Object.entries(entity.elements ?? {})) {
             this.visitElement(ename, element, file, buffer)
             // make foreign keys explicit
-            for (const [fkname, fkelement] of Object.entries(element.foreignKeys ?? {})) {
-                this.visitElement(`${ename}_${fkname}`, fkelement, file, buffer)
+            if ('target' in element) {
+                for (const [kname, kelement] of Object.entries(this.csn.definitions[element.target].keys)) {
+                    this.visitElement(`${ename}_${kname}`, kelement, file, buffer)
+                }
             }
         }
         for (const [aname, action] of Object.entries(entity.actions ?? {})) {

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -132,7 +132,10 @@ class Visitor {
             this.visitElement(ename, element, file, buffer)
             // make foreign keys explicit
             if ('target' in element) {
-                for (const [kname, kelement] of Object.entries(this.csn.definitions[element.target].keys)) {
+                // lookup in cds.definitions can fail for inline structs.
+                // We don't really have to care for this case, as keys from such structs are _not_ propagated to
+                // the containing entity.
+                for (const [kname, kelement] of Object.entries(this.csn.definitions[element.target]?.keys ?? {})) {
                     this.visitElement(`${ename}_${kname}`, kelement, file, buffer)
                 }
             }

--- a/test/unit/files/references/model.cds
+++ b/test/unit/files/references/model.cds
@@ -1,6 +1,8 @@
+using { cuid } from '@sap/cds/common';
+
 namespace references;
 
-entity Foo {
+entity Foo: cuid {  // inherits an additional key ID
     key first_key: UUID;
     key second_key: String;
 }
@@ -12,6 +14,6 @@ entity Bar {
     comp_one: Composition of one Foo;
     comp_many: Composition of many Foo;
     // inline structs (only composition is allowed for structs)
-    inl_comp_one: Composition of { a: String; };
+    inl_comp_one: Composition of { a: String; key ID: UUID };
     inl_comp_many: Composition of many { a: String; };
 };

--- a/test/unit/references.test.js
+++ b/test/unit/references.test.js
@@ -16,7 +16,7 @@ describe('References', () => {
         const paths = await cds2ts
             .compileFromFile(locations.unit.files('references/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
             // eslint-disable-next-line no-console
-            .catch((err) => console.error(err))
+            //.catch((err) => console.error(err))
         const ast = new ASTWrapper(path.join(paths[1], 'index.ts'))
         expect(ast.exists('_BarAspect', 'assoc_one', m => true
                 && m.type.name === 'to'
@@ -40,6 +40,9 @@ describe('References', () => {
         expect(ast.exists('_BarAspect', 'assoc_one_second_key', m => true
                 && m.type.keyword === 'string'
         )).toBeTruthy()
+        expect(ast.exists('_BarAspect', 'assoc_one_ID', m => true
+                && m.type.keyword === 'string'
+        )).toBeTruthy()
     })
 
     test('Inline', async () => {
@@ -59,5 +62,7 @@ describe('References', () => {
                 && m.type.args[0].args[0].members[0].name === 'a'
                 && m.type.args[0].args[0].members[0].type.keyword === 'string'
         )).toBeTruthy()
+        // inline ID is not propagated into the parent entity
+        expect(() => ast.exists('_BarAspect', 'inl_comp_one_ID')).toThrow(Error)
     })
 })

--- a/test/unit/references.test.js
+++ b/test/unit/references.test.js
@@ -15,8 +15,6 @@ describe('References', () => {
     test('Entity', async () => {
         const paths = await cds2ts
             .compileFromFile(locations.unit.files('references/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
-            // eslint-disable-next-line no-console
-            //.catch((err) => console.error(err))
         const ast = new ASTWrapper(path.join(paths[1], 'index.ts'))
         expect(ast.exists('_BarAspect', 'assoc_one', m => true
                 && m.type.name === 'to'


### PR DESCRIPTION
```cds
// model.cds
entity C {
  key y: String;
}

entity B: C {
  key x: String;
}

entity A {
  b: Association to one B
}
```

```ts
// generated index.ts
class A {
  b: Association.to<B>
  b_x: string
  b_y: string  // ✨ new, B inherited this from aspect C
}
```

Also fixes https://github.com/cap-js/cds-typer/issues/62