### PR TITLE
Print Service Names as Default Export 

### DIFF
--- a/lib/components/resolver.js
+++ b/lib/components/resolver.js
@@ -312,10 +312,13 @@ class Resolver {
      * read from left to right which does not contain a kind 'context' or 'service'.
      * That is, if in the above example 'D' is a context and 'E' is a service,
      * the resulting namespace is 'a.b.c'.
-     * @param {string[]} pathParts the distinct parts of the namespace, i.e. ['a','b','c','D','E']
+     * @param {string[] | string} pathParts the distinct parts of the namespace, i.e. ['a','b','c','D','E'] or a single path interspersed with periods
      * @returns {string} the namespace's name, i.e. 'a.b.c'.
      */
     resolveNamespace(pathParts) {
+        if (typeof pathParts === 'string') {
+            pathParts = pathParts.split('.')
+        }
         let result
         while (result === undefined) {
             const path = pathParts.join('.')

--- a/lib/file.js
+++ b/lib/file.js
@@ -122,6 +122,8 @@ class SourceFile extends File {
         this.typeNames = {}
         /** @type {[string, string, string][]} */
         this.inflections = []
+        /** @type {{ buffer: Buffer, names: string[]}} */
+        this.services = { buffer: new Buffer(), names: [] }
     }
 
     /**
@@ -327,6 +329,19 @@ class SourceFile extends File {
     }
 
     /**
+     * Adds a service to the file.
+     * We consider each service its own distinct namespace and therefore expect
+     * at most one service per file.
+     * @param {string} fq the fully qualified name of the service
+     */
+    addService(fq) {
+        if (this.services.names.length) {
+            throw new Error(`trying to add more than one service to file ${this.path.asDirectory()}. Existing service is ${this.services.names[0]}, trying to add ${fq}`)
+        }
+        this.services.names.push(fq)
+    }
+
+    /**
      * Writes all imports to a buffer, relative to the current file.
      * Creates a new buffer on each call, as concatenating import strings directly
      * upon discovering them would complicate filtering out duplicate entries.
@@ -362,6 +377,7 @@ class SourceFile extends File {
             this.classes.join(),
             this.events.buffer.join(),
             this.actions.buffer.join(),
+            this.services.buffer.join() // should be at the end
         ].filter(Boolean).join('\n')
     }
 
@@ -394,6 +410,8 @@ class SourceFile extends File {
             .concat(this.enums.fqs.map(({name, fq, property}) => property 
                 ? stringifyAnonymousEnum(name, fq, property)
                 : stringifyNamedEnum(name, fq)))
+            // FIXME: move stringification of service into own module
+            .concat(this.services.names.map(name => `module.exports.default = { name: '${name}' }`))  // there should be only one
             .join('\n') + '\n'
     }
 }

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -367,6 +367,15 @@ class Visitor {
         buffer.add('}')
     }
 
+    #printService(name, service) {
+        this.logger.debug(`Printing service ${name}:\n${JSON.stringify(service, null, 2)}`)
+        const ns = this.resolver.resolveNamespace(name)
+        const file = this.getNamespaceFile(ns)
+        // service.name is clean of namespace
+        file.services.buffer.add(`export default { name: '${service.name}' }`)
+        file.addService(service.name)
+    }
+
     /**
      * Visits a single entity from the CSN's definition field.
      * Will call #printEntity or #printAction based on the entity's kind.
@@ -392,6 +401,9 @@ class Visitor {
                 break
             case 'event':
                 this.#printEvent(name, entity)
+                break
+            case 'service':
+                this.#printService(name, entity)
                 break
             default:
                 this.logger.error(`Unhandled entity kind '${entity.kind}'.`)


### PR DESCRIPTION
Files that represent a service now have a default export that roughly mimics the structure of services within CSN. 
As such, they currently expose a property `name` that contains the clean name of the service.

```cds
service FooService { ... }
```

```ts
// index.ts
export default { name: 'FooService' }
```

```js
// index.js
module.exports.default = { name: 'FooService' }
```
