### PR TITLE
Fix runtime error when using typeof in enum declaration

### DIFF
--- a/lib/components/resolver.js
+++ b/lib/components/resolver.js
@@ -77,6 +77,7 @@ const Builtins = {
  *   If t is obviously not a builtin, false is returned.
  */
 function resolveBuiltin (t) {
+    if (!Array.isArray(t) && typeof t !== 'string') return false
     const path = Array.isArray(t) ? t : t.split('.')
     return path.length === 2 && path[0] === 'cds'
         ? Builtins[path[1]]

--- a/test/unit/enum.test.js
+++ b/test/unit/enum.test.js
@@ -176,3 +176,29 @@ describe('Imported Enums', () => {
         expect(enumExampleNodes.find(n => n.nodeType === 'typeAliasDeclaration')).toBeTruthy()
     })
 })
+
+describe('Enums of typeof', () => {
+    /* FIXME: these should actually be inline-defined enums of the referenced type with explicit values
+     * ```cds
+     * entity X { y: String };
+     * type T: X:y { a }  // should produce a string enum with value `a`
+     * ```
+     * but as a first step, they'll be just a value of the referenced type
+     */
+    let astw
+
+    beforeAll(async () => {
+        const paths = (await prepareUnitTest('enums/enumtyperef.cds', locations.testOutput('enums_test'))).paths
+        astw = new ASTWrapper(path.join(paths[2], 'index.ts'))
+    })
+    
+    test('it works', () => {
+        // FIXME: returntypecheck currently broken: cds-typer can currently only deal with refs
+        // that contain exactly one element. Type refs are of guise { ref: ['n.A', 'p'] }
+        // so right now the property type reference is incorrectly resolved to n.A
+        checkFunction(astw.tree.find(node => node.name === 'EnumInParamAndReturn'), {
+            //returnTypeCheck: type =>  check.isNullable(type, [check.isIndexedAccessType]),
+            parameterCheck: ({members: [fst]}) => check.isNullable(fst.type, [check.isIndexedAccessType])
+        })
+    })
+})

--- a/test/unit/files/enums/enumtyperef.cds
+++ b/test/unit/files/enums/enumtyperef.cds
@@ -1,0 +1,10 @@
+// https://github.com/cap-js/cds-typer/issues/171
+namespace enumtyperef;
+
+entity EnumTypeOf {
+    str: String;
+}
+  
+service EnumsInActions {
+    action EnumInParamAndReturn(Param: EnumTypeOf:str enum { a; }) returns EnumTypeOf:str enum { b; };
+}


### PR DESCRIPTION
Partially addresses https://github.com/cap-js/cds-typer/issues/171
For the example given by the reporter cds-typer now infers `string` as the type instead of crashing the type generation process.
But we still need to precisely refer to the type in question and also allow it in general `type` definitions and return types. Therefore not closing the issue yet.