### PR TITLE
Bump node version to 18+20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        version: [18, 16]
+        version: [20, 18]
         platform: [ macos-latest, ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/70