### PR TITLE
Add missing file entry in package.json for build plugin

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -67,7 +67,7 @@ cds.build?.register?.('typescript', class extends cds.build.Plugin {
             const directory = alias.match(/(?:\.\/)?(.*)\/\*\/index\.ts/)[1]
             return normalize(directory)  // could contain forward slashes in tsconfig.json
         } catch {
-            DEBUG?.('tsconfig.json not found, not parsable, or unconclusive. Using default model directory name')
+            DEBUG?.('tsconfig.json not found, not parsable, or inconclusive. Using default model directory name')
         }
         return '@cds-models'
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/cds-typer",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Generates .ts files for a CDS model to receive code completion in VS Code",
   "main": "index.js",
   "repository": "github:cap-js/cds-typer",
@@ -31,7 +31,8 @@
     "CHANGELOG.md",
     "index.js",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "cds-plugin.js"
   ],
   "types": "index.d.ts",
   "bin": {


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/248