### PR TITLE
Concise Anonymous Enums

### DIFF
--- a/lib/components/enum.js
+++ b/lib/components/enum.js
@@ -21,7 +21,7 @@
  * ```
  *
  * @param {Buffer} buffer Buffer to write into
- * @param {string} name local name of the enum
+ * @param {string} name local name of the enum, i.e. the name under which it should be created in the .ts file
  * @param {[string, string][]} kvs list of key-value pairs
  */
 function printEnum(buffer, name, kvs, options = {}) {
@@ -66,12 +66,11 @@ const csnToEnum = ({enum: enm, type}, options = {}) => {
 }
 
 /**
- * 
+ * @param {string} entity
+ * @param {string} property
  */
-const propertyToInlineEnumName = (entity, property) => `${entity}_${property}`
+const propertyToAnonymousEnumName = (entity, property) => `${entity}_${property}`
 
-            // if the type is in csn.definitions, then it's actually referring
-            // to an external enum. Those are handled elsewhere.
 /**
  * A type is considered to be an inline enum, iff it has a `.enum` property
  * _and_ its type is a CDS primitive, i.e. it is not contained in `cds.definitions`.
@@ -83,9 +82,27 @@ const propertyToInlineEnumName = (entity, property) => `${entity}_${property}`
  */
 const isInlineEnumType = (element, csn) => element.enum && !(element.type in csn.definitions)
 
+const stringifyEnumImplementation = (name, enm) => `module.exports.${name} = Object.fromEntries(Object.entries(${enm}).map(([k,v]) => [k,v.val]))`
+
+/**
+ * @param {string} name
+ * @param {string} fq
+ * @returns {string}
+ */
+const stringifyNamedEnum = (name, fq) => stringifyEnumImplementation(name, `cds.model.definitions['${fq}'].enum`)
+/**
+ * @param {string} name
+ * @param {string} fq
+ * @param {string} property
+ * @returns {string}
+ */
+const stringifyAnonymousEnum = (name, fq, property) => stringifyEnumImplementation(fq, `cds.model.definitions['${name}'].elements.${property}.enum`)
+
 module.exports = {
     printEnum,
     csnToEnum,
-    propertyToInlineEnumName,
-    isInlineEnumType
+    propertyToAnonymousEnumName,
+    isInlineEnumType,
+    stringifyNamedEnum,
+    stringifyAnonymousEnum
 }

--- a/lib/components/resolver.js
+++ b/lib/components/resolver.js
@@ -4,7 +4,7 @@ const util = require('../util')
 const { Buffer, SourceFile, Path, Library, baseDefinitions } = require("../file")
 const { deepRequire, createToManyAssociation, createToOneAssociation, createArrayOf, createCompositionOfMany, createCompositionOfOne } = require('./wrappers')
 const { StructuredInlineDeclarationResolver } = require("./inline")
-const { isInlineEnumType, propertyToInlineEnumName } = require('./enum')
+const { isInlineEnumType, propertyToInlineEnumName, propertyToAnonymousEnumName } = require('./enum')
 
 /** @typedef {{ cardinality?: { max?: '*' | number } }} EntityCSN */
 /** @typedef {{ definitions?: Object<string, EntityCSN> }} CSN */
@@ -107,6 +107,7 @@ class Resolver {
      * @returns {string} the entity name without leading namespace.
      */
     trimNamespace(p) {
+        // TODO: we might want to cache this
         // start on right side, go up while we have an entity at hand
         // we cant start on left side, as that clashes with undefined entities like "sap"
         const parts = p.split('.')
@@ -361,7 +362,7 @@ class Resolver {
                 // we use the singular as the initial declaration of these enums takes place
                 // while defining the singular class. Which therefore uses the singular over the plural name.
                 const cleanEntityName = util.singular4(element.parent, true)
-                const enumName = propertyToInlineEnumName(cleanEntityName, element.name)
+                const enumName = propertyToAnonymousEnumName(cleanEntityName, element.name)
                 result.type = enumName
                 result.plainName = enumName
                 result.isInlineDeclaration = true

--- a/lib/file.js
+++ b/lib/file.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs').promises
 const { readFileSync } = require('fs')
-const { printEnum } = require('./components/enum')
+const { printEnum, stringifyNamedEnum, stringifyAnonymousEnum, propertyToAnonymousEnumName } = require('./components/enum')
 const path = require('path')
 
 const AUTO_GEN_NOTE = "// This is an automatically generated file. Please do not change its contents manually!"
@@ -104,7 +104,7 @@ class SourceFile extends File {
         this.events = { buffer: new Buffer(), fqs: []} 
         /** @type {Buffer} */
         this.types = new Buffer()
-        /** @type {{ buffer: Buffer, fqs: {name: string, fq: string}[]}} */
+        /** @type {{ buffer: Buffer, fqs: {name: string, fq: string, property?: string}[]}} */
         this.enums = { buffer: new Buffer(), fqs: [] }
         /** @type {{ buffer: Buffer }} */
         this.inlineEnums = { buffer: new Buffer() }
@@ -221,17 +221,56 @@ class SourceFile extends File {
 
     /**
      * Adds an enum to this file.
-     * @param {string} fq fully qualified name of the enum
+     * @param {string} fq fully qualified name of the enum (entity name within CSN)
      * @param {string} name local name of the enum
      * @param {[string, string][]} kvs list of key-value pairs
+     * @param {string} [property] property to which the enum is attached. 
+     *  If given, the enum is considered to be an anonymous inline definition of an enum.
+     *  If not, it is considered to be regular, named enum.
      */
     addEnum(fq, name, kvs) {
         this.enums.fqs.push({ name, fq })
         printEnum(this.enums.buffer, name, kvs)
     }
 
-    addInlineEnum(name, kvs) {
-        printEnum(this.inlineEnums.buffer, name, kvs, {export: false})
+    /**
+     * Adds an anonymous enum to this file.
+     * @param {string} entityCleanName name of the entity the enum is attached to without namespace
+     * @param {string} entityFqName name of the entity the enum is attached to with namespace
+     * 
+     * @param {string} propertyName property to which the enum is attached. 
+     * @param {[string, string][]} kvs list of key-value pairs
+     *  If given, the enum is considered to be an anonymous inline definition of an enum.
+     *  If not, it is considered to be regular, named enum.
+     * 
+     * @example
+     * ```js
+     * addAnonymousEnum('Books.genre', 'Books', 'genre', [['horror','horror']])
+     * ```
+     * generates
+     * ```js
+     * // index.js
+     * module.exports.Books.genre = F(cds.model.definitions['Books'].elements.genre.enum)
+     * // F(...) is a function that maps a CSN enum to a more convenient style
+     * ```
+     * and also
+     * ```ts
+     * // index.ts
+     * const Books_genre = { horror: 'horror' }
+     * type Books_genre = 'horror'
+     * class Book {
+     *   static genre = Books_genre
+     *   genre: Books_genre
+     * }
+     * ```
+     */
+    addAnonymousEnum(entityCleanName, entityFqName, propertyName, kvs) {
+        this.enums.fqs.push({ 
+            name: entityFqName,
+            property: propertyName,
+            fq: `${entityCleanName}.${propertyName}`
+        })
+        printEnum(this.inlineEnums.buffer, propertyToAnonymousEnumName(entityCleanName, propertyName), kvs, {export: false})
     }
 
     /**
@@ -352,7 +391,9 @@ class SourceFile extends File {
             .concat(['// actions'])
             .concat(this.actions.names.map(name => `module.exports.${name} = '${name}'`))
             .concat(['// enums'])
-            .concat(this.enums.fqs.map(({fq, name}) => `module.exports.${name} = Object.fromEntries(Object.entries(cds.model.definitions['${fq}'].enum).map(([k,v]) => [k,v.val]))`))
+            .concat(this.enums.fqs.map(({name, fq, property}) => property 
+                ? stringifyAnonymousEnum(name, fq, property)
+                : stringifyNamedEnum(name, fq)))
             .join('\n') + '\n'
     }
 }

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -8,7 +8,7 @@ const { FlatInlineDeclarationResolver, StructuredInlineDeclarationResolver } = r
 const { Resolver } = require('./components/resolver')
 const { Logger } = require('./logging')
 const { docify } = require('./components/wrappers')
-const { csnToEnum, propertyToInlineEnumName, isInlineEnumType } = require('./components/enum')
+const { csnToEnum, propertyToAnonymousEnumName, isInlineEnumType } = require('./components/enum')
 
  /** @typedef {import('./file').File} File */
  /** @typedef {{ entity: String }} Context */
@@ -153,18 +153,11 @@ class Visitor {
             }
         }
 
-        if (enums.length) {
-            buffer.add('static elements = {')
-            buffer.indent()
-            for (const e of enums) {
-                const enumName = propertyToInlineEnumName(clean, e.name)
-                file.addInlineEnum(enumName, csnToEnum(e, {unwrapVals: false}))
-                buffer.add(`${e.name}: { enum: ${enumName} },`)
-            }
-            buffer.outdent()
-            buffer.add('}')
+        buffer.indent()
+        for (const e of enums) {
+            buffer.add(`static ${e.name} = ${propertyToAnonymousEnumName(clean, e.name)}`)
+            file.addAnonymousEnum(clean, name, e.name, csnToEnum(e, {unwrapVals: true}))
         }
-
         buffer.add('static actions: {')
         buffer.indent()
         for (const [aname, action] of Object.entries(entity.actions ?? {})) {
@@ -177,6 +170,7 @@ class Visitor {
                 })
             )
         }
+        buffer.outdent()
         buffer.outdent()
         buffer.add('}') // end of actions
 

--- a/test/unit/enum.test.js
+++ b/test/unit/enum.test.js
@@ -20,21 +20,13 @@ describe('Enum Types', () => {
         ast = new ASTWrapper(path.join(paths[1], 'index.ts'))
     })
 
-    describe('Static Enum Property', () => {
-        test('Wrapper Present', async () => {
-            expect(ast.getAspects().find(({name, members}) => name === '_InlineEnumAspect'
-                && members?.find(member => member.name === 'elements' && member.modifiers?.find(m => m.keyword === 'static')))
-            ).toBeTruthy()
-        })
-    })
-
     describe('Anonymous', () => {
         describe('String Enum', () => {
             test('Definition Present', async () => 
                 expect(ast.tree.find(n => n.name === 'InlineEnum_gender' 
-                && n.initializer.expression.female.val === 'female'
-                && n.initializer.expression.male.val === 'male'
-                && n.initializer.expression.non_binary.val === 'non-binary'))
+                && n.initializer.expression.female === 'female'
+                && n.initializer.expression.male === 'male'
+                && n.initializer.expression.non_binary === 'non-binary'))
                 .toBeTruthy())
 
             test('Referring Property', async () =>
@@ -47,10 +39,10 @@ describe('Enum Types', () => {
         describe('Int Enum', () => {
             test('Definition Present', async () => 
                 expect(ast.tree.find(n => n.name === 'InlineEnum_status' 
-                && n.initializer.expression.submitted.val === 1
-                && n.initializer.expression.fulfilled.val === 2
-                && n.initializer.expression.canceled.val === -1
-                && n.initializer.expression.shipped.val === 42))
+                && n.initializer.expression.submitted === 1
+                && n.initializer.expression.fulfilled === 2
+                && n.initializer.expression.canceled === -1
+                && n.initializer.expression.shipped === 42))
                 .toBeTruthy())
 
             test('Referring Property', async () =>
@@ -62,10 +54,10 @@ describe('Enum Types', () => {
         describe('Mixed Enum', () => {
             test('Definition Present', async () =>
                 expect(ast.tree.find(n => n.name === 'InlineEnum_yesno'
-                && n.initializer.expression.catchall.val === 42
-                && n.initializer.expression.no.val === false
-                && n.initializer.expression.yes.val === true
-                && n.initializer.expression.yesnt.val === false))
+                && n.initializer.expression.catchall === 42
+                && n.initializer.expression.no === false
+                && n.initializer.expression.yes === true
+                && n.initializer.expression.yesnt === false))
                 .toBeTruthy())
 
             test('Referring Property', async () =>


### PR DESCRIPTION
Anonymous (inline) enums had before been generated to match exactly with how they were defined in CSN.
This led to long-winded calls with additionally wrapped properties:

```js
myBook.genre = Books.definitions.genre.enum.Horror.val
```

This PR flattens the generated enums and produces their runtime equivalent in the respective `index.js` files.

```js
myBook.genre = Books.genre.Horror
``` 

Their level of convenience should therefore now on a par with named enums.
