### PR TITLE
Do not add is_singular to singulars that retain the original name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.23.0 - TBD
+### Fixed
+- Plurals no longer have `is_singular` attached in the resulting .js files
 
 ## Version 0.22.0 - 2024-06-20
 ### Fixed

--- a/lib/file.js
+++ b/lib/file.js
@@ -398,7 +398,11 @@ class SourceFile extends File {
                     // This could be an issue when the user re-used the original name in a @singular/@plural annotation.
                     // Seems unlikely, but we have to eliminate the original entry if users start running into this.
                     if (singular !== original) {
-                        exports.push(`module.exports.${original} = { is_singular: true, __proto__: csn.${original} }`)
+                        // do not do the is_singular spiel if the original name is used for the plural
+                        const rhs = plural === original 
+                            ? `csn.${original}`
+                            : `{ is_singular: true, __proto__: csn.${original} }`
+                        exports.push(`module.exports.${original} = ${rhs}`)
                     }
                     return exports
                 })


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/260