### PR TITLE
Add `Readable` as Possible Type for `cds.LargeBinary`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## Version 0.12.0 - TBD
 
 ### Changed
+- Generate `cds.LargeBinary` as string, buffer, _or readable_ in the case of media content
 
 ### Added
 ### Fixed

--- a/lib/components/resolver.js
+++ b/lib/components/resolver.js
@@ -41,7 +41,7 @@ const Builtins = {
     String: 'string',
     Binary: 'string',
     LargeString: 'string',
-    LargeBinary: 'Buffer | string',
+    LargeBinary: 'Buffer | string | {value: Readable, $mediaContentType: string, $mediaContentDispositionFilename?: string, $mediaContentDispositionType?: string}',
     Integer: 'number',
     UInt8: 'number',
     Int16: 'number',

--- a/lib/components/resolver.js
+++ b/lib/components/resolver.js
@@ -41,7 +41,7 @@ const Builtins = {
     String: 'string',
     Binary: 'string',
     LargeString: 'string',
-    LargeBinary: 'Buffer | string | {value: Readable, $mediaContentType: string, $mediaContentDispositionFilename?: string, $mediaContentDispositionType?: string}',
+    LargeBinary: 'Buffer | string | {value: import("stream").Readable, $mediaContentType: string, $mediaContentDispositionFilename?: string, $mediaContentDispositionType?: string}',
     Integer: 'number',
     UInt8: 'number',
     Int16: 'number',


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/97