### PR TITLE
Use CLI parameters over `cds.env`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 - Types representing CDS events are now only `declare`d to avoid having to make their properties optional
 - Singular forms in generated _index.js_ files now contain a `.is_singular` property as marker for distinguished handling of singular and plural in the runtime
+- Parameters passed to the CLI now take precedence over configuration contained in the `typer` section of `cds.env`
 
 ## Version 0.20.2 - 2024-04-29
 ### Fixed

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -45,7 +45,7 @@ const writeJsConfig = (path, logger) => {
  */
 const compileFromCSN = async (csn, parameters) => {
     const envSettings = cds.env?.typer ?? {}
-    parameters = { ...parameters, ...envSettings }
+    parameters = { ...envSettings, ...parameters }
     const logger = new Logger()
     logger.addFrom(parameters.logLevel)
     if (parameters.jsConfigPath) {


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/238

(was actually already done, but parameters passed to the CLI now take precedence over `cds.env`)