### PR TITLE
Don't print out array type for cds types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.19.0 - TBD
 
+
+## Version 0.18.1 - 2024-03-13
+### Fix
+- Remove faulty plural for CDS `type` definitions from the generated _index.js_ files
+
 ## Version 0.18.0 - 2024-03-12
 ### Added
 - Improved support for projections, including projections on inline definitions, and on views, as well as support for explicit exclusion and selection of properties

--- a/lib/file.js
+++ b/lib/file.js
@@ -403,7 +403,7 @@ class SourceFile extends File {
                     //     or when plural4 produced weird inflection.
                     .flatMap(([singular, plural, original]) => Array.from(new Set([
                         `module.exports.${singular} = csn.${original}`,
-                        ///Array<.*>/.test(plural) ? `module.exports.${plural} = csn.${original}` : undefined,
+                        /Array<.*>/.test(plural) ? undefined : `module.exports.${plural} = csn.${original}`,
                         // FIXME: we currently produce at most 3 entries.
                         // This could be an issue when the user re-used the original name in a @singular/@plural annotation.
                         // Seems unlikely, but we have to eliminate the original entry if users start running into this.

--- a/lib/file.js
+++ b/lib/file.js
@@ -403,12 +403,12 @@ class SourceFile extends File {
                     //     or when plural4 produced weird inflection.
                     .flatMap(([singular, plural, original]) => Array.from(new Set([
                         `module.exports.${singular} = csn.${original}`,
-                        `module.exports.${plural} = csn.${original}`,
+                        ///Array<.*>/.test(plural) ? `module.exports.${plural} = csn.${original}` : undefined,
                         // FIXME: we currently produce at most 3 entries.
                         // This could be an issue when the user re-used the original name in a @singular/@plural annotation.
                         // Seems unlikely, but we have to eliminate the original entry if users start running into this.
                         `module.exports.${original} = csn.${original}`
-                    ])))
+                    ].filter(Boolean))))  // FIXME: this is a hack to support CDS types that will produce "Array<MyType>" as plural, which we do not want as export in the index.js files
             ) // singular -> plural aliases
             .concat(['// events'])
             .concat(this.events.fqs.map(({fq, name}) => `module.exports.${name} = '${fq}'`))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/cds-typer",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Generates .ts files for a CDS model to receive code completion in VS Code",
   "main": "index.js",
   "repository": "github:cap-js/cds-typer",


### PR DESCRIPTION
As CDS `type` definitions no longer receive an inflection as of 0.18.0, they instead use `Array<MyType` for their plural.
This particular kind of plural should _not_ be printed to the corresponding _index.js_ files, as that would lead to:

```js
module.exports.Array<MyType> = ...
```

which is a syntax error.