### PR TITLE
Propagate Multi-Level Keys Recursively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Support for drafts via `@odata.draft.enabled` annotation
 
 ### Fixed
+- Foreign keys are now propagated more than one level (think: `x_ID_ID_ID`)
 
 
 ## Version 0.8.0 - 2023-09-05

--- a/lib/csn.js
+++ b/lib/csn.js
@@ -185,6 +185,7 @@ function unrollDraftability(csn) {
  *   ref_name: String;
  * }
  * ```
+ * @returns {{[key: string]: object}}
  */
 function propagateForeignKeys(csn) {
     for (const element of Object.values(csn.definitions)) {
@@ -194,9 +195,20 @@ function propagateForeignKeys(csn) {
                 // They need to be explicitly accessible in subclasses to generate
                 // foreign key fields from Associations/ Compositions.
                 if (!Object.hasOwn(this, '__keys')) {
-                    const ownKeys = Object.fromEntries(Object.entries(this.elements ?? {}).filter(([,el]) => el.key === true))
-                    const inheritedKeys = this.includes?.flatMap(parent => csn.definitions[parent].keys) ?? []
-                    this.__keys = inheritedKeys.reduce((ks, ps) => ({...ps, ...ks}), ownKeys)
+                    const ownKeys = Object.entries(this.elements ?? {}).filter(([,el]) => el.key === true)
+                    const inheritedKeys = this.includes?.flatMap(parent => Object.entries(csn.definitions[parent].keys)) ?? []
+                    // not sure why, but .associations contains both Associations, as well as Compositions in CSN.
+                    // (.compositions contains only Compositions, if any)
+                    const remoteKeys = Object.entries(this.associations ?? {})
+                        .filter(([,{key}]) => key)  // only follow associations that are keys, that way we avoid cycles
+                        .flatMap(([kname, key]) => Object.entries(csn.definitions[key.target].keys)
+                            .map(([ckname, ckey]) => [`${kname}_${ckname}`, ckey])) 
+
+                    this.__keys = Object.fromEntries(ownKeys
+                        .concat(inheritedKeys)
+                        .concat(remoteKeys)
+                        .filter(([,ckey]) => !ckey.target)  // discard keys that are Associations. Those are already part of .elements
+                    )
                 }
                 return this.__keys
             }

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -132,6 +132,7 @@ class Visitor {
 
         for (const [ename, element] of Object.entries(entity.elements ?? {})) {
             this.visitElement(ename, element, file, buffer)
+
             // make foreign keys explicit
             if ('target' in element) {
                 // lookup in cds.definitions can fail for inline structs.
@@ -141,7 +142,8 @@ class Visitor {
                     this.visitElement(`${ename}_${kname}`, kelement, file, buffer)
                 }
             }
-        }
+        }      
+
         for (const [aname, action] of Object.entries(entity.actions ?? {})) {
             buffer.add(
                 SourceFile.stringifyLambda({

--- a/test/unit/draft.test.js
+++ b/test/unit/draft.test.js
@@ -30,8 +30,6 @@ describe('@odata.draft.enabled', () => {
         await fs.unlink(dir).catch(err => {})
         const paths = await cds2ts
             .compileFromFile(locations.unit.files('draft/model.cds'), { outputDirectory: dir })
-            // eslint-disable-next-line no-console
-            .catch((err) => console.error(err))
         ast = new ASTWrapper(path.join(paths[1], 'index.ts')).tree
     })
 

--- a/test/unit/enum.test.js
+++ b/test/unit/enum.test.js
@@ -17,8 +17,6 @@ describe('Enum Types', () => {
     beforeAll(async () => {
         const paths = await cds2ts
             .compileFromFile(locations.unit.files('enums/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
-            // eslint-disable-next-line no-console
-            .catch((err) => console.error(err))
         ast = new ASTWrapper(path.join(paths[1], 'index.ts'))
     })
 

--- a/test/unit/files/foreignkeys/model.cds
+++ b/test/unit/files/foreignkeys/model.cds
@@ -1,0 +1,24 @@
+namespace foreignkeys;
+
+entity A {
+    demo: String(100);
+    key b : Association to B;
+}
+
+entity B {
+  key c: Association to C;
+  key d: Association to D;
+}
+
+entity C {
+  key ID : String(100);
+  key e: Association to E;
+}
+
+entity D {
+  key ID : String(100);
+}
+
+entity E {
+  key ID : String(100);
+}

--- a/test/unit/foreignkeys.test.js
+++ b/test/unit/foreignkeys.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const fs = require('fs').promises
+const path = require('path')
+const cds2ts = require('../../lib/compile')
+const { ASTWrapper } = require('../ast')
+const { locations } = require('../util')
+
+const dir = locations.testOutput('foreign_keys')
+
+describe('Foreign Keys', () => {
+    let ast
+    beforeEach(async () => await fs.unlink(dir).catch(err => {}))
+    beforeAll(async () => {
+        const paths = await cds2ts
+            .compileFromFile(locations.unit.files('foreignkeys/model.cds'), { outputDirectory: dir })
+        ast = new ASTWrapper(path.join(paths[1], 'index.ts'))
+    })
+
+    test('One Level Deep', async () => {
+        expect(ast.exists('_BAspect', 'c_ID', m => m.type.keyword === 'string')).toBeTruthy()
+        expect(ast.exists('_BAspect', 'd_ID', m => m.type.keyword === 'string')).toBeTruthy()
+        expect(ast.exists('_CAspect', 'e_ID', m => m.type.keyword === 'string')).toBeTruthy()
+    })
+
+    test('Two Levels Deep', async () => {
+        expect(ast.exists('_AAspect', 'b_c_ID', m => m.type.keyword === 'string')).toBeTruthy()
+        expect(ast.exists('_AAspect', 'b_d_ID', m => m.type.keyword === 'string')).toBeTruthy()
+        expect(ast.exists('_BAspect', 'c_e_ID', m => m.type.keyword === 'string')).toBeTruthy()
+    })
+
+    test('Three Levels Deep', async () => {
+        expect(ast.exists('_AAspect', 'b_c_e_ID', m => m.type.keyword === 'string')).toBeTruthy()
+    })
+})


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/62

While foreign keys were propagated through inheritance over arbitrary depth, structured fields that were keys and contained keys itself propagated only one level of keys. This is fixed now.