### PR TITLE
Skip entities in printout if they are unresolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 ### Fixed
+- Fixed an error when an entity uses `type of` on a property they have inherited from another entity
 
 ## Version 0.10.0 - 2023-09-21
 

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -97,7 +97,11 @@ class Visitor {
      */
     visitDefinitions() {
         for (const [name, entity] of Object.entries(this.csn.definitions)) {
-            this.visitEntity(name, entity)
+            if (entity._unresolved === true) {
+                this.logger.error(`Skipping unresolved entity: ${JSON.stringify(entity)}`)
+            } else {
+                this.visitEntity(name, entity)
+            }
         }
     }
 


### PR DESCRIPTION
Using `typeof X` with `X` being inherited from another aspect in combination with `cds.load(..., flavor: {'xtended'})` currently generates ominous entities that are not resolved. They will now be skipped with an appropriate error message.

```cds
// model.cds
entity Parent {
    property: String;
}

entity Child: Parent {
    reference: type of property
}
```
⬇️
```
[ERROR] Skipping unresolved entity: {"name":{"ref":["Parent","property"]},"_unresolved":true,"@odata.draft.enabled":false}
```