### PR TITLE
Do Not Emit Elements That Are Part of `excluding` Clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## Version 0.13.0 - TBD
 ### Changes
 - Enums are now generated ecplicitly in the respective _index.js_ files and don't have to extract their values from the model at runtime anymore
+- The `excluding` clause in projections now actually excludes the specified properties in the generated types
 
 ## Version 0.12.0 - 2023-11-23
 

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -156,7 +156,9 @@ class Visitor {
         buffer.indent()
 
         const enums = []
-        for (const [ename, element] of Object.entries(entity.elements ?? {})) {
+        const exclusions = new Set(entity.projection?.excluding ?? [])
+        const elements = Object.entries(entity.elements ?? {}).filter(([ename]) => !exclusions.has(ename))
+        for (const [ename, element] of elements) {
             this.visitElement(ename, element, file, buffer)
 
             // make foreign keys explicit

--- a/test/unit/excluding.test.js
+++ b/test/unit/excluding.test.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const fs = require('fs').promises
+const path = require('path')
+const cds2ts = require('../../lib/compile')
+const { ASTWrapper, check } = require('../ast')
+const { locations } = require('../util')
+const dir = locations.testOutput('excluding_test')
+
+describe('Excluding Clause', () => {
+    let paths
+
+    beforeEach(async () => await fs.unlink(dir).catch(() => {}))
+    beforeAll(async () => {
+        paths = await cds2ts
+            .compileFromFile(locations.unit.files('excluding/model.cds'), { outputDirectory: dir })
+    })
+
+    test('Element Present in Original', async () => 
+        expect(new ASTWrapper(path.join(paths[1], 'index.ts')).exists('_TestObjectAspect', 'dependencies')).toBeTruthy())
+
+    test('Element Gone in Projection', async () => 
+            expect(new ASTWrapper(path.join(paths[2], 'index.ts'))
+                .getAspect('_SlimTestObjectAspect')
+                .members
+                .find(({name}) => name === 'dependencies')
+            ).toBeFalsy())
+})

--- a/test/unit/excluding.test.js
+++ b/test/unit/excluding.test.js
@@ -3,7 +3,7 @@
 const fs = require('fs').promises
 const path = require('path')
 const cds2ts = require('../../lib/compile')
-const { ASTWrapper, check } = require('../ast')
+const { ASTWrapper } = require('../ast')
 const { locations } = require('../util')
 const dir = locations.testOutput('excluding_test')
 

--- a/test/unit/files/excluding/model.cds
+++ b/test/unit/files/excluding/model.cds
@@ -1,0 +1,14 @@
+namespace excluding_test;
+
+entity Foo {}
+
+entity TestObjects {
+    key ID: UUID;
+    name: String not null;
+    description: String;
+    dependencies: Association to many Foo;
+}
+
+service TestService {
+    entity SlimTestObjects as projection on TestObjects excluding { dependencies };
+}


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/117

```cds
entity Foo {
  a: Int;
  b: Int;
}

service S {
  entity Bar as projection on Foo excluding { a };
}
```

⬇️ (more or less)

```ts
// index.ts
class Foo {
  a: number
  b: number
}

// S/index.ts
class Bar {
  b: number
}
```