### PR TITLE
Allow typeof syntax on externally defined enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.17.0 - TBD
+### Fixed
+- Fixed a bug where refering to an externally defined enum via the `typeof` syntax would crash the type generation
 
 ## Version 0.16.0 - 2024-02-01
 ### Changed

--- a/lib/components/reference.js
+++ b/lib/components/reference.js
@@ -1,0 +1,23 @@
+/**
+ * Check if an element references another type.
+ * This happens for foreign key relationships
+ * and for the typeof syntax.
+ * 
+ * ```cds
+ * entity E {
+ *   x: Integer
+ * }
+ * 
+ * entity F {
+ *   y: E.x  // <- ref
+ * }
+ * ```
+ * 
+ * @param {{type: any}} element
+ * @returns boolean
+ */
+const isReferenceType = (element) => element.type && Object.hasOwn(element.type, 'ref')
+
+module.exports = {
+    isReferenceType
+}

--- a/lib/components/resolver.js
+++ b/lib/components/resolver.js
@@ -6,6 +6,7 @@ const { Buffer, SourceFile, Path, Library, baseDefinitions } = require('../file'
 const { deepRequire, createToManyAssociation, createToOneAssociation, createArrayOf, createCompositionOfMany, createCompositionOfOne } = require('./wrappers')
 const { StructuredInlineDeclarationResolver } = require('./inline')
 const { isInlineEnumType, propertyToInlineEnumName } = require('./enum')
+const { isReferenceType } = require('./reference')
 
 /** @typedef {{ cardinality?: { max?: '*' | number } }} EntityCSN */
 /** @typedef {{ definitions?: Object<string, EntityCSN> }} CSN */
@@ -370,7 +371,7 @@ class Resolver {
             result.type = '{}'
             result.isInlineDeclaration = true
         } else {
-            if (isInlineEnumType(element, this.csn)) {
+            if (!isReferenceType(element) && isInlineEnumType(element, this.csn)) {
                 // element.parent is only set if the enum is attached to an entity's property.
                 // If it is missing then we are dealing with an inline parameter type of an action.
                 // Edge case: element.parent is set, but no .name property is attached. This happens

--- a/lib/file.js
+++ b/lib/file.js
@@ -583,7 +583,7 @@ export type EntitySet<T> = T[] & {
 
 export type DeepRequired<T> = { 
     [K in keyof T]: DeepRequired<T[K]>
-} & Required<T>;
+} & Exclude<Required<T>, null>;
 `)
 
 /**

--- a/test/unit/files/typeof/external.cds
+++ b/test/unit/files/typeof/external.cds
@@ -1,0 +1,10 @@
+namespace external;
+
+type Status: Integer enum {
+    OK;
+    ERROR
+}
+
+entity Issues {
+    status: Status;
+}

--- a/test/unit/files/typeof/external.cds
+++ b/test/unit/files/typeof/external.cds
@@ -1,8 +1,8 @@
 namespace external;
 
 type Status: Integer enum {
-    OK;
-    ERROR
+    OK = 0;
+    ERROR = 1;
 }
 
 entity Issues {

--- a/test/unit/files/typeof/model.cds
+++ b/test/unit/files/typeof/model.cds
@@ -1,3 +1,4 @@
+using { external } from './external';
 namespace typeof;
 
 //type T: { s: String };
@@ -14,3 +15,7 @@ entity Bar {
     ref_b: Foo:b;
     ref_c: Foo:c.x;
 };
+
+entity Baz {
+    ref: external.Issues:status
+}

--- a/test/unit/typeof.test.js
+++ b/test/unit/typeof.test.js
@@ -10,49 +10,41 @@ const dir = locations.testOutput('typeof')
 
 // compilation produces semantically complete Typescript
 describe('Typeof Syntax', () => {
-    beforeEach(async () => await fs.unlink(dir).catch(() => {})) //console.log('INFO', `Unable to unlink '${dir}' (${err}). This may not be an issue.`)
+    let astw
 
-    test('External', async () => {
+    beforeEach(async () => await fs.unlink(dir).catch(() => {}))
+    beforeAll(async () => {
         const paths = await cds2ts
             .compileFromFile(locations.unit.files('typeof/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
-            // eslint-disable-next-line no-console
-            .catch((err) => console.error(err))
-        const astw = new ASTWrapper(path.join(paths[1], 'index.ts'))    
+        astw = new ASTWrapper(path.join(paths[1], 'index.ts'))
+    })
+
+    test('External', async () => {
         expect(astw.exists('_BazAspect', 'ref', m => check.isNullable(m.type, [st => check.isIndexedAccessType(st) && st.indexType.literal === 'status']))).toBeTruthy()
     })
 
     test('Structured', async () => {
-        const paths = await cds2ts
-            .compileFromFile(locations.unit.files('typeof/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
-            // eslint-disable-next-line no-console
-            .catch((err) => console.error(err))
-        const ast = new ASTWrapper(path.join(paths[1], 'index.ts'))
-        expect(ast.exists('_BarAspect', 'ref_a', 
+        expect(astw.exists('_BarAspect', 'ref_a', 
             m => check.isNullable(m.type, [st => check.isIndexedAccessType(st) && st.indexType.literal === 'a'])
         )).toBeTruthy()
-        expect(ast.exists('_BarAspect', 'ref_b', 
+        expect(astw.exists('_BarAspect', 'ref_b', 
             m => check.isNullable(m.type, [st => check.isIndexedAccessType(st) && st.indexType.literal === 'b'])
         )).toBeTruthy()
         // meh, this is not exactly correct, as I apparently did not retrieve the chained type accesses properly,
         // but it's kinda good enough
-        expect(ast.exists('_BarAspect', 'ref_c', 
+        expect(astw.exists('_BarAspect', 'ref_c', 
             m => check.isNullable(m.type, [st => check.isIndexedAccessType(st) && st.indexType.literal === 'x'])
         )).toBeTruthy()
     })
 
     test('Flat', async () => {
-        const paths = await cds2ts
-            .compileFromFile(locations.unit.files('typeof/model.cds'), { outputDirectory: dir })
-            // eslint-disable-next-line no-console
-            .catch((err) => console.error(err))
-        const ast = new ASTWrapper(path.join(paths[1], 'index.ts'))
-        expect(ast.exists('_BarAspect', 'ref_a', 
+        expect(astw.exists('_BarAspect', 'ref_a', 
         m => check.isNullable(m.type, [st => check.isIndexedAccessType(st) && st.indexType.literal === 'a'])
         )).toBeTruthy()
-        expect(ast.exists('_BarAspect', 'ref_b', 
+        expect(astw.exists('_BarAspect', 'ref_b', 
         m => check.isNullable(m.type, [st => check.isIndexedAccessType(st) && st.indexType.literal === 'b'])
         )).toBeTruthy()
-        expect(ast.exists('_BarAspect', 'ref_c', 
+        expect(astw.exists('_BarAspect', 'ref_c', 
         m => check.isNullable(m.type, [st => check.isIndexedAccessType(st) && st.indexType.literal === 'c_x'])
         )).toBeTruthy()
               /*

--- a/test/unit/typeof.test.js
+++ b/test/unit/typeof.test.js
@@ -50,17 +50,5 @@ describe('Typeof Syntax', () => {
         expect(astw.exists('_BarAspect', 'ref_c', 
         m => check.isNullable(m.type, [st => check.isIndexedAccessType(st) && st.indexType.literal === 'c_x'])
         )).toBeTruthy()
-              /*
-                && m.type.members.length === 2
-                && m.type.members[0].name === 'a'
-                    && m.type.members[0].type.members.length === 2
-                    && m.type.members[0].type.members[0].name === 'b'
-                    && m.type.members[0].type.members[0].type.keyword === 'number'
-                    && m.type.members[0].type.members[1].name === 'c'
-                    && m.type.members[0].type.members[1].type.nodeType === 'typeReference'
-                    && m.type.members[0].type.members[1].type.args[0].full === 'Foo'
-                && m.type.members[1].name === 'y'
-                    && m.type.members[1].type.keyword === 'string'
-                */
     })
 })

--- a/test/unit/typeof.test.js
+++ b/test/unit/typeof.test.js
@@ -10,20 +10,20 @@ const dir = locations.testOutput('typeof')
 
 // compilation produces semantically complete Typescript
 describe('Typeof Syntax', () => {
-    let astw
 
     beforeEach(async () => await fs.unlink(dir).catch(() => {}))
-    beforeAll(async () => {
-        const paths = await cds2ts
-            .compileFromFile(locations.unit.files('typeof/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
-        astw = new ASTWrapper(path.join(paths[1], 'index.ts'))
-    })
 
     test('External', async () => {
+        const paths = await cds2ts
+        .compileFromFile(locations.unit.files('typeof/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
+        const astw = new ASTWrapper(path.join(paths[1], 'index.ts'))
         expect(astw.exists('_BazAspect', 'ref', m => check.isNullable(m.type, [st => check.isIndexedAccessType(st) && st.indexType.literal === 'status']))).toBeTruthy()
     })
 
     test('Structured', async () => {
+        const paths = await cds2ts
+        .compileFromFile(locations.unit.files('typeof/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
+        const astw = new ASTWrapper(path.join(paths[1], 'index.ts'))
         expect(astw.exists('_BarAspect', 'ref_a', 
             m => check.isNullable(m.type, [st => check.isIndexedAccessType(st) && st.indexType.literal === 'a'])
         )).toBeTruthy()
@@ -38,6 +38,9 @@ describe('Typeof Syntax', () => {
     })
 
     test('Flat', async () => {
+        const paths = await cds2ts
+        .compileFromFile(locations.unit.files('typeof/model.cds'), { outputDirectory: dir, inlineDeclarations: 'flat' })
+        const astw = new ASTWrapper(path.join(paths[1], 'index.ts'))
         expect(astw.exists('_BarAspect', 'ref_a', 
         m => check.isNullable(m.type, [st => check.isIndexedAccessType(st) && st.indexType.literal === 'a'])
         )).toBeTruthy()

--- a/test/unit/typeof.test.js
+++ b/test/unit/typeof.test.js
@@ -12,6 +12,15 @@ const dir = locations.testOutput('typeof')
 describe('Typeof Syntax', () => {
     beforeEach(async () => await fs.unlink(dir).catch(() => {})) //console.log('INFO', `Unable to unlink '${dir}' (${err}). This may not be an issue.`)
 
+    test('External', async () => {
+        const paths = await cds2ts
+            .compileFromFile(locations.unit.files('typeof/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })
+            // eslint-disable-next-line no-console
+            .catch((err) => console.error(err))
+        const astw = new ASTWrapper(path.join(paths[1], 'index.ts'))    
+        expect(astw.exists('_BazAspect', 'ref', m => check.isNullable(m.type, [st => check.isIndexedAccessType(st) && st.indexType.literal === 'status']))).toBeTruthy()
+    })
+
     test('Structured', async () => {
         const paths = await cds2ts
             .compileFromFile(locations.unit.files('typeof/model.cds'), { outputDirectory: dir, inlineDeclarations: 'structured' })


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/93