### PR TITLE
Retrieve keys from both flavours of CSN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.15.0 - TBD
+### Fixed
+- Foreign keys of projection entities are now propagated as well
 
 ## Version 0.14.0 - 2023-12-13
 ### Added

--- a/lib/csn.js
+++ b/lib/csn.js
@@ -240,4 +240,4 @@ const isView = entity => entity.query && !entity.projection
  */
 const isUnresolved = entity => entity._unresolved === true
 
-module.exports = { amendCSN, isView, isUnresolved }
+module.exports = { amendCSN, isView, isUnresolved, propagateForeignKeys }

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -2,7 +2,7 @@
 
 const util = require('./util')
 
-const { amendCSN, isView, isUnresolved } = require('./csn')
+const { amendCSN, isView, isUnresolved, propagateForeignKeys } = require('./csn')
 // eslint-disable-next-line no-unused-vars
 const { SourceFile, baseDefinitions, Buffer } = require('./file')
 const { FlatInlineDeclarationResolver, StructuredInlineDeclarationResolver } = require('./components/inline')
@@ -63,6 +63,7 @@ class Visitor {
      */
     constructor(csn, options = {}, logger = new Logger()) {
         amendCSN(csn.xtended)
+        propagateForeignKeys(csn.inferred)
         this.options = { ...defaults, ...options }
         this.logger = logger
         this.csn = csn
@@ -131,6 +132,24 @@ class Visitor {
     }
 
     /**
+     * Retrieves all the keys from an entity.
+     * That is: all keys that are present in both inferred, as well as xtended flavour.
+     * @returns {[string, object][]} array of key name and key element pairs
+     */
+    #keys(name) {
+        // FIXME: this is actually pretty bad, as not only have to propagate keys through
+        // both flavours of CSN (see constructor), but we are now also collecting them from
+        // both flavours and deduplicating them.
+        // xtended contains keys that have been inherited from parents
+        // inferred contains keys from queried entities (thing `entity Foo as select from Bar`, where Bar has keys)
+        // So we currently need them both.
+        return Object.entries({
+            ...this.csn.inferred.definitions[name]?.keys ?? {},
+            ...this.csn.xtended.definitions[name]?.keys ?? {}
+        })
+    }
+
+    /**
      * Transforms an entity or CDS aspect into a JS aspect (aka mixin).
      * That is, for an element A we get:
      * - the function A(B) to mix the aspect into another class B
@@ -168,7 +187,7 @@ class Visitor {
                 // lookup in cds.definitions can fail for inline structs.
                 // We don't really have to care for this case, as keys from such structs are _not_ propagated to
                 // the containing entity.
-                for (const [kname, kelement] of Object.entries(this.csn.xtended.definitions[element.target]?.keys ?? {})) {
+                for (const [kname, kelement] of this.#keys(element.target)) {
                     if (this.resolver.getMaxCardinality(element) === 1) {
                         kelement.isRefNotNull = !!element.notNull || !!element.key
                         this.visitElement(`${ename}_${kname}`, kelement, file, buffer)


### PR DESCRIPTION
Keys are now propagated through both flavours of CSN (inferred and xtended) and retrieved from them as well when printing out the classes.
We need to consider both flavours, as xtended contains inherited keys, and inferred contains keys from queries entities.