### PR TITLE
Default Enum Values to Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 ### Fixed
+- Now using names of enum values in generated _index.js_ files if no explicit value is present
 
 ## Version 0.11.1 - 2023-10-12
 
@@ -17,7 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 ### Fixed
-Fixed how service names are exported as default export
+- Fixed how service names are exported as default export
 
 ## Version 0.11.0 - 2023-10-10
 

--- a/lib/components/enum.js
+++ b/lib/components/enum.js
@@ -82,7 +82,7 @@ const propertyToAnonymousEnumName = (entity, property) => `${entity}_${property}
  */
 const isInlineEnumType = (element, csn) => element.enum && !(element.type in csn.definitions)
 
-const stringifyEnumImplementation = (name, enm) => `module.exports.${name} = Object.fromEntries(Object.entries(${enm}).map(([k,v]) => [k,v.val]))`
+const stringifyEnumImplementation = (name, enm) => `module.exports.${name} = Object.fromEntries(Object.entries(${enm}).map(([k,v]) => [k,v.val??k]))`
 
 /**
  * @param {string} name


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/99

Enums that did not provide an explicit value for enum fields would have `undefined` for their values in the generated _index.js_ files before.

```cds
// model.cds
type Foo : String enum {
    Bar;
    Baz = "baz";
}
```
⬇️ (more or less)
```js
// index.js
const Foo = {
  Bar: undefined,
  Baz: "baz"
}
```

To rectify this, the field's name is now used as fallback value:

```js
// index.js
const Foo = {
  Bar: "Bar",
  Baz: "baz"
}
```