### PR TITLE
Declare event classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.21.0 - TBD
+### Changed
+- Types representing CDS events are now only `declare`d to avoid having to make their properties optional
 
 ## Version 0.20.2 - 2024-04-29
 ### Fixed
@@ -17,7 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## Version 0.20.0 - 2024-04-23
 ### Added
 - Types for actions and functions now expose a `.kind` property which holds the string `'function'` or `'action'` respectively
-- Added the CdsDate, CdsDateTime, CdsTime, CdsTimestamp types, which are each represented as a `string`.
+- Added the `CdsDate`, `CdsDateTime`, `CdsTime`, `CdsTimestamp` types, which are each represented as a `string`.
 - Plural types can now also contain an optional numeric `$count` property
 
 ### Changed

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -412,7 +412,8 @@ class Visitor {
         file.addEvent(clean, name)
         const buffer = file.events.buffer
         buffer.add('// event')
-        buffer.addIndentedBlock(`export class ${clean} {`, function() {
+        // only declare classes, as their properties are not optional, so we don't have to do awkward initialisation thereof.
+        buffer.addIndentedBlock(`export declare class ${clean} {`, function() {
             const propOpt = this.options.propertiesOptional
             this.options.propertiesOptional = false
             for (const [ename, element] of Object.entries(event.elements ?? {})) {


### PR DESCRIPTION
Only `declare` classes representing events, as their properties are not optional, so we'd have to initialise them awkwardly.