### PR TITLE
Resolve externally defined enums in action parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.16.0 - TBD
+### Fixed
+- Externally defined enums can now be used as parameter types in actions
 
 ## Version 0.15.0 - 2023-12-21
 ### Added

--- a/lib/components/enum.js
+++ b/lib/components/enum.js
@@ -59,7 +59,7 @@ const stringifyEnumType = kvs => [...uniqueValues(kvs)].join(' | ')
 const uniqueValues = kvs => new Set(kvs.map(([,v]) => v?.val ?? v))  // in case of wrapped vals we need to unwrap here for the type
 
 // in case of strings, wrap in quotes and fallback to key to make sure values are attached for every key
-const enumVal = (key, value, enumType) => enumType === 'cds.String' ? JSON.stringify(`${value ?? key}`) : value
+const  enumVal = (key, value, enumType) => enumType === 'cds.String' ? JSON.stringify(`${value ?? key}`) : value
 
 /**
  * Converts a CSN type describing an enum into a list of kv-pairs.

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -338,7 +338,9 @@ class Visitor {
     }
 
     #stringifyFunctionParamType(type, file) {
-        return type.enum
+        // if type.type is not 'cds.String', 'cds.Integer', ..., then we are actually looking
+        // at a named enum type. In that case also resolve that type name
+        return type.enum && type.type.startsWith('cds.')
             ? stringifyEnumType(csnToEnumPairs(type))
             : this.inlineDeclarationResolver.getPropertyDatatype(this.resolver.resolveAndRequire(type, file))
     }

--- a/test/ast.js
+++ b/test/ast.js
@@ -432,6 +432,7 @@ const checkFunction = (fnNode, {callCheck, parameterCheck, returnTypeCheck, modi
 }
 
 const checkKeyword = (node, expected) => node?.keyword === expected
+const checkNodeType = (node, expected) => node?.nodeType === expected
 
 const check = {
     isString: node => checkKeyword(node, 'string'),
@@ -445,6 +446,7 @@ const check = {
         && of.reduce((acc, predicate) => acc && node.subtypes.some(st => predicate(st)), true),
     isNullable: (node, of = []) => check.isUnionType(node, of.concat([check.isNull])),
     isLiteral: (node, literal = undefined) => checkKeyword(node, 'literaltype') && (literal === undefined || node.literal === literal),
+    isTypeReference: (node, full) => checkNodeType(node, 'typeReference') && node.full === full
 }
 
 

--- a/test/unit/enum.test.js
+++ b/test/unit/enum.test.js
@@ -28,7 +28,15 @@ describe('Enum Action Parameters', () => {
                     t => check.isLiteral(t, 'b'),
                 ])
         })
-    }) 
+    })
+
+    test('External Enum Definition Parameter', () => {
+        const actions = astw.getAspectProperty('_FoobarAspect', 'actions')
+        checkFunction(actions.type.members.find(fn => fn.name === 'g'), {
+            parameterCheck: ({members: [fst]}) => fst.name === 'p'
+                && check.isNullable(fst.type, [t => check.isTypeReference(t, 'EnumFoo')])
+        })       
+    })
 })
 
 

--- a/test/unit/files/enums/actions.cds
+++ b/test/unit/files/enums/actions.cds
@@ -1,6 +1,12 @@
+type EnumFoo: String enum {
+  foo = 'FOO';
+  bar
+}
+
 entity Foobar {} actions {
   action f(p: String enum {
     A;
     B = 'b'
-  })
+  });
+  action g(p: EnumFoo);
 };


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/137

Using an externally (read: not inline) defined enum as type for an action parameter would incorrectly assume non-string values. This is now fixed by instead resolving the enum's name.