### PR TITLE
Make Bound Functions Static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## Version 0.9.1 - TBD
 
 ### Changed
+- Actions and functions are now attached to a static `.actions` property of each generated class. This reflects the runtime behaviour better than the former way of generating instance methods
 
 ### Added
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -145,10 +145,13 @@ class SourceFile extends File {
      * stringifyLambda({name: 'f', parameters: [['p','T']], returns: 'number'})  // { (p: T): number, __parameters: { p: T } }
      * ```
      */
-    static stringifyLambda({name, parameters=[], returns='any', initialiser}) {
+    static stringifyLambda({name, parameters=[], returns='any', initialiser, isStatic=false}) {
         const parameterTypes = parameters.map(([n, t]) => `${n}: ${t}`).join(', ')
         const callableSignature = `(${parameterTypes}): ${returns}`
-        const prefix = name ? `${name}: `: ''
+        let prefix = name ? `${name}: `: ''
+        if (prefix && isStatic) {
+            prefix = `static ${prefix}`
+        }
         const suffix = initialiser ? ` = ${initialiser}` : ''
         const lambda = `{ ${callableSignature}, __parameters: {${parameterTypes}}, __returns: ${returns} }`
         return prefix + lambda + suffix

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -144,21 +144,25 @@ class Visitor {
             }
         }      
 
+        buffer.add('static actions: {')
+        buffer.indent()
         for (const [aname, action] of Object.entries(entity.actions ?? {})) {
             buffer.add(
                 SourceFile.stringifyLambda({
                     name: aname,
                     parameters: this.#stringifyFunctionParams(action.params, file),
-                    returns: action.returns ? this.resolver.resolveAndRequire(action.returns, file).typeName : 'any',
-                    initialiser: `undefined as unknown as typeof ${clean}.${aname}`,
-                    isStatic: true
+                    returns: action.returns ? this.resolver.resolveAndRequire(action.returns, file).typeName : 'any'
+                    //initialiser: `undefined as unknown as typeof ${clean}.${aname}`,
                 })
             )
         }
         buffer.outdent()
-        buffer.add('};')
+        buffer.add('}') // end of actions
+
         buffer.outdent()
-        buffer.add('}')
+        buffer.add('};') // end of generated class
+        buffer.outdent()
+        buffer.add('}')  // end of aspect
 
         // CLASS WITH ADDED ASPECTS
         file.addImport(baseDefinitions.path)

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -150,7 +150,8 @@ class Visitor {
                     name: aname,
                     parameters: this.#stringifyFunctionParams(action.params, file),
                     returns: action.returns ? this.resolver.resolveAndRequire(action.returns, file).typeName : 'any',
-                    initialiser: `undefined as unknown as this['${aname}']`
+                    initialiser: `undefined as unknown as typeof ${clean}.${aname}`,
+                    isStatic: true
                 })
             )
         }

--- a/test/ast.js
+++ b/test/ast.js
@@ -186,7 +186,7 @@ function visitTypeReference(node) {
 }
 
 /**
- * @typedef {{name: string, type: any, optional: boolean, nodeType: string}} PropertyDeclaration
+ * @typedef {{name: string, type: any, optional: boolean, nodeType: string, modifiers: object}} PropertyDeclaration
  * @param node {ts.PropertyDeclaration}
  * @returns {PropertyDeclaration}
  */
@@ -194,7 +194,8 @@ function visitPropertyDeclaration(node) {
     const name = visit(node.name)
     const type = visit(node.type)
     const optional = !!node.questionToken
-    return { name, type, optional, nodeType: kinds.PropertyDeclaration }
+    const modifiers = node.modifiers?.map(visit) ?? []
+    return { name, type, optional, nodeType: kinds.PropertyDeclaration, modifiers }
 }
 
 /**
@@ -382,7 +383,7 @@ class JSASTWrapper {
     }
 }
 
-const checkFunction = (fnNode, {callCheck, parameterCheck, returnTypeCheck}) => {
+const checkFunction = (fnNode, {callCheck, parameterCheck, returnTypeCheck, modifiersCheck}) => {
     if (!fnNode) throw new Error('the function does not exist (or was not properly accessed from the AST)') 
     const [callsignature, parameters, returnType] = fnNode?.type?.members
     if (!callsignature || callsignature.keyword !== 'callsignature') throw new Error('callsignature is not present or of wrong type')
@@ -392,14 +393,18 @@ const checkFunction = (fnNode, {callCheck, parameterCheck, returnTypeCheck}) => 
     if (callCheck && !callCheck(callsignature.type)) throw new Error('callsignature is not matching expectations')
     if (parameterCheck && !parameterCheck(parameters.type)) throw new Error('parameter type is not matching expectations')
     if (returnTypeCheck && !returnTypeCheck(returnType.type)) throw new Error('return type is not matching expectations')
+    if (modifiersCheck && !modifiersCheck(fnNode?.modifiers)) throw new Error('modifiers did not meet expectations')
 
     return true
 }
 
-const type = {
-    isString: node => node?.keyword === 'string',
-    isNumber: node => node?.keyword === 'number',
-    isAny: node => node?.keyword === 'any'
+const checkKeyword = (node, expected) => node?.keyword === expected
+
+const check = {
+    isString: node => checkKeyword(node, 'string'),
+    isNumber: node => checkKeyword(node, 'number'),
+    isAny: node => checkKeyword(node, 'any'),
+    isStatic: node => checkKeyword(node, 'static')
 }
 
 
@@ -407,5 +412,5 @@ module.exports = {
     ASTWrapper,
     JSASTWrapper,
     checkFunction,
-    type
+    check: check
 }

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -13,12 +13,12 @@ describe('Actions', () => {
     test('Bound', async () => {
         const paths = await cds2ts('actions/model.cds', { outputDirectory: dir, inlineDeclarations: 'structured' })
         const astw = new ASTWrapper(path.join(paths[1], 'index.ts'))
-        checkFunction(astw.getAspectProperty('_EAspect', 'f'), {
-            modifiersCheck: modifiers => modifiers.some(check.isStatic),
+        const actions = astw.getAspectProperty('_EAspect', 'actions')
+        expect(actions.modifiers.some(check.isStatic)).toBeTruthy()
+        checkFunction(actions.type.members.find(fn => fn.name === 'f'), {
             parameterCheck: ({members: [fst]}) => fst.name === 'x' && check.isString(fst.type)
         })
-        checkFunction(astw.getAspectProperty('_EAspect', 'g'), {
-            modifiersCheck: modifiers => modifiers.some(check.isStatic),
+        checkFunction(actions.type.members.find(fn => fn.name === 'g'), {
             parameterCheck: ({members: [fst, snd]}) => {
                 const fstCorrect = fst.name === 'a' && fst.type.members[0].name === 'x' && check.isNumber(fst.type.members[0].type)
                     && fst.type.members[1].name === 'y' && check.isNumber(fst.type.members[1].type)
@@ -44,21 +44,20 @@ describe('Actions', () => {
     test('Bound Returning External Type', async () => {
         const paths = await cds2ts('actions/model.cds', { outputDirectory: dir, inlineDeclarations: 'structured' })
         const astw = new ASTWrapper(path.join(paths[1], 'index.ts'))
-        checkFunction(astw.getAspectProperty('_EAspect', 'f'), {
-            modifiersCheck: modifiers => modifiers.some(check.isStatic),
+        const actions = astw.getAspectProperty('_EAspect', 'actions')
+        expect(actions.modifiers.some(check.isStatic)).toBeTruthy()
+        checkFunction(actions.type.members.find(fn => fn.name === 'f'), {
             callCheck: signature => check.isAny(signature),
             parameterCheck: ({members: [fst]}) => fst.name === 'x' && check.isString(fst.type),
             returnTypeCheck: returns => check.isAny(returns)
         })
 
-        checkFunction(astw.getAspectProperty('_EAspect', 'k'), {
-            modifiersCheck: modifiers => modifiers.some(check.isStatic),
+        checkFunction(actions.type.members.find(fn => fn.name === 'k'), {
             callCheck: ({full}) => full === '_elsewhere.ExternalType',
             returnTypeCheck: ({full}) => full === '_elsewhere.ExternalType'
         })
 
-        checkFunction(astw.getAspectProperty('_EAspect', 'l'), {
-            modifiersCheck: modifiers => modifiers.some(check.isStatic),
+        checkFunction(actions.type.members.find(fn => fn.name === 'l'), {
             callCheck: ({full}) => full === '_.ExternalInRoot',
             returnTypeCheck: ({full}) => full === '_.ExternalInRoot'
         })
@@ -84,21 +83,22 @@ describe('Actions', () => {
     test('Bound Expecting $self Arguments', async () => {
         const paths = await cds2ts('actions/model.cds', { outputDirectory: dir, inlineDeclarations: 'structured' })
         const astw = new ASTWrapper(path.join(paths[1], 'index.ts'))
+        const actions = astw.getAspectProperty('_EAspect', 'actions')
+        expect(actions.modifiers.some(check.isStatic)).toBeTruthy()
+        
+
         // mainly make sure $self parameter is not present at all
-        checkFunction(astw.getAspectProperty('_EAspect', 's1'), {
-            modifiersCheck: modifiers => modifiers.some(check.isStatic),
+        checkFunction(actions.type.members.find(fn => fn.name === 's1'), {
             callCheck: signature => check.isAny(signature),
             returnTypeCheck: returns => check.isAny(returns),
             parameterCheck: ({members}) => members.length === 0
         })
-        checkFunction(astw.getAspectProperty('_EAspect', 'sn'), {
-            modifiersCheck: modifiers => modifiers.some(check.isStatic),
+        checkFunction(actions.type.members.find(fn => fn.name === 'sn'), {
             callCheck: signature => check.isAny(signature),
             returnTypeCheck: returns => check.isAny(returns),
             parameterCheck: ({members}) => members.length === 0           
         })
-        checkFunction(astw.getAspectProperty('_EAspect', 'sx'), {
-            modifiersCheck: modifiers => modifiers.some(check.isStatic),
+        checkFunction(actions.type.members.find(fn => fn.name === 'sx'), {
             callCheck: signature => check.isAny(signature),
             returnTypeCheck: returns => check.isAny(returns),
             parameterCheck: ({members: [fst]}) => check.isNumber(fst.type)

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs').promises
 const path = require('path')
-const { ASTWrapper, checkFunction, type } = require('../ast')
+const { ASTWrapper, checkFunction, check } = require('../ast')
 const { locations, cds2ts } = require('../util')
 
 const dir = locations.testOutput('actions_test')
@@ -14,13 +14,15 @@ describe('Actions', () => {
         const paths = await cds2ts('actions/model.cds', { outputDirectory: dir, inlineDeclarations: 'structured' })
         const astw = new ASTWrapper(path.join(paths[1], 'index.ts'))
         checkFunction(astw.getAspectProperty('_EAspect', 'f'), {
-            parameterCheck: ({members: [fst]}) => fst.name === 'x' && type.isString(fst.type)
+            modifiersCheck: modifiers => modifiers.some(check.isStatic),
+            parameterCheck: ({members: [fst]}) => fst.name === 'x' && check.isString(fst.type)
         })
         checkFunction(astw.getAspectProperty('_EAspect', 'g'), {
+            modifiersCheck: modifiers => modifiers.some(check.isStatic),
             parameterCheck: ({members: [fst, snd]}) => {
-                const fstCorrect = fst.name === 'a' && fst.type.members[0].name === 'x' && type.isNumber(fst.type.members[0].type)
-                    && fst.type.members[1].name === 'y' && type.isNumber(fst.type.members[1].type)
-                const sndCorrect = snd.name === 'b' && type.isNumber(snd.type)
+                const fstCorrect = fst.name === 'a' && fst.type.members[0].name === 'x' && check.isNumber(fst.type.members[0].type)
+                    && fst.type.members[1].name === 'y' && check.isNumber(fst.type.members[1].type)
+                const sndCorrect = snd.name === 'b' && check.isNumber(snd.type)
                 return fstCorrect && sndCorrect
             }
         })
@@ -30,11 +32,12 @@ describe('Actions', () => {
         const paths = await cds2ts('actions/model.cds', { outputDirectory: dir, inlineDeclarations: 'structured' })
         const ast = new ASTWrapper(path.join(paths[2], 'index.ts')).tree
         checkFunction(ast.find(node => node.name === 'free'), {
-            callCheck: ({members: [fst, snd]}) => fst.name === 'a' && type.isNumber(fst.type)
-                && snd.name === 'b' && type.isString(snd.type),
-            parameterCheck: ({members: [fst]}) => fst.name === 'param' && type.isString(fst.type),
-            returnTypeCheck: ({members: [fst, snd]}) => fst.name === 'a' && type.isNumber(fst.type)
-                && snd.name === 'b' && type.isString(snd.type)
+            modifiersCheck: (modifiers = []) => !modifiers.some(check.isStatic),
+            callCheck: ({members: [fst, snd]}) => fst.name === 'a' && check.isNumber(fst.type)
+                && snd.name === 'b' && check.isString(snd.type),
+            parameterCheck: ({members: [fst]}) => fst.name === 'param' && check.isString(fst.type),
+            returnTypeCheck: ({members: [fst, snd]}) => fst.name === 'a' && check.isNumber(fst.type)
+                && snd.name === 'b' && check.isString(snd.type)
         })
     })
 
@@ -42,17 +45,20 @@ describe('Actions', () => {
         const paths = await cds2ts('actions/model.cds', { outputDirectory: dir, inlineDeclarations: 'structured' })
         const astw = new ASTWrapper(path.join(paths[1], 'index.ts'))
         checkFunction(astw.getAspectProperty('_EAspect', 'f'), {
-            callCheck: signature => type.isAny(signature),
-            parameterCheck: ({members: [fst]}) => fst.name === 'x' && type.isString(fst.type),
-            returnTypeCheck: returns => type.isAny(returns)
+            modifiersCheck: modifiers => modifiers.some(check.isStatic),
+            callCheck: signature => check.isAny(signature),
+            parameterCheck: ({members: [fst]}) => fst.name === 'x' && check.isString(fst.type),
+            returnTypeCheck: returns => check.isAny(returns)
         })
 
         checkFunction(astw.getAspectProperty('_EAspect', 'k'), {
+            modifiersCheck: modifiers => modifiers.some(check.isStatic),
             callCheck: ({full}) => full === '_elsewhere.ExternalType',
             returnTypeCheck: ({full}) => full === '_elsewhere.ExternalType'
         })
 
         checkFunction(astw.getAspectProperty('_EAspect', 'l'), {
+            modifiersCheck: modifiers => modifiers.some(check.isStatic),
             callCheck: ({full}) => full === '_.ExternalInRoot',
             returnTypeCheck: ({full}) => full === '_.ExternalInRoot'
         })
@@ -63,11 +69,13 @@ describe('Actions', () => {
         const ast = new ASTWrapper(path.join(paths[2], 'index.ts')).tree
         
         checkFunction(ast.find(node => node.name === 'free2'), {
+            modifiersCheck: (modifiers = []) => !modifiers.some(check.isStatic),
             callCheck: ({full}) => full === '_elsewhere.ExternalType',
             returnTypeCheck: ({full}) => full === '_elsewhere.ExternalType'
         })
 
         checkFunction(ast.find(node => node.name === 'free3'), {
+            modifiersCheck: (modifiers = []) => !modifiers.some(check.isStatic),
             callCheck: ({full}) => full === '_.ExternalInRoot',
             returnTypeCheck: ({full}) => full === '_.ExternalInRoot'
         })
@@ -78,19 +86,22 @@ describe('Actions', () => {
         const astw = new ASTWrapper(path.join(paths[1], 'index.ts'))
         // mainly make sure $self parameter is not present at all
         checkFunction(astw.getAspectProperty('_EAspect', 's1'), {
-            callCheck: signature => type.isAny(signature),
-            returnTypeCheck: returns => type.isAny(returns),
+            modifiersCheck: modifiers => modifiers.some(check.isStatic),
+            callCheck: signature => check.isAny(signature),
+            returnTypeCheck: returns => check.isAny(returns),
             parameterCheck: ({members}) => members.length === 0
         })
         checkFunction(astw.getAspectProperty('_EAspect', 'sn'), {
-            callCheck: signature => type.isAny(signature),
-            returnTypeCheck: returns => type.isAny(returns),
+            modifiersCheck: modifiers => modifiers.some(check.isStatic),
+            callCheck: signature => check.isAny(signature),
+            returnTypeCheck: returns => check.isAny(returns),
             parameterCheck: ({members}) => members.length === 0           
         })
         checkFunction(astw.getAspectProperty('_EAspect', 'sx'), {
-            callCheck: signature => type.isAny(signature),
-            returnTypeCheck: returns => type.isAny(returns),
-            parameterCheck: ({members: [fst]}) => type.isNumber(fst.type)
+            modifiersCheck: modifiers => modifiers.some(check.isStatic),
+            callCheck: signature => check.isAny(signature),
+            returnTypeCheck: returns => check.isAny(returns),
+            parameterCheck: ({members: [fst]}) => check.isNumber(fst.type)
         })
     })
 

--- a/test/unit/arrayof.test.js
+++ b/test/unit/arrayof.test.js
@@ -3,7 +3,7 @@
 const fs = require('fs').promises
 const path = require('path')
 const cds2ts = require('../../lib/compile')
-const { ASTWrapper, checkFunction, type } = require('../ast')
+const { ASTWrapper, checkFunction, check } = require('../ast')
 const { locations } = require('../util')
 
 const dir = locations.testOutput('arrayof_test')
@@ -28,13 +28,13 @@ describe('array of', () => {
         test('array of String', async () => {
             expect(aspect.members.find(m => m.name === 'stringz' 
                 && m.type.full === 'Array' 
-                && type.isString(m.type.args[0]))).toBeTruthy()
+                && check.isString(m.type.args[0]))).toBeTruthy()
         })
     
         test('many Integer', async () => {
             expect(aspect.members.find(m => m.name === 'numberz' 
                 && m.type.full === 'Array' 
-                && type.isNumber(m.type.args[0]))).toBeTruthy()
+                && check.isNumber(m.type.args[0]))).toBeTruthy()
         })
     
         test('array of locally defined type', async () => {
@@ -64,9 +64,9 @@ describe('array of', () => {
         test('Returning array of String', async () => {
             //expect(func.type.type.full === 'Array' && func.type.type.args[0].keyword === 'string').toBeTruthy()
             expect(checkFunction(func, {
-                callCheck: signature => type.isString(signature.args?.[0]),
+                callCheck: signature => check.isString(signature.args?.[0]),
                 parameterCheck: params => params.members?.[0]?.name === 'xs',
-                returnTypeCheck: returns => type.isString(returns?.args[0])
+                returnTypeCheck: returns => check.isString(returns?.args[0])
             }))
         })
 


### PR DESCRIPTION
Bound functions/ actions are now generated into a `static` property named `actions`. (They were formally generated as instance methods.)

```cds 
entity E {}
    actions {
        action f ();
        function g ();
    }
}
```

⬇️

```ts
class E {
  static actions: {
    f: () => void,
    g: () => void
  }
}
```