### PR TITLE
Change TS detection mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 - Suppressed an error that would incorrectly point out naming clashes when an entity was named in singular inflection in the model
 
+### Changed
+- The TypeScript task for `cds build` no longer looks for tsconfig.json to determine if the project has TS nature and instead checks the dependencies in the project's package.json for an occurrence of `typescript`
 
 ## Version 0.23.0 - 2024-07-04
 ### Fixed

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -16,7 +16,7 @@ const BUILD_CONFIG = 'tsconfig.cdsbuild.json'
 const isTypeScriptProject = () => {
     if (!fs.existsSync('package.json')) return false
     const pkg = require(path.resolve('package.json'))
-    return pkg.devDependencies?.typescript || pkg.dependencies?.typescript
+    return Boolean(pkg.devDependencies?.typescript || pkg.dependencies?.typescript)
 }
 
 /**

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -10,9 +10,14 @@ const DEBUG = cds.debug('cli|build')
 const BUILD_CONFIG = 'tsconfig.cdsbuild.json'
 
 /**
- * Check if a tsconfig file exists.
+ * Check if the project is a TypeScript project by looking for a dependency on TypeScript.
+ * @returns {boolean}
  */
-const tsConfigExists = () => fs.existsSync('tsconfig.json')
+const isTypeScriptProject = () => {
+    if (!fs.existsSync('package.json')) return false
+    const pkg = require(path.resolve('package.json'))
+    return pkg.devDependencies?.typescript || pkg.dependencies?.typescript
+}
 
 /**
  * Check if separate tsconfig file that is used for building the project.
@@ -56,7 +61,7 @@ if (!cds?.version || cds.version < '8.0.0') {
 // requires @sap/cds-dk version >= 7.5.0
 cds.build?.register?.('typescript', class extends cds.build.Plugin {
     static taskDefaults = { src: '.' }
-    static hasTask() { return tsConfigExists() }
+    static hasTask() { return isTypeScriptProject() }
 
     // lower priority than the nodejs task
     get priority() { return -1 }


### PR DESCRIPTION
Instead of looking for a tsconfig.json, which users may be using to configure their LSP in a JS project, we now check if the project's package.json contains a dependency to `typescript`.