### PR TITLE
Auto Expose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 
 ### Added
+- Autoexposed entities in services are now also generated
 - Inline enums that are defined as literal type of properties are now supported as well (note: this feature is experimental. The location to which enums are generated might change in the future!)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Fixed an error when an entity uses `type of` on a property they have inherited from another entity
 - Fixed an error during draftability propagation when defining compositions on types that are declared inline
 
+### Removed
+- `compileFromCSN` is no longer part of the package's API
+
 ## Version 0.10.0 - 2023-09-21
 
 ### Changed

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -70,6 +70,5 @@ const compileFromCSN = async (csn, parameters) => {
 }
 
 module.exports = {
-    compileFromFile,
-    //compileFromCSN,
+    compileFromFile
 }

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -45,13 +45,14 @@ const writeJsConfig = (path, logger) => {
  */
 const compileFromFile = async (inputFile, parameters) => {
     const paths = typeof inputFile === 'string' ? normalize(inputFile) : inputFile.map(f => normalize(f))
-    const csn = await cds.linked(await cds.load(paths, { docs: true, flavor: 'xtended' }))
-    return compileFromCSN(csn, parameters)
+    const xtended = await cds.linked(await cds.load(paths, { docs: true, flavor: 'xtended' }))
+    const inferred = await cds.linked(await cds.load(paths, { docs: true, flavor: 'xtended' }))
+    return compileFromCSN({xtended, inferred}, parameters)
 }
 
 /**
  * Compiles a CSN object to Typescript types.
- * @param csn {CSN}
+ * @param {{xtended: CSN, inferred: CSN}} csn
  * @param parameters {CompileParameters} path to root directory for all generated files, min log level
  */
 const compileFromCSN = async (csn, parameters) => {
@@ -70,5 +71,5 @@ const compileFromCSN = async (csn, parameters) => {
 
 module.exports = {
     compileFromFile,
-    compileFromCSN,
+    //compileFromCSN,
 }

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -46,7 +46,7 @@ const writeJsConfig = (path, logger) => {
 const compileFromFile = async (inputFile, parameters) => {
     const paths = typeof inputFile === 'string' ? normalize(inputFile) : inputFile.map(f => normalize(f))
     const xtended = await cds.linked(await cds.load(paths, { docs: true, flavor: 'xtended' }))
-    const inferred = await cds.linked(await cds.load(paths, { docs: true, flavor: 'xtended' }))
+    const inferred = await cds.linked(await cds.load(paths, { docs: true }))
     return compileFromCSN({xtended, inferred}, parameters)
 }
 

--- a/lib/components/resolver.js
+++ b/lib/components/resolver.js
@@ -64,7 +64,7 @@ const Builtins = {
 }
 
 class Resolver {
-    get csn() { return this.visitor.csn }
+    get csn() { return this.visitor.csn.xtended }
     
     /** @param {Visitor} visitor */
     constructor(visitor) {

--- a/lib/components/resolver.js
+++ b/lib/components/resolver.js
@@ -64,7 +64,7 @@ const Builtins = {
 }
 
 class Resolver {
-    get csn() { return this.visitor.csn.xtended }
+    get csn() { return this.visitor.csn.inferred }
     
     /** @param {Visitor} visitor */
     constructor(visitor) {

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -104,6 +104,17 @@ class Visitor {
                 this.visitEntity(name, entity)
             }
         }
+        // FIXME: optimise
+        // We are currently working with two flavours of CSN:
+        // xtended, as it is as close as possible to an OOP class hierarchy
+        // inferred, as it contains information missing in xtended
+        // This is less than optimal and has to be revisited at some point!
+        const handledKeys = new Set(Object.keys(this.csn.xtended.definitions))
+        // we are looking for autoexposed entities in services
+        const missing = Object.entries(this.csn.inferred.definitions).filter(([key]) => !key.endsWith('.texts') &&!handledKeys.has(key))
+        for (const [name, entity] of missing) {
+            this.visitEntity(name, entity)
+        }
     }
 
     /**

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -57,11 +57,11 @@ class Visitor {
     }
 
     /**
-     * @param csn root CSN
+     * @param {{xtended: CSN, inferred: CSN}} csn root CSN
      * @param {VisitorOptions} options
      */
     constructor(csn, options = {}, logger = new Logger()) {
-        amendCSN(csn)
+        amendCSN(csn.xtended)
         this.options = { ...defaults, ...options }
         this.logger = logger
         this.csn = csn
@@ -97,7 +97,7 @@ class Visitor {
      * Visits all definitions within the CSN definitions.
      */
     visitDefinitions() {
-        for (const [name, entity] of Object.entries(this.csn.definitions)) {
+        for (const [name, entity] of Object.entries(this.csn.xtended.definitions)) {
             if (entity._unresolved === true) {
                 this.logger.error(`Skipping unresolved entity: ${JSON.stringify(entity)}`)
             } else {
@@ -142,13 +142,13 @@ class Visitor {
                 // lookup in cds.definitions can fail for inline structs.
                 // We don't really have to care for this case, as keys from such structs are _not_ propagated to
                 // the containing entity.
-                for (const [kname, kelement] of Object.entries(this.csn.definitions[element.target]?.keys ?? {})) {
+                for (const [kname, kelement] of Object.entries(this.csn.xtended.definitions[element.target]?.keys ?? {})) {
                     this.visitElement(`${ename}_${kname}`, kelement, file, buffer)
                 }
             }
 
             // store inline enums for later handling, as they have to go into one common "static elements" wrapper
-            if (isInlineEnumType(element, this.csn)) {
+            if (isInlineEnumType(element, this.csn.xtended)) {
                 enums.push(element)
             }
         }
@@ -232,7 +232,7 @@ class Visitor {
                 `Derived singular and plural forms for '${singular}' are the same. This usually happens when your CDS entities are named following singular flexion. Consider naming your entities in plural or providing '@singular:'/ '@plural:' annotations to have a clear distinction between the two. Plural form will be renamed to '${plural}' to avoid compilation errors within the output.`
             )
         }
-        if (singular in this.csn.definitions) {
+        if (singular in this.csn.xtended.definitions) {
             this.logger.error(
                 `Derived singular '${singular}' for your entity '${name}', already exists. The resulting types will be erronous. Please consider using '@singular:'/ '@plural:' annotations in your model to resolve this collision.`
             )

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -113,7 +113,13 @@ class Visitor {
         // we are looking for autoexposed entities in services
         const missing = Object.entries(this.csn.inferred.definitions).filter(([key]) => !key.endsWith('.texts') &&!handledKeys.has(key))
         for (const [name, entity] of missing) {
-            this.visitEntity(name, entity)
+            // instead of using the definition from inferred CSN, we refer to the projected entity from xtended CSN instead.
+            // The latter contains the CSN fixes (propagated foreign keys, etc) and none of the localised fields we don't handle yet.
+            if (entity.projection) {
+                this.visitEntity(name, this.csn.xtended.definitions[entity.projection.from.ref[0]])
+            } else {
+                this.logger.error(`Expecting an autoexposed projection within a service. Skipping ${name}`)
+            }
         }
     }
 

--- a/test/unit/autoexpose.test.js
+++ b/test/unit/autoexpose.test.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const fs = require('fs').promises
+const path = require('path')
+const { ASTWrapper, checkFunction, check } = require('../ast')
+const { locations, cds2ts } = require('../util')
+
+const dir = locations.testOutput('autoexpose_test')
+
+describe('Autoexpose', () => {
+    beforeEach(async () => await fs.unlink(dir).catch(_ => {}))
+
+    test('Autoexposed Composition Target Present in Service', async () => {
+        const paths = await cds2ts('autoexpose/service.cds', { outputDirectory: dir, inlineDeclarations: 'structured' })
+        const ast = new ASTWrapper(path.join(paths[1], 'index.ts')).tree
+        expect(ast.find(n => n.name === 'Books')).toBeTruthy()
+    })
+})

--- a/test/unit/files/autoexpose/schema.cds
+++ b/test/unit/files/autoexpose/schema.cds
@@ -1,0 +1,11 @@
+namespace autoexpose_test;
+
+@cds.autoexpose
+entity Books {
+    ID: UUID
+}
+
+entity Libraries {
+    ID: UUID;
+    books: Composition of many Books;
+}

--- a/test/unit/files/autoexpose/service.cds
+++ b/test/unit/files/autoexpose/service.cds
@@ -1,0 +1,5 @@
+using { autoexpose_test as my } from './schema.cds';
+
+service MyService {
+  entity Libraries as projection on my.Libraries;
+}


### PR DESCRIPTION
Due to the use of `xtended` CSN flavour, cds-typer currently does not generate code for auto exposed entities in services.
This PR makes sure those entities are printed as well _at a high performance price_, so this feature will have to be revisited soon.

This is closely related to https://github.com/cap-js/cds-typer/issues/77, as `.texts` entities are also included in `inferred`.