### PR TITLE
Generate utility object in lambdas

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -148,10 +148,9 @@ class SourceFile extends File {
     static stringifyLambda({name, parameters=[], returns='any', initialiser}) {
         const parameterTypes = parameters.map(([n, t]) => `${n}: ${t}`).join(', ')
         const callableSignature = `(${parameterTypes}): ${returns}`
-        const parametersProperty = `__parameters: {${parameterTypes}}`
         const prefix = name ? `${name}: `: ''
         const suffix = initialiser ? ` = ${initialiser}` : ''
-        const lambda = `{ ${callableSignature}, ${parametersProperty}}`
+        const lambda = `{ ${callableSignature}, __parameters: {${parameterTypes}}, __returns: ${returns} }`
         return prefix + lambda + suffix
     }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -127,18 +127,32 @@ class SourceFile extends File {
      * @returns {string} - the stringified lambda
      * @example
      * ```js
-     * stringifyLambda({parameters: [['p','T']]}  // (p: T) => any
-     * stringifyLambda({name: 'f', parameters: [['p','T']]}  // f: (p: T) => any
-     * stringifyLambda({name: 'f', parameters: [['p','T']], returns: 'number'}  // f: (p: T) => number
-     * stringifyLambda({name: 'f', parameters: [['p','T']], returns: 'number', initialiser: '_ => 42'}  // f: (p: T) => string = _ => 42
+     * // note: these samples are actually simplified! See below.
+     * stringifyLambda({parameters: [['p','T']]})  // f: { (p: T): any, ... }
+     * stringifyLambda({name: 'f', parameters: [['p','T']]})  // f: { (p: T) => any, ...  }
+     * stringifyLambda({name: 'f', parameters: [['p','T']], returns: 'number'})  // f: { (p: T) => number, ...  }
+     * stringifyLambda({name: 'f', parameters: [['p','T']], returns: 'number', initialiser: '_ => 42'})  // f: { (p: T): string = _ => 42, ...  }
+     * ```
      * 
+     * The generated string will not be just the signature of the function. Instead, it will be an object offering a callable signature.
+     * On top of that, it will also expose a property `__parameters`, which is an object reflecting the functions parameters.
+     * The reason for this is that the CDS runtime actually treats the function parameters as a named object. This can not be rectified via
+     * type magic, as parameter names do not exist on type level. So we can not use these names to reuse them as object properties.
+     * Instead, we generate this utility object for the runtime to use:
+     * 
+     * @example
+     * ```js
+     * stringifyLambda({name: 'f', parameters: [['p','T']], returns: 'number'})  // { (p: T): number, __parameters: { p: T } }
      * ```
      */
     static stringifyLambda({name, parameters=[], returns='any', initialiser}) {
-        const signature = `(${parameters.map(([n, t]) => `${n}: ${t}`).join(', ')}) => ${returns}`
+        const parameterTypes = parameters.map(([n, t]) => `${n}: ${t}`).join(', ')
+        const callableSignature = `(${parameterTypes}): ${returns}`
+        const parametersProperty = `__parameters: {${parameterTypes}}`
         const prefix = name ? `${name}: `: ''
         const suffix = initialiser ? ` = ${initialiser}` : ''
-        return prefix + signature + suffix
+        const lambda = `{ ${callableSignature}, ${parametersProperty}}`
+        return prefix + lambda + suffix
     }
 
     /**

--- a/test/ast.js
+++ b/test/ast.js
@@ -378,8 +378,28 @@ class JSASTWrapper {
     }
 }
 
+const checkFunction = (fnNode, {callCheck, parameterCheck, returnTypeCheck}) => {  
+    const [callsignature, parameters, returnType] = fnNode?.type?.members
+    if (!callsignature || callsignature.keyword !== 'callsignature') throw new Error('callsignature is not present or of wrong type')
+    if (!parameters || ts.unescapeLeadingUnderscores(parameters.name) !== '__parameters') throw new Error('__parameters property is missing or named incorrectly')
+    if (!returnType || ts.unescapeLeadingUnderscores(returnType.name) !== '__returns') throw new Error('__returns property is missing or named incorrectly')
+
+    if (callCheck && !callCheck(callsignature.type)) throw new Error('callsignature is not matching expectations')
+    if (parameterCheck && !parameterCheck(parameters.type)) throw new Error('parameter type is not matching expectations')
+    if (returnTypeCheck && !returnTypeCheck(returnType.type)) throw new Error('return type is not matching expectations')
+
+    return true
+}
+
+const type = {
+    isString: node => node?.keyword === 'string',
+    isNumber: node => node?.keyword === 'number'
+}
+
 
 module.exports = {
     ASTWrapper,
-    JSASTWrapper
+    JSASTWrapper,
+    checkFunction,
+    type
 }

--- a/test/ast.js
+++ b/test/ast.js
@@ -318,13 +318,17 @@ class ASTWrapper {
         return this.getAspectFunctions().map(({name, body}) => ({...body[0], name}))
     }
 
+    getAspect(name) {
+        return this.getAspects().find(c => c.name === name)
+    }
+
+    getAspectProperty(name, property) {
+        return this.getAspect(name).members.find(m => m.name === property)
+    }
+
     /** @returns {VariableStatement[]} */
     getEntities() {
         return this.tree.filter(n => n.nodeType === kinds.VariableStatement)
-    }
-
-    getAspectProperties(name) {
-        const cls = this.getAspects().find(c => c.name === name)
     }
 
     exists(clazz, property, type, typeArg) {

--- a/test/ast.js
+++ b/test/ast.js
@@ -382,7 +382,8 @@ class JSASTWrapper {
     }
 }
 
-const checkFunction = (fnNode, {callCheck, parameterCheck, returnTypeCheck}) => {  
+const checkFunction = (fnNode, {callCheck, parameterCheck, returnTypeCheck}) => {
+    if (!fnNode) throw new Error('the function does not exist (or was not properly accessed from the AST)') 
     const [callsignature, parameters, returnType] = fnNode?.type?.members
     if (!callsignature || callsignature.keyword !== 'callsignature') throw new Error('callsignature is not present or of wrong type')
     if (!parameters || ts.unescapeLeadingUnderscores(parameters.name) !== '__parameters') throw new Error('__parameters property is missing or named incorrectly')
@@ -397,7 +398,8 @@ const checkFunction = (fnNode, {callCheck, parameterCheck, returnTypeCheck}) => 
 
 const type = {
     isString: node => node?.keyword === 'string',
-    isNumber: node => node?.keyword === 'number'
+    isNumber: node => node?.keyword === 'number',
+    isAny: node => node?.keyword === 'any'
 }
 
 

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -2,24 +2,21 @@
 
 const fs = require('fs').promises
 const path = require('path')
-const cds2ts = require('../../lib/compile')
 const { ASTWrapper, checkFunction, type } = require('../ast')
-const { locations } = require('../util')
+const { locations, cds2ts } = require('../util')
 
 const dir = locations.testOutput('actions_test')
 
-// FIXME: need to parse the function args from the AST to test them
 describe('Actions', () => {
     beforeEach(async () => await fs.unlink(dir).catch(err => {}))
 
     test('Bound', async () => {
-        const paths = await cds2ts
-            .compileFromFile(locations.unit.files('actions/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
-        const ast = new ASTWrapper(path.join(paths[1], 'index.ts'))
-        checkFunction(ast.getAspectProperty('_EAspect', 'f'), {
+        const paths = await cds2ts('actions/model.cds', { outputDirectory: dir, inlineDeclarations: 'structured' })
+        const astw = new ASTWrapper(path.join(paths[1], 'index.ts'))
+        checkFunction(astw.getAspectProperty('_EAspect', 'f'), {
             parameterCheck: ({members: [fst]}) => fst.name === 'x' && type.isString(fst.type)
         })
-        checkFunction(ast.getAspectProperty('_EAspect', 'g'), {
+        checkFunction(astw.getAspectProperty('_EAspect', 'g'), {
             parameterCheck: ({members: [fst, snd]}) => {
                 const fstCorrect = fst.name === 'a' && fst.type.members[0].name === 'x' && type.isNumber(fst.type.members[0].type)
                     && fst.type.members[1].name === 'y' && type.isNumber(fst.type.members[1].type)
@@ -30,10 +27,9 @@ describe('Actions', () => {
     })
 
     test('Unbound', async () => {
-        const paths = await cds2ts
-            .compileFromFile(locations.unit.files('actions/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
-        const ast = new ASTWrapper(path.join(paths[2], 'index.ts'))
-        checkFunction(ast.tree.find(node => node.name === 'free'), {
+        const paths = await cds2ts('actions/model.cds', { outputDirectory: dir, inlineDeclarations: 'structured' })
+        const ast = new ASTWrapper(path.join(paths[2], 'index.ts')).tree
+        checkFunction(ast.find(node => node.name === 'free'), {
             callCheck: ({members: [fst, snd]}) => fst.name === 'a' && type.isNumber(fst.type)
                 && snd.name === 'b' && type.isString(snd.type),
             parameterCheck: ({members: [fst]}) => fst.name === 'param' && type.isString(fst.type),
@@ -43,61 +39,59 @@ describe('Actions', () => {
     })
 
     test('Bound Returning External Type', async () => {
-        const paths = await cds2ts
-            .compileFromFile(locations.unit.files('actions/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
-        const ast = new ASTWrapper(path.join(paths[1], 'index.ts'))
-        checkFunction(ast.getAspectProperty('_EAspect', 'f'), {
+        const paths = await cds2ts('actions/model.cds', { outputDirectory: dir, inlineDeclarations: 'structured' })
+        const astw = new ASTWrapper(path.join(paths[1], 'index.ts'))
+        checkFunction(astw.getAspectProperty('_EAspect', 'f'), {
             callCheck: signature => type.isAny(signature),
             parameterCheck: ({members: [fst]}) => fst.name === 'x' && type.isString(fst.type),
             returnTypeCheck: returns => type.isAny(returns)
         })
 
-        checkFunction(ast.getAspectProperty('_EAspect', 'k'), {
+        checkFunction(astw.getAspectProperty('_EAspect', 'k'), {
             callCheck: ({full}) => full === '_elsewhere.ExternalType',
             returnTypeCheck: ({full}) => full === '_elsewhere.ExternalType'
         })
 
-        checkFunction(ast.getAspectProperty('_EAspect', 'l'), {
+        checkFunction(astw.getAspectProperty('_EAspect', 'l'), {
             callCheck: ({full}) => full === '_.ExternalInRoot',
             returnTypeCheck: ({full}) => full === '_.ExternalInRoot'
         })
     })
 
     test('Unbound Returning External Type', async () => {
-        const paths = await cds2ts
-            .compileFromFile(locations.unit.files('actions/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
-            // eslint-disable-next-line no-console
-            .catch((err) => console.error(err))
-        const ast = new ASTWrapper(path.join(paths[2], 'index.ts'))
+        const paths = await cds2ts('actions/model.cds', { outputDirectory: dir, inlineDeclarations: 'structured' })
+        const ast = new ASTWrapper(path.join(paths[2], 'index.ts')).tree
+        
+        checkFunction(ast.find(node => node.name === 'free2'), {
+            callCheck: ({full}) => full === '_elsewhere.ExternalType',
+            returnTypeCheck: ({full}) => full === '_elsewhere.ExternalType'
+        })
 
-        const fn = ast.tree[3]  // very classy with the index and such
-        expect(fn.nodeType).toBe('variableStatement')
-        expect(fn.name).toBe('free2')
-        const res = fn.type.type
-        expect(res.full).toBe('_elsewhere.ExternalType')
-
-        const fn2 = ast.tree[4]  // very classy with the index and such
-        expect(fn2.nodeType).toBe('variableStatement')
-        expect(fn2.name).toBe('free3')
-        const res2 = fn2.type.type
-        expect(res2.full).toBe('_.ExternalInRoot')
+        checkFunction(ast.find(node => node.name === 'free3'), {
+            callCheck: ({full}) => full === '_.ExternalInRoot',
+            returnTypeCheck: ({full}) => full === '_.ExternalInRoot'
+        })
     })
 
     test('Bound Expecting $self Arguments', async () => {
-        const paths = await cds2ts
-            .compileFromFile(locations.unit.files('actions/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
-            // eslint-disable-next-line no-console
-            .catch((err) => console.error(err))
-        const ast = new ASTWrapper(path.join(paths[1], 'index.ts'))
-        expect(ast.exists('_EAspect', 's1', 
-            m => m.type.keyword === 'functiontype'
-        )).toBeTruthy()  
-        expect(ast.exists('_EAspect', 'sn', 
-            m => m.type.keyword === 'functiontype'
-        )).toBeTruthy()  
-        expect(ast.exists('_EAspect', 'sx', 
-            m => m.type.keyword === 'functiontype'
-        )).toBeTruthy()  
+        const paths = await cds2ts('actions/model.cds', { outputDirectory: dir, inlineDeclarations: 'structured' })
+        const astw = new ASTWrapper(path.join(paths[1], 'index.ts'))
+        // mainly make sure $self parameter is not present at all
+        checkFunction(astw.getAspectProperty('_EAspect', 's1'), {
+            callCheck: signature => type.isAny(signature),
+            returnTypeCheck: returns => type.isAny(returns),
+            parameterCheck: ({members}) => members.length === 0
+        })
+        checkFunction(astw.getAspectProperty('_EAspect', 'sn'), {
+            callCheck: signature => type.isAny(signature),
+            returnTypeCheck: returns => type.isAny(returns),
+            parameterCheck: ({members}) => members.length === 0           
+        })
+        checkFunction(astw.getAspectProperty('_EAspect', 'sx'), {
+            callCheck: signature => type.isAny(signature),
+            returnTypeCheck: returns => type.isAny(returns),
+            parameterCheck: ({members: [fst]}) => type.isNumber(fst.type)
+        })
     })
 
 })

--- a/test/unit/arrayof.test.js
+++ b/test/unit/arrayof.test.js
@@ -3,7 +3,7 @@
 const fs = require('fs').promises
 const path = require('path')
 const cds2ts = require('../../lib/compile')
-const { ASTWrapper } = require('../ast')
+const { ASTWrapper, checkFunction, type } = require('../ast')
 const { locations } = require('../util')
 
 const dir = locations.testOutput('arrayof_test')
@@ -28,13 +28,13 @@ describe('array of', () => {
         test('array of String', async () => {
             expect(aspect.members.find(m => m.name === 'stringz' 
                 && m.type.full === 'Array' 
-                && m.type.args[0].keyword === 'string')).toBeTruthy()
+                && type.isString(m.type.args[0]))).toBeTruthy()
         })
     
         test('many Integer', async () => {
             expect(aspect.members.find(m => m.name === 'numberz' 
                 && m.type.full === 'Array' 
-                && m.type.args[0].keyword === 'number')).toBeTruthy()
+                && type.isNumber(m.type.args[0]))).toBeTruthy()
         })
     
         test('array of locally defined type', async () => {
@@ -62,7 +62,12 @@ describe('array of', () => {
         beforeAll(async () => func = ast.tree.find(n => n.name === 'fn'))
 
         test('Returning array of String', async () => {
-            expect(func.type.type.full === 'Array' && func.type.type.args[0].keyword === 'string').toBeTruthy()
+            //expect(func.type.type.full === 'Array' && func.type.type.args[0].keyword === 'string').toBeTruthy()
+            expect(checkFunction(func, {
+                callCheck: signature => type.isString(signature.args?.[0]),
+                parameterCheck: params => params.members?.[0]?.name === 'xs',
+                returnTypeCheck: returns => type.isString(returns?.args[0])
+            }))
         })
 
         /*

--- a/test/util.js
+++ b/test/util.js
@@ -4,6 +4,8 @@ const path = require('path')
 const { Logger } = require('../lib/logging')
 const { fail } = require('assert')
 const os = require('os')
+const typer = require('../lib/compile')
+
 
 /**
  * Hackish. When having code as string, we can either:
@@ -311,6 +313,12 @@ const locations = {
     }
 }
 
+
+const cds2ts = async (cdsFile, options = {}) => await typer.compileFromFile(
+    locations.unit.files(cdsFile), 
+    options
+)
+
 module.exports = {
     loadModule,
     toHaveAll,
@@ -320,5 +328,6 @@ module.exports = {
     resolveAliases,
     validateDTSTypes,
     toHavePropertyOfType,
-    locations
+    locations,
+    cds2ts
 }


### PR DESCRIPTION
Instead generating actions/ functions as

```ts
f: (a: string, b: number) => boolean
```

they are now instead generated as

```ts
f: {
  (a: string, b: number): boolean,
  __parameters: { a: string, b: number },
  __returns: boolean
}
```

this leaves `f` as callable, but also injects the parameter list as explicit object into `f`. This makes it far more easy to extract the parameter types on CDS side, where we need them in context of handler implementations.