### PR TITLE
Introduce stricter check for builtin types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.19.0 - TBD
 
-## Version 0.18.2 - TBD
+## Version 0.18.2 - 2024-03-21
 ### Fix
 - Resolving `@sap/cds` will now look in the CWD first to ensure a consistent use the same CDS version across different setups
 - Types of function parameters starting with `cds.` are not automatically considered builtin anymore and receive a more thorough check against an allow-list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## Version 0.18.2 - TBD
 ### Fix
 - Resolving `@sap/cds` will now look in the CWD first to ensure a consistent use the same CDS version across different setups
+- Types of function parameters starting with `cds.` are not automatically considered builtin anymore and receive a more thorough check against an allow-list
 
 
 ## Version 0.18.1 - 2024-03-13

--- a/lib/components/resolver.js
+++ b/lib/components/resolver.js
@@ -66,6 +66,19 @@ const Builtins = {
     Association: 'Array'
 }
 
+/**
+ * @param {string | string[]} type name or parts of the type name split on dots
+ * @returns {string | undefined | false} if t refers to a builtin, the name of the corresponding TS type is returned.
+ *   If t _looks like_ a builtin (`cds.X`), undefined is returned.
+ *   If t is obviously not a builtin, false is returned.
+ */
+function resolveBuiltin (t) {
+    const path = Array.isArray(t) ? t : t.split('.')
+    return path.length === 2 && path[0] === 'cds'
+        ? Builtins[path[1]]
+        : false
+}
+
 class Resolver {
 
     #caches = {
@@ -550,13 +563,13 @@ class Resolver {
     #resolveTypeName(t, into) {
         const result = into || {}
         const path = t.split('.')
-        if (path.length === 2 && path[0] === 'cds') {
-            // builtin type
-            const resolvedBuiltin = Builtins[path[1]]
-            if (!resolvedBuiltin) {
-                throw new Error(`Can not resolve apparent builtin type '${t}' to any CDS type.`)
-            }
-            result.type = resolvedBuiltin
+        const builtin = resolveBuiltin(path)
+        if (builtin === undefined) {
+            // looks like builtin, but isn't
+            throw new Error(`Can not resolve apparent builtin type '${t}' to any CDS type.`)
+        } else if (builtin !== false) {
+            // builtin
+            result.type = builtin
             result.isBuiltin = true
         } else if (t in this.csn.definitions) {
             // user-defined type
@@ -607,5 +620,6 @@ class Resolver {
 }
 
 module.exports = {
-    Resolver
+    Resolver,
+    resolveBuiltin
 }

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -6,7 +6,7 @@ const { amendCSN, isView, isUnresolved, propagateForeignKeys, isDraftEnabled, is
 // eslint-disable-next-line no-unused-vars
 const { SourceFile, FileRepository, baseDefinitions, Buffer } = require('./file')
 const { FlatInlineDeclarationResolver, StructuredInlineDeclarationResolver } = require('./components/inline')
-const { Resolver } = require('./components/resolver')
+const { Resolver, resolveBuiltin } = require('./components/resolver')
 const { Logger } = require('./logging')
 const { docify } = require('./components/wrappers')
 const { csnToEnumPairs, propertyToInlineEnumName, isInlineEnumType, stringifyEnumType } = require('./components/enum')
@@ -338,7 +338,7 @@ class Visitor {
     #stringifyFunctionParamType(type, file) {
         // if type.type is not 'cds.String', 'cds.Integer', ..., then we are actually looking
         // at a named enum type. In that case also resolve that type name
-        return type.enum && type.type.startsWith('cds.')
+        return type.enum && resolveBuiltin(type.type)
             ? stringifyEnumType(csnToEnumPairs(type))
             : this.inlineDeclarationResolver.getPropertyDatatype(this.resolver.resolveAndRequire(type, file))
     }


### PR DESCRIPTION
Types would sometimes be considered builtin even if they weren't. Specifically, this happened when a type started with `cds.` in parameter types. We now stricten this check to use an allow-list instead of relying on the prefix.