### PR TITLE
Generate Static Name Property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 
 ### Added
+- Each generated class now contains their original fully qualified name in a static `.name` property
 
 ### Fixed
 - Fixed an error when an entity uses `type of` on a property they have inherited from another entity

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -196,10 +196,12 @@ class Visitor {
     }
 
     #staticClassContents(clean, entity) {
-        return this.#isDraftEnabled(entity) ? [`static drafts: typeof ${clean}`] : [] 
+        return this.#isDraftEnabled(entity) ? [`static drafts: typeof ${clean}`] : []
     }
 
     #printEntity(name, entity) {
+        // static .name has to be defined more forcefully: https://github.com/microsoft/TypeScript/issues/442
+        const overrideNameProperty = (clazz, content) => `Object.defineProperty(${clazz}, 'name', { value: '${content}' })`
         const clean = this.resolver.trimNamespace(name)
         const ns = this.resolver.resolveNamespace(name.split('.'))
         const file = this.getNamespaceFile(ns)
@@ -224,10 +226,9 @@ class Visitor {
         file.addClass(plural, name)
 
         const parent = this.resolver.resolveParent(entity.name)
-        const buffer =
-            parent && parent.kind === 'entity'
-                ? file.getSubNamespace(this.resolver.trimNamespace(parent.name))
-                : file.classes
+        const buffer = parent && parent.kind === 'entity'
+            ? file.getSubNamespace(this.resolver.trimNamespace(parent.name))
+            : file.classes
 
         // we can't just use "singular" here, as it may have the subnamespace removed:
         // "Books.text" is just "text" in "singular". Within the inflected exports we need
@@ -250,6 +251,8 @@ class Visitor {
         // plural can not be a type alias to $singular[] but needs to be a proper class instead,
         // so it can get passed as value to CQL functions.
         buffer.add(`export class ${plural} extends Array<${singular}> {${this.#staticClassContents(singular, entity).join('\n')}}`)
+        buffer.add(overrideNameProperty(singular, entity.name))
+        buffer.add(overrideNameProperty(plural, entity.name))
         buffer.add('')
     }
 


### PR DESCRIPTION
Generated classes (both for singular and plural) will now contain a static `.name` property which contains the fully qualified name of the entity it was generated from.

```cds
namespace 'sap.bookshop';

entity Books {}
```
⬇️ (more or less)
```ts
// sap/bookshop/.index.ts
class Book {
  static name = 'sap.bookshop.Books'
}

class Books extends Array<Book> {
  static name = 'sap.bookshop.Books'
}
```
This allows the class _and its transpiled form_ to be used as parameter for CDS functions that expect CSN definitions. Those will look for a `.name` property and use that as lookup key in the compiled CSN.

This PR is therefore a step towards using the transpiled `index.js` files in a TypeScript context.

Note that `.name` is actually a [reserved name](https://github.com/microsoft/TypeScript/issues/442), so we have to forcefully inject it into the generated classes. This does not seem to be an issue, but should be kept an eye on.
