### PR TITLE
feat: use `Proxy`s for entity exports in index.js files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.26.0 - TBD
 ### Added
+- Added a CLI option `--useEntitiesProxy`. When set to `true`, all entities are wrapped into `Proxy` objects during runtime, allowing top level imports of entity types.
 - Added a static `.kind` property for entities and types, which contains `'entity'` or `'type'` respectively
 - Apps need to provide `@sap/cds` version `8.2` or higher.
 - Apps need to provide `@cap-js/cds-types` version `0.6.4` or higher.
@@ -14,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Actions for ABAP RFC modules cannot be called with positional parameters, but only with named ones. They have 'parameter categories' (import/export/changing/tables) that cannot be called in a flat order.
 - Services now have their own export (named like the service itself). The current default export is not usable in some scenarios from CommonJS modules.
 - Enums and operation parameters can have doc comments
+
 
 ## Version 0.25.0 - 2024-08-13
 ### Added

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -35,6 +35,11 @@ const flags = {
         desc: `Path to where the jsconfig.json should be written.${EOL}If specified, ${toolName} will create a jsconfig.json file and${EOL}set it up to restrict property usage in types entities to${EOL}existing properties only.`,
         type: 'string'
     },
+    useEntitiesProxy: {
+        desc: `If set to true the 'cds.entities' exports in the generated 'index.js'${EOL}files will be wrapped in 'Proxy' objects\nso static import/require calls can be used everywhere.${EOL}${EOL}WARNING: entity properties can still only be accessed after${EOL}'cds.entities' has been loaded`,
+        allowed: ['true', 'false'],
+        default: 'false'
+    },
     version: {
         desc: 'Prints the version of this tool.'
     },
@@ -117,6 +122,7 @@ const main = async (/** @type {any} */ args) => {
         // temporary fix until rootDir is faded out
         outputDirectory: [args.named.outputDirectory, args.named.rootDir].find(d => d !== './') ?? './',
         logLevel: args.named.logLevel,
+        useEntitiesProxy: args.named.useEntitiesProxy === 'true',
         jsConfigPath: args.named.jsConfigPath,
         inlineDeclarations: args.named.inlineDeclarations,
         propertiesOptional: args.named.propertiesOptional === 'true',

--- a/lib/components/javascript.js
+++ b/lib/components/javascript.js
@@ -3,18 +3,18 @@
 const proxyAccessFunction = function (namespace, name, opts = {}) {
     const { target, customProps } = { target: {}, customProps: [], ...opts }
     const fq = namespace !== '' ? `${namespace}.${name}` : name
-    let _entity
+    let entity
     return new Proxy(target, {
         get: function (target, prop) {
             // we already know the name so we skip the cds.entities proxy access
             if (prop === 'name') return fq
             // custom properties access on 'target' as well as cached _entity property access goes here
-            if (Object.prototype.hasOwnProperty.call(target, prop)) return target[prop]
+            if (Object.hasOwn(target, prop)) return target[prop]
             // inline enums have to be caught here for first time access, as they do not exist on the entity
-            if (customProps.length && customProps.includes(prop)) return target[prop]
+            if (customProps.includes(prop)) return target[prop]
             // last but not least we pass the property access to cds.entities
             if (cds.entities) {
-                const entity = _entity ? _entity : (_entity = cds.entities(namespace)[name])
+                entity ??= cds.entities(namespace)[name]
                 if (!entity) throw new Error(`'${fq}' could not be found in cds.entities('${namespace}')`)
                 if (entity[prop]) target[prop] = entity[prop]
                 return target[prop]

--- a/lib/components/javascript.js
+++ b/lib/components/javascript.js
@@ -19,7 +19,7 @@ const proxyAccessFunction = function (fqParts, opts = {}) {
             // inline enums have to be caught here for first time access, as they do not exist on the entity
             if (customProps.includes(prop)) return target[prop]
             // last but not least we pass the property access to cds.entities
-            throw new Error(`Property ${prop} does not exist on entity '${fq}' or cds.entities is not yet defined`)
+            throw new Error(`Property ${prop} does not exist on entity '${fq}' or cds.entities is not yet defined. Ensure the CDS runtime is fully booted before accessing properties.`)
         }
     })
 }.toString()

--- a/lib/components/javascript.js
+++ b/lib/components/javascript.js
@@ -1,13 +1,14 @@
 /* eslint-disable no-undef */
 // this function will be stringified as part of the generated types and is not supposed to be used internally
-const proxyAccessFunction = function (namespace, name, opts = {}) {
+// @ts-nocheck
+const proxyAccessFunction = function (fqParts, opts = {}) {
     const { target, customProps } = { target: {}, customProps: [], ...opts }
-    const fq = namespace !== '' ? `${namespace}.${name}` : name
-    let entity
+    const fq = fqParts.join('.')
     return new Proxy(target, {
         get: function (target, prop) {
             if (cds.entities) {
                 target.__proto__ = cds.entities[fq]
+                // overwrite/simplify getter after cds.entities is accessible
                 this.get = (target, prop) => target[prop]
                 return target[prop]
             }

--- a/lib/components/javascript.js
+++ b/lib/components/javascript.js
@@ -20,10 +20,6 @@ const proxyAccessFunction = function (namespace, name, opts = {}) {
                 return target[prop]
             }
             throw new Error(`Property ${prop} does not exist on entity '${fq}' or cds.entities is not yet defined`)
-        },
-        set: function (target, prop, newVal) {
-            target[prop] = newVal
-            return true
         }
     })
 }.toString()

--- a/lib/components/javascript.js
+++ b/lib/components/javascript.js
@@ -14,7 +14,7 @@ const proxyAccessFunction = function (namespace, name, opts = {}) {
             if (customProps.includes(prop)) return target[prop]
             // last but not least we pass the property access to cds.entities
             if (cds.entities) {
-                entity ??= cds.entities(namespace)[name]
+                entity ??= cds.entities[fq]
                 if (!entity) throw new Error(`'${fq}' could not be found in cds.entities('${namespace}')`)
                 if (entity[prop]) target[prop] = entity[prop]
                 return target[prop]

--- a/lib/components/javascript.js
+++ b/lib/components/javascript.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-undef */
+// this function will be stringified as part of the generated types and is not supposed to be used internally
+const proxyAccessFunction = function (namespace, name, opts = {}) {
+    const { target, customProps } = { target: {}, customProps: [], ...opts }
+    const fq = namespace !== '' ? `${namespace}.${name}` : name
+    let _entity
+    return new Proxy(target, {
+        get: function (target, prop) {
+            // we already know the name so we skip the cds.entities proxy access
+            if (prop === 'name') return fq
+            // custom properties access on 'target' as well as cached _entity property access goes here
+            if (Object.prototype.hasOwnProperty.call(target, prop)) return target[prop]
+            // inline enums have to be caught here for first time access, as they do not exist on the entity
+            if (customProps.length && customProps.includes(prop)) return target[prop]
+            // last but not least we pass the property access to cds.entities
+            if (cds.entities) {
+                const entity = _entity ? _entity : (_entity = cds.entities(namespace)[name])
+                if (!entity) throw new Error(`'${fq}' could not be found in cds.entities('${namespace}')`)
+                if (entity[prop]) target[prop] = entity[prop]
+                return target[prop]
+            }
+            throw new Error(`Property ${prop} does not exist on entity '${fq}' or cds.entities is not yet defined`)
+        },
+        set: function (target, prop, newVal) {
+            target[prop] = newVal
+            return true
+        }
+    })
+}.toString()
+/* eslint-enable no-undef */
+
+module.exports = { proxyAccessFunction }

--- a/lib/components/javascript.js
+++ b/lib/components/javascript.js
@@ -6,6 +6,11 @@ const proxyAccessFunction = function (namespace, name, opts = {}) {
     let entity
     return new Proxy(target, {
         get: function (target, prop) {
+            if (cds.entities) {
+                target.__proto__ = cds.entities[fq]
+                this.get = (target, prop) => target[prop]
+                return target[prop]
+            }
             // we already know the name so we skip the cds.entities proxy access
             if (prop === 'name') return fq
             // custom properties access on 'target' as well as cached _entity property access goes here
@@ -13,12 +18,6 @@ const proxyAccessFunction = function (namespace, name, opts = {}) {
             // inline enums have to be caught here for first time access, as they do not exist on the entity
             if (customProps.includes(prop)) return target[prop]
             // last but not least we pass the property access to cds.entities
-            if (cds.entities) {
-                entity ??= cds.entities[fq]
-                if (!entity) throw new Error(`'${fq}' could not be found in cds.entities('${namespace}')`)
-                if (entity[prop]) target[prop] = entity[prop]
-                return target[prop]
-            }
             throw new Error(`Property ${prop} does not exist on entity '${fq}' or cds.entities is not yet defined`)
         }
     })

--- a/lib/file.js
+++ b/lib/file.js
@@ -6,6 +6,7 @@ const { readFileSync } = require('fs')
 const { printEnum, propertyToInlineEnumName, stringifyEnumImplementation } = require('./components/enum')
 const { normalise } = require('./components/identifier')
 const { empty } = require('./components/typescript')
+const { proxyAccessFunction } = require('./components/javascript')
 const { createObjectOf } = require('./components/wrappers')
 
 const AUTO_GEN_NOTE = '// This is an automatically generated file. Please do not change its contents manually!'
@@ -415,33 +416,7 @@ class SourceFile extends File {
         ].filter(Boolean).join('\n')
     }
     #getEntityProxyFunctionExport() {
-        return `module.exports.createEntityProxy = function(namespace, name, opts = {}) {
-    const { target, customProps } = { target: {}, customProps: [], ...opts }
-    const fq = namespace !== '' ? \`\${namespace}.\${name}\` : name
-    let _entity
-    return new Proxy(target, {
-        get: function (target, prop) {
-            // we already know the name so we skip the cds.entities proxy access
-            if (prop === "name") return fq
-            // custom properties access on 'target' as well as cached _entity property access goes here
-            if (target.hasOwnProperty(prop)) return target[prop]
-            // inline enums have to be caught here for first time access, as they do not exist on the entity
-            if (customProps.length && customProps.includes(prop)) return target[prop]
-            // last but not least we pass the property access to cds.entities
-            if (cds.entities) {
-                const entity = _entity ? _entity : (_entity = cds.entities(namespace)[name]);
-                if (!entity) throw new Error(\`'\${fq}' could not be found in cds.entities('\${namespace}')\`)
-                if (entity[prop]) target[prop] = entity[prop]
-                return target[prop]
-            }
-            throw new Error(\`Property \${prop} does not exist on entity '\${fq}' or cds.entities is not yet defined\`);
-        },
-        set: function (target, prop, newVal) {
-            target[prop] = newVal
-            return true
-        }
-    })
-}`
+        return `module.exports.createEntityProxy = ${proxyAccessFunction}`
     }
     #getEntityProxyCustomProps(name) {
         const customProps = this.entityProxies[name] ?? []

--- a/lib/file.js
+++ b/lib/file.js
@@ -12,6 +12,7 @@ const { createObjectOf } = require('./components/wrappers')
 const AUTO_GEN_NOTE = '// This is an automatically generated file. Please do not change its contents manually!'
 
 /** @typedef {import('./typedefs').file.Namespace} Namespace */
+/** @typedef {import('./typedefs').file.FileOptions} FileOptions */
 
 class File {
     /**
@@ -108,9 +109,11 @@ class Library extends File {
 class SourceFile extends File {
     /**
      * @param {string | Path} path - path to the file
+     * @param {FileOptions} [options] - options for file output
      */
-    constructor(path) {
+    constructor(path, options) {
         super()
+        this.options = options ?? { useEntitiesProxy: false }
         /** @type {Path} */
         this.path = path instanceof Path ? path : new Path(path.split('.'))
         /** @type {{[key:string]: any}} */
@@ -418,64 +421,101 @@ class SourceFile extends File {
     #getEntityProxyFunctionExport() {
         return `module.exports.createEntityProxy = ${proxyAccessFunction}`
     }
-    #getEntityProxyCustomProps(name) {
-        const customProps = this.entityProxies[name] ?? []
-        if (customProps.length) return `, customProps: ${JSON.stringify(customProps)}`
-        return ''
+    /**
+     * Returns boilerplate code for `index.js` files
+     * - `useEntitiesProxy = true` -> import `createEntityProxy` function for entity proxy
+     * - `useEntitiesProxy = false` -> retrieve entities via `cds.entities(namespace)`
+     * @returns {string[]}
+     */
+    #getJSExportBoilerplate() {
+        const namespace = this.path.asNamespace()
+
+        const boilerplate = [AUTO_GEN_NOTE]
+        if (this.options.useEntitiesProxy) {
+            if (namespace === '_') {
+                boilerplate.push('const cds = require(\'@sap/cds\')', this.#getEntityProxyFunctionExport())
+            } else {
+                boilerplate.push(`const { createEntityProxy } = require('${new Path(['_']).asDirectory({relative: this.path.asDirectory()})}')`)
+            }
+        } else {
+            boilerplate.push(
+                'const cds = require(\'@sap/cds\')',
+                `const csn = cds.entities('${namespace}')`
+            )
+        }
+        return boilerplate
+    }
+    /**
+     * Returns RHS for entity `module.exports` assignments
+     * - `useEntitiesProxy = true` -> use function calls to create `Proxy` objects
+     * - `useEntitiesProxy = false` -> access entity from CSN directly
+     * @param {string} singular - singular name of entity
+     * @param {string} original - original name of entity
+     * @returns {{singularRhs: string, pluralRhs: string}}
+     */
+    #getEntityExportsRhs(singular, original) {
+        if (this.options.useEntitiesProxy) {
+            const namespace = this.path.asNamespace()
+            // determine the custom properties for the proxy function call
+            const customProps = this.entityProxies[singular] ?? []
+            let customPropsStr = customProps.length ? `, customProps: ${JSON.stringify(customProps)}` : ''
+
+            return {
+                singularRhs: `createEntityProxy(['${namespace}', '${original}'], { target: { is_singular: true }${customPropsStr} })`,
+                pluralRhs: `createEntityProxy(['${namespace}', '${original}'])`,
+            }
+        } else {
+            return {
+                singularRhs: `{ is_singular: true, __proto__: csn.${original} }`,
+                pluralRhs: `csn.${original}`
+            }
+        }
     }
     toJSExports() {
-        const namespace = this.path.asNamespace()
-        if (namespace === '_') {
-            return [AUTO_GEN_NOTE, 'const cds = require(\'@sap/cds\')', this.#getEntityProxyFunctionExport()].join('\n') + '\n'
-        } else {
-            return [AUTO_GEN_NOTE, `const { createEntityProxy } = require('${new Path(['_']).asDirectory({relative: this.path.asDirectory()})}')`, ''] // boilerplate
-                .concat(
-                    // FIXME: move stringification of service into own module
-                    this.services.names.flatMap(name => {
-                        const nameSimple = name.split('.').pop()
-                        return [
-                            '// service',
-                            `const ${nameSimple} = { name: '${name}' }`,
-                            `module.exports = ${nameSimple}`, // there should be only one and must be the first
-                            `module.exports.${nameSimple} = ${nameSimple}`
-                        ]
-                    })
-                )
-                .concat(this.inflections
-                // sorting the entries based on the number of dots in their singular.
-                // that makes sure we have defined all parent namespaces before adding subclasses to them e.g.:
-                // "module.exports.Books" is defined before "module.exports.Books.text"
-                    .sort(([a], [b]) => a.split('.').length - b.split('.').length)
-                    .flatMap(([singular, plural, original]) => {
-                        const getSingularProxy = () => `createEntityProxy('${namespace}', '${original}', { target: { is_singular: true }${this.#getEntityProxyCustomProps(singular)} })`
-                        const getPluralProxy = () => `createEntityProxy('${namespace}', '${original}')`
+        return this.#getJSExportBoilerplate() // boilerplate
+            .concat(
+                // FIXME: move stringification of service into own module
+                this.services.names.flatMap(name => {
+                    const nameSimple = name.split('.').pop()
+                    return [
+                        '// service',
+                        `const ${nameSimple} = { name: '${name}' }`,
+                        `module.exports = ${nameSimple}`, // there should be only one and must be the first
+                        `module.exports.${nameSimple} = ${nameSimple}`
+                    ]
+                })
+            )
+            .concat(this.inflections
+            // sorting the entries based on the number of dots in their singular.
+            // that makes sure we have defined all parent namespaces before adding subclasses to them e.g.:
+            // "module.exports.Books" is defined before "module.exports.Books.text"
+                .sort(([a], [b]) => a.split('.').length - b.split('.').length)
+                .flatMap(([singular, plural, original]) => {
+                    const { singularRhs, pluralRhs } = this.#getEntityExportsRhs(singular, original)
 
-                        const exports = [`module.exports.${singular} = ${getSingularProxy()}`]
-                        if (!/Array<.*>/.test(plural) && plural !== original) {
-                            // FIXME: this is a hack to support CDS types that will produce "Array<MyType>" as plural, which we do not want as export in the index.js files
-                            exports.push(`module.exports.${plural} = ${getPluralProxy()}`)
-                            // REVISIT: create proxy for this as well???
-                            // exports.push(`module.exports.${plural} = createEntityProxy("${namespace}.${original}, "${original}")`)
-                        }
-                        // FIXME: we currently produce at most 3 entries.
-                        // This could be an issue when the user re-used the original name in a @singular/@plural annotation.
-                        // Seems unlikely, but we have to eliminate the original entry if users start running into this.
-                        if (singular !== original) {
-                            // do not do the is_singular spiel if the original name is used for the plural
-                            const rhs = plural === original ? getPluralProxy() : getSingularProxy()
-                            exports.push(`module.exports.${original} = ${rhs}`)
-                        }
-                        return exports
-                    })
-                ) // singular -> plural aliases
-                .concat(['// events'])
-                .concat(this.events.fqs.map(({fq, name}) => `module.exports.${name} = '${fq}'`))
-                .concat(['// actions'])
-                .concat(this.operations.names.map(name => `module.exports.${name} = '${name}'`))
-                .concat(['// enums'])
-                .concat(this.enums.data.map(({name, kvs}) => stringifyEnumImplementation(name, kvs)))
-                .join('\n') + '\n'
-        }
+                    const exports = [`// ${original}`, `module.exports.${singular} = ${singularRhs}`]
+                    if (!/Array<.*>/.test(plural) && plural !== original) {
+                        // FIXME: this is a hack to support CDS types that will produce "Array<MyType>" as plural, which we do not want as export in the index.js files
+                        exports.push(`module.exports.${plural} = ${pluralRhs}`)
+                    }
+                    // FIXME: we currently produce at most 3 entries.
+                    // This could be an issue when the user re-used the original name in a @singular/@plural annotation.
+                    // Seems unlikely, but we have to eliminate the original entry if users start running into this.
+                    if (singular !== original) {
+                        // do not do the is_singular spiel if the original name is used for the plural
+                        const rhs = plural === original ? pluralRhs : singularRhs
+                        exports.push(`module.exports.${original} = ${rhs}`)
+                    }
+                    return exports
+                })
+            ) // singular -> plural aliases
+            .concat(['// events'])
+            .concat(this.events.fqs.map(({fq, name}) => `module.exports.${name} = '${fq}'`))
+            .concat(['// actions'])
+            .concat(this.operations.names.map(name => `module.exports.${name} = '${name}'`))
+            .concat(['// enums'])
+            .concat(this.enums.data.map(({name, kvs}) => stringifyEnumImplementation(name, kvs)))
+            .join('\n') + '\n'
     }
 }
 
@@ -652,6 +692,13 @@ class FileRepository {
     #files = {}
 
     /**
+     * @param {FileOptions} options - options to control file
+     */
+    constructor(options) {
+        this.options = options
+    }
+
+    /**
      * @param {string} name - file name
      * @param {SourceFile} file - the file
      */
@@ -667,7 +714,7 @@ class FileRepository {
      */
     getNamespaceFile(path) {
         const key = path instanceof Path ? path.asNamespace() : path
-        return (this.#files[key] ??= new SourceFile(path))
+        return (this.#files[key] ??= new SourceFile(path, this.options))
     }
 
     /**

--- a/lib/file.js
+++ b/lib/file.js
@@ -470,7 +470,7 @@ class SourceFile extends File {
                 // "module.exports.Books" is defined before "module.exports.Books.text"
                     .sort(([a], [b]) => a.split('.').length - b.split('.').length)
                     .flatMap(([singular, plural, original]) => {
-                        const getSingularProxy = () => `createEntityProxy('${namespace}', '${original}', { target: { is_singular:true }${this.#getEntityProxyCustomProps(singular)} })`
+                        const getSingularProxy = () => `createEntityProxy('${namespace}', '${original}', { target: { is_singular: true }${this.#getEntityProxyCustomProps(singular)} })`
                         const getPluralProxy = () => `createEntityProxy('${namespace}', '${original}')`
 
                         const exports = [`module.exports.${singular} = ${getSingularProxy()}`]

--- a/lib/file.js
+++ b/lib/file.js
@@ -415,17 +415,18 @@ class SourceFile extends File {
         ].filter(Boolean).join('\n')
     }
     #getEntityProxyFunctionExport() {
-        return `module.exports.createEntityProxy = function(namespace, name, { target, customProps } = { target: {}, customProps: [] }) {
+        return `module.exports.createEntityProxy = function(namespace, name, opts = {}) {
+    const { target, customProps } = { target: {}, customProps: [], ...opts }
     const fq = \`\${namespace}.\${name}\`
     let _entity
-    return new Proxy(target ?? {}, {
+    return new Proxy(target, {
         get: function (target, prop) {
             // we already know the name so we skip the cds.entities proxy access
             if (prop === "name") return fq
-            // mostly is_singular is accessed
+            // custom properties access on 'target' as well as cached _entity property access goes here
             if (target.hasOwnProperty(prop)) return target[prop]
             // inline enums have to be caught here, as they do not exist on the entity
-            if (customProps?.length && customProps.includes(prop)) return target[prop]
+            if (customProps.length && customProps.includes(prop)) return target[prop]
             // last but not least we pass the property access to cds.entities
             if (cds.entities) {
                 const entity = _entity ? _entity : (_entity = cds.entities(namespace)[name]);

--- a/lib/file.js
+++ b/lib/file.js
@@ -140,6 +140,8 @@ class SourceFile extends File {
         this.inflections = []
         /** @type {{ buffer: Buffer, names: string[]}} */
         this.services = { buffer: new Buffer(), names: [] }
+        /** @type {Record<string,string[]>} */
+        this.entityProxies = {};
     }
 
     /**
@@ -295,6 +297,8 @@ class SourceFile extends File {
             kvs,
             fq: `${entityCleanName}.${propertyName}`
         })
+        const entityProxy = this.entityProxies[entityCleanName] ?? (this.entityProxies[entityCleanName] = [])
+        entityProxy.push(propertyName)
         printEnum(this.inlineEnums.buffer, propertyToInlineEnumName(entityCleanName, propertyName), kvs, {export: false})
     }
 
@@ -410,52 +414,91 @@ class SourceFile extends File {
             namespaces.join()  // needs to be after classes for possible declaration merging
         ].filter(Boolean).join('\n')
     }
-
+    #getEntityProxyFunctionExport() {
+        return `module.exports.createEntityProxy = function(namespace, name, { target, customProps } = { target: {}, customProps: [] }) {
+    const fq = \`\${namespace}.\${name}\`
+    let _entity
+    return new Proxy(target ?? {}, {
+        get: function (target, prop) {
+            // we already know the name so we skip the cds.entities proxy access
+            if (prop === "name") return fq
+            // mostly is_singular is accessed
+            if (target.hasOwnProperty(prop)) return target[prop]
+            // inline enums have to be caught here, as they do not exist on the entity
+            if (customProps?.length && customProps.includes(prop)) return target[prop]
+            // last but not least we pass the property access to cds.entities
+            if (cds.entities) {
+                const entity = _entity ? _entity : (_entity = cds.entities(namespace)[name]);
+                if (entity[prop]) target[prop] = entity[prop]
+                return target[prop]
+            }
+            throw new Error(\`Property \${prop} does not exist on entity '\${fq}' or cds.entities is not yet defined\`);
+        },
+        set: function (target, prop, newVal) {
+            target[prop] = newVal
+            return true
+        }
+    })
+}`
+    }
+    #getEntityProxyCustomProps(name) {
+        const customProps = this.entityProxies[name] ?? []
+        if (customProps.length) return `, customProps: ${JSON.stringify(customProps)}`
+        return ''
+    }
     toJSExports() {
-        return [AUTO_GEN_NOTE, 'const cds = require(\'@sap/cds\')', `const csn = cds.entities('${this.path.asNamespace()}')`] // boilerplate
-            .concat(
-                // FIXME: move stringification of service into own module
-                this.services.names.flatMap(name => {
-                    const nameSimple = name.split('.').pop()
-                    return [
-                        '// service',
-                        `const ${nameSimple} = { name: '${name}' }`,
-                        `module.exports = ${nameSimple}`, // there should be only one and must be the first
-                        `module.exports.${nameSimple} = ${nameSimple}`
-                    ]
-                })
-            )
-            .concat(this.inflections
-            // sorting the entries based on the number of dots in their singular.
-            // that makes sure we have defined all parent namespaces before adding subclasses to them e.g.:
-            // "module.exports.Books" is defined before "module.exports.Books.text"
-                .sort(([a], [b]) => a.split('.').length - b.split('.').length)
-                .flatMap(([singular, plural, original]) => {
-                    const exports = [`// ${original}`, `module.exports.${singular} = { is_singular: true, __proto__: csn.${original} }`]
-                    if (!/Array<.*>/.test(plural) && plural !== original) {
-                        // FIXME: this is a hack to support CDS types that will produce "Array<MyType>" as plural, which we do not want as export in the index.js files
-                        exports.push(`module.exports.${plural} = csn.${original}`)
-                    }
-                    // FIXME: we currently produce at most 3 entries.
-                    // This could be an issue when the user re-used the original name in a @singular/@plural annotation.
-                    // Seems unlikely, but we have to eliminate the original entry if users start running into this.
-                    if (singular !== original) {
-                        // do not do the is_singular spiel if the original name is used for the plural
-                        const rhs = plural === original
-                            ? `csn.${original}`
-                            : `{ is_singular: true, __proto__: csn.${original} }`
-                        exports.push(`module.exports.${original} = ${rhs}`)
-                    }
-                    return exports
-                })
-            ) // singular -> plural aliases
-            .concat(['// events'])
-            .concat(this.events.fqs.map(({fq, name}) => `module.exports.${name} = '${fq}'`))
-            .concat(['// actions'])
-            .concat(this.operations.names.map(name => `module.exports.${name} = '${name}'`))
-            .concat(['// enums'])
-            .concat(this.enums.data.map(({name, kvs}) => stringifyEnumImplementation(name, kvs)))
-            .join('\n') + '\n'
+        const namespace = this.path.asNamespace()
+        if (namespace === "_") {
+            return [AUTO_GEN_NOTE, 'const cds = require(\'@sap/cds\')', this.#getEntityProxyFunctionExport()].join('\n') + '\n'
+        } else {
+            return [AUTO_GEN_NOTE, `const { createEntityProxy } = require('${new Path(['_']).asDirectory({relative: this.path.asDirectory()})}')`, ''] // boilerplate
+                .concat(
+                    // FIXME: move stringification of service into own module
+                    this.services.names.flatMap(name => {
+                        const nameSimple = name.split('.').pop()
+                        return [
+                            '// service',
+                            `const ${nameSimple} = { name: '${name}' }`,
+                            `module.exports = ${nameSimple}`, // there should be only one and must be the first
+                            `module.exports.${nameSimple} = ${nameSimple}`
+                        ]
+                    })
+                )
+                .concat(this.inflections
+                // sorting the entries based on the number of dots in their singular.
+                // that makes sure we have defined all parent namespaces before adding subclasses to them e.g.:
+                // "module.exports.Books" is defined before "module.exports.Books.text"
+                    .sort(([a], [b]) => a.split('.').length - b.split('.').length)
+                    .flatMap(([singular, plural, original]) => {
+                        const getSingularProxy = () => `createEntityProxy('${namespace}', '${original}', { target: { is_singular:true }${this.#getEntityProxyCustomProps(singular)} })`
+                        const getPluralProxy = () => `createEntityProxy('${namespace}', '${original}')`
+
+                        const exports = [`module.exports.${singular} = ${getSingularProxy()}`]
+                        if (!/Array<.*>/.test(plural) && plural !== original) {
+                            // FIXME: this is a hack to support CDS types that will produce "Array<MyType>" as plural, which we do not want as export in the index.js files
+                            exports.push(`module.exports.${plural} = ${getPluralProxy()}`)
+                            // REVISIT: create proxy for this as well???
+                            // exports.push(`module.exports.${plural} = createEntityProxy("${namespace}.${original}, "${original}")`)
+                        }
+                        // FIXME: we currently produce at most 3 entries.
+                        // This could be an issue when the user re-used the original name in a @singular/@plural annotation.
+                        // Seems unlikely, but we have to eliminate the original entry if users start running into this.
+                        if (singular !== original) {
+                            // do not do the is_singular spiel if the original name is used for the plural
+                            const rhs = plural === original ? getPluralProxy() : getSingularProxy()
+                            exports.push(`module.exports.${original} = ${rhs}`)
+                        }
+                        return exports
+                    })
+                ) // singular -> plural aliases
+                .concat(['// events'])
+                .concat(this.events.fqs.map(({fq, name}) => `module.exports.${name} = '${fq}'`))
+                .concat(['// actions'])
+                .concat(this.operations.names.map(name => `module.exports.${name} = '${name}'`))
+                .concat(['// enums'])
+                .concat(this.enums.data.map(({name, kvs}) => stringifyEnumImplementation(name, kvs)))
+                .join('\n') + '\n'
+        }
     }
 }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -141,7 +141,7 @@ class SourceFile extends File {
         /** @type {{ buffer: Buffer, names: string[]}} */
         this.services = { buffer: new Buffer(), names: [] }
         /** @type {Record<string,string[]>} */
-        this.entityProxies = {};
+        this.entityProxies = {}
     }
 
     /**
@@ -448,7 +448,7 @@ class SourceFile extends File {
     }
     toJSExports() {
         const namespace = this.path.asNamespace()
-        if (namespace === "_") {
+        if (namespace === '_') {
             return [AUTO_GEN_NOTE, 'const cds = require(\'@sap/cds\')', this.#getEntityProxyFunctionExport()].join('\n') + '\n'
         } else {
             return [AUTO_GEN_NOTE, `const { createEntityProxy } = require('${new Path(['_']).asDirectory({relative: this.path.asDirectory()})}')`, ''] // boilerplate

--- a/lib/file.js
+++ b/lib/file.js
@@ -417,7 +417,7 @@ class SourceFile extends File {
     #getEntityProxyFunctionExport() {
         return `module.exports.createEntityProxy = function(namespace, name, opts = {}) {
     const { target, customProps } = { target: {}, customProps: [], ...opts }
-    const fq = \`\${namespace}.\${name}\`
+    const fq = namespace !== '' ? \`\${namespace}.\${name}\` : name
     let _entity
     return new Proxy(target, {
         get: function (target, prop) {
@@ -425,11 +425,12 @@ class SourceFile extends File {
             if (prop === "name") return fq
             // custom properties access on 'target' as well as cached _entity property access goes here
             if (target.hasOwnProperty(prop)) return target[prop]
-            // inline enums have to be caught here, as they do not exist on the entity
+            // inline enums have to be caught here for first time access, as they do not exist on the entity
             if (customProps.length && customProps.includes(prop)) return target[prop]
             // last but not least we pass the property access to cds.entities
             if (cds.entities) {
                 const entity = _entity ? _entity : (_entity = cds.entities(namespace)[name]);
+                if (!entity) throw new Error(\`'\${fq}' could not be found in cds.entities('\${namespace}')\`)
                 if (entity[prop]) target[prop] = entity[prop]
                 return target[prop]
             }

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -119,6 +119,7 @@ export module visitor {
     export type CompileParameters = {
         outputDirectory: string,
         logLevel: number,
+        useEntitiesProxy: boolean,
         jsConfigPath?: string,
         inlineDeclarations: 'flat' | 'structured',
         propertiesOptional: boolean,
@@ -133,6 +134,10 @@ export module visitor {
          * `inlineDeclarations = 'flat'` -> @see {@link inline.FlatInlineDeclarationResolver}
          */
         inlineDeclarations: 'flat' | 'structured',
+        /**
+         * `useEntitiesProxy = true` will wrap the `module.exports.<entityName>` in `Proxy` objects
+         */
+        useEntitiesProxy: boolean
     }
 
     export type Inflection = {
@@ -155,4 +160,7 @@ export module visitor {
 
 export module file {
     export type Namespace = Object<string, Buffer>
+    export type FileOptions = {
+        useEntitiesProxy: boolean
+    }
 }

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -29,6 +29,7 @@ const { getPropertyModifiers } = require('./components/property')
 const defaults = {
     // FIXME: add defaults for remaining parameters
     propertiesOptional: true,
+    useEntitiesProxy: false,
     inlineDeclarations: 'flat'
 }
 
@@ -63,7 +64,9 @@ class Visitor {
         this.entityRepository = new EntityRepository(this.resolver)
 
         /** @type {FileRepository} */
-        this.fileRepository = new FileRepository()
+        this.fileRepository = new FileRepository(this.options)
+        // REVISIT: better way to pass options to base source file ???
+        baseDefinitions.options = this.options
         this.fileRepository.add(baseDefinitions.path.asNamespace(), baseDefinitions)
         this.inlineDeclarationResolver =
             this.options.inlineDeclarations === 'structured'

--- a/test/ast.js
+++ b/test/ast.js
@@ -434,18 +434,13 @@ class JSASTWrapper {
     }
 
     hasExport(lhs, rhs) {
-        return this.getExports().find(exp => exp.lhs === lhs && (exp.rhs === rhs || exp.rhs.name === rhs))
+        return this.getExports().find(exp => exp.lhs === lhs && exp.rhs === rhs)
     }
 
     /**
      * @returns {{ lhs: string, rhs: string | { singular: boolean, name: string }}}
      */
     getExports() {
-        const processObjectLiteral = ({properties}) => ({
-            singular: properties.find(p => p.key.name === 'is_singular' && p.value.value),
-            name: properties.find(p => p.key.name === '__proto__')?.value.property.name
-        })
-        this.program.body[2].expression.right.properties[1].value.property
         return this.exports ??= this.program.body.filter(node => {
             if (node.type !== 'ExpressionStatement') return false
             if (node.expression.left.type !== 'MemberExpression') return false
@@ -454,7 +449,8 @@ class JSASTWrapper {
         }).map(node => (
             {
                 lhs: node.expression.left.property.name,
-                rhs: node.expression.right.property?.name ?? processObjectLiteral(node.expression.right)
+                // CallExpression, where second argument is the original entity name
+                rhs: node.expression.right.arguments[1].value
             }
         ))
     }

--- a/test/unit/entitiesproxy.test.js
+++ b/test/unit/entitiesproxy.test.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const path = require('path')
+const { beforeAll, describe, test, expect } = require('@jest/globals')
+const { JSASTWrapper } = require('../ast')
+const { locations, prepareUnitTest } = require('../util')
+
+describe('Compilation - with Entities Proxies', () => {
+    let paths
+
+    describe('Bookshoplet', () => {
+
+        beforeAll(async () => ({paths} = await prepareUnitTest('bookshoplet/model.cds', locations.testOutput('entities_proxy_test/bookshoplet'), {typerOptions: {useEntitiesProxy: true}})))
+
+        test('index.js', async () => {
+            const jsw = await JSASTWrapper.initialise(path.join(paths[1], 'index.js'), true)
+            // cds.entities must not be used directly
+            expect(jsw.hasCdsEntitiesAccess()).toBeFalsy()
+            // check if exports are used in proxy function call
+            jsw.exportsAre([
+                ['Book', 'Books'],
+                ['Books', 'Books'],
+                ['Author', 'Authors'],
+                ['Authors', 'Authors'],
+                ['Genre', 'Genres'],
+                ['Genres', 'Genres'],
+                ['A_', 'A'],
+                ['A', 'A'],
+                ['B_', 'B'],
+                ['B', 'B'],
+                ['C_', 'C'],
+                ['C', 'C'],
+                ['D_', 'D'],
+                ['D', 'D'],
+                ['E_', 'E'],
+                ['E', 'E'],
+                ['QueryEntity_', 'QueryEntity'],
+                ['QueryEntity', 'QueryEntity']
+            ])
+        })
+    })
+
+    describe('Enums', () => {
+        beforeAll(async () => ({paths} = await prepareUnitTest('enums/model.cds', locations.testOutput('entities_proxy_test/enums'), {typerOptions: {useEntitiesProxy: true}})))
+
+        test('Inline enum names passed to proxy function call', async () => {
+            const jsw = await JSASTWrapper.initialise(path.join(paths[1], 'index.js'), true)
+
+            jsw.hasProxyExport('InlineEnum', ['gender', 'status', 'yesno'])
+            jsw.hasProxyExport('TypeWithInlineEnum', ['inlineEnumProperty'])
+        })
+    })
+})


### PR DESCRIPTION
Wrapping the `module.exports` in `Proxy` objects removes the need for dynamic imports everywhere.

### Changes

- new `module.exports` in `index.js` of namespace `_`  
   ![image](https://github.com/user-attachments/assets/8322c358-a3f1-4837-a8a5-234f2af0010f)
- wrapping the entity `module.exports` in the new `createEntityProxy` function  
  ![image](https://github.com/user-attachments/assets/8fccfce0-16ae-4991-895b-483bee0ef795)

### Remarks

- The `set`-trap in the Proxy and the `customProps` are mainly for the inline enums, otherwise they could not be accessed