### PR TITLE
Use `@singular`/`@plural` in Generated `index.js` Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 ### Fixed
+- Explicitly annotated `@singular` and `@plural` names are now properly used in generated _index.js_ files
 
 ## Version 0.7.0 - 2023-08-22
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -335,6 +335,9 @@ class SourceFile extends File {
                     .flatMap(([singular, plural, original]) => Array.from(new Set([
                         `module.exports.${singular} = csn.${original}`,
                         `module.exports.${plural} = csn.${original}`,
+                        // FIXME: we currently produce at most 3 entries.
+                        // This could be an issue when the user re-used the original name in a @singular/@plural annotation.
+                        // Seems unlikely, but we have to eliminate the original entry if users start running into this.
                         `module.exports.${original} = csn.${original}`
                     ])))
             ) // singular -> plural aliases

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -207,7 +207,8 @@ class Visitor {
         // to have Books.texts = Books.text, so we derive the singular once more without cutting off the ns.
         // Directly deriving it from the plural makes sure we retain any parent namespaces of kind "entity",
         // which would not be possible while already in singular form, as "Book.text" could not be resolved in CSN.
-        file.addInflection(util.singular4(plural), plural, clean)
+        // edge case: @singular annotation present. singular4 will take care of that.
+        file.addInflection(util.singular4(entity), plural, clean)
         if ('doc' in entity) {
             docify(entity.doc).forEach((d) => buffer.add(d))
         }


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/53