### PR TITLE
Wrap fs.read in JS wrapper initialisation

### DIFF
--- a/test/ast.js
+++ b/test/ast.js
@@ -7,7 +7,7 @@
  * That means, the resulting AST is highly specialised for TS elements that are emitted
  * by the type generator -- if the output of the generator changes, the AST has to be adjusted accordingly.
  */ 
- 
+const fs = require('fs/promises')
 const ts = require('typescript')
 const acorn = require('acorn')
 
@@ -356,6 +356,10 @@ class ASTWrapper {
 }
 
 class JSASTWrapper {
+    static async initialise(file) {
+        return new JSASTWrapper(await fs.readFile(file, 'utf-8'))
+    }
+
     constructor(code) {
         this.programm = acorn.parse(code, { ecmaVersion: 'latest'})
     }

--- a/test/unit/output.test.js
+++ b/test/unit/output.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const fs = require('fs').promises
+const fs = require('fs/promises')
 const path = require('path')
 const cds2ts = require('../../lib/compile')
 const { ASTWrapper, JSASTWrapper, check } = require('../ast')
@@ -25,8 +25,7 @@ describe('Compilation', () => {
         })
 
         test('index.js', async () => {
-            const code = await fs.readFile(path.join(paths[1], 'index.js'), 'utf-8')
-            const jsw = new JSASTWrapper(code)
+            const jsw = await JSASTWrapper.initialise(path.join(paths[1], 'index.js'))
             jsw.exportsAre([
                 ['Book', 'Books'],
                 ['Books', 'Books'],
@@ -166,8 +165,7 @@ describe('Compilation', () => {
         test('Generated Paths', () => expect(paths).toHaveLength(2)) // the one module [1] + baseDefinitions [0]
 
         test('index.js', async () => {
-            const code = await fs.readFile(path.join(paths[1], 'index.js'), 'utf-8')
-            const jsw = new JSASTWrapper(code)
+            const jsw = await JSASTWrapper.initialise(path.join(paths[1], 'index.js'))
             jsw.exportsAre([
                 ['Gizmo', 'Gizmos'],
                 ['Gizmos', 'Gizmos'],


### PR DESCRIPTION
For (more) streamlined testing API across JS/TS.