### PR TITLE
Support optional operation parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Apps need to provide `@sap/cds` version `8.2` or higher.
 - Apps need to provide `@cap-js/cds-types` version `0.6.4` or higher.
 - Typed methods are now generated for calls of unbound actions. Named and positional call styles are supported, e.g. `service.action({one, two})` and `service.action(one, two)`.
+- Action parameters can be optional in the named call style (`service.action({one:1, ...})`).
 
 ## Version 0.25.0 - 2024-08-13
 ### Added

--- a/lib/file.js
+++ b/lib/file.js
@@ -146,7 +146,7 @@ class SourceFile extends File {
      * Stringifies a lambda expression.
      * @param {object} options - options
      * @param {string} options.name - name of the lambda
-     * @param {[string, string][]} [options.parameters] - list of parameters, passed as [name, type] pairs
+     * @param {[string, string, string][]} [options.parameters] - list of parameters, passed as [name, modifier, type] pairs
      * @param {string} [options.returns] - the return type of the function
      * @param {'action' | 'function'} options.kind - kind of the lambda
      * @param {string} [options.initialiser] - the initialiser expression
@@ -156,10 +156,10 @@ class SourceFile extends File {
      * @example
      * ```js
      * // note: these samples are actually simplified! See below.
-     * stringifyLambda({parameters: [['p','T']]})  // f: { (p: T): any, ... }
-     * stringifyLambda({name: 'f', parameters: [['p','T']]})  // f: { (p: T) => any, ...  }
-     * stringifyLambda({name: 'f', parameters: [['p','T']], returns: 'number'})  // f: { (p: T) => number, ...  }
-     * stringifyLambda({name: 'f', parameters: [['p','T']], returns: 'number', initialiser: '_ => 42'})  // f: { (p: T): string = _ => 42, ...  }
+     * stringifyLambda({parameters: [['p','','T']]})  // f: { (p: T): any, ... }
+     * stringifyLambda({name: 'f', parameters: [['p','','T']]})  // f: { (p: T) => any, ...  }
+     * stringifyLambda({name: 'f', parameters: [['p','?','T']], returns: 'number'})  // f?: { (p: T) => number, ...  }
+     * stringifyLambda({name: 'f', parameters: [['p','?','T']], returns: 'number', initialiser: '_ => 42'})  // f?: { (p: T): string = _ => 42, ...  }
      * ```
      *
      * The generated string will not be just the signature of the function. Instead, it will be an object offering callable signature(s).
@@ -169,11 +169,11 @@ class SourceFile extends File {
      * Instead, we generate this utility object for the runtime to use:
      * @example
      * ```js
-     * stringifyLambda({name: 'f', parameters: [['p','T']], returns: 'number'})  // { (p: T): number, __parameters: { p: T } }
+     * stringifyLambda({name: 'f', parameters: [['p','','T']], returns: 'number'})  // { (p: T): number, __parameters: { p: T } }
      * ```
      */
     static stringifyLambda({name, parameters=[], returns='any', kind, initialiser, isStatic=false, callStyles={positional:true, named:true}}) {
-        const parameterTypes = parameters.map(([n, t]) => `${normalise(n)}: ${t}`).join(', ')
+        const parameterTypes = parameters.map(([n, mod='', t]) => `${normalise(n)}${mod}: ${t}`).join(', ')
         const parameterTypeAsObject = parameterTypes.length
             ? createObjectOf(parameterTypes)
             : empty
@@ -212,7 +212,7 @@ class SourceFile extends File {
     /**
      * Adds a function definition in form of a arrow function to the file.
      * @param {string} name - name of the function
-     * @param {[string, string][]} parameters - list of parameters, passed as [name, type] pairs
+     * @param {[string, string, string][]} parameters - list of parameters, passed as [name, modifier, type] tuple
      * @param {string} returns - the return type of the function
      * @param {'function' | 'action'} kind - kind of the node
      */

--- a/lib/file.js
+++ b/lib/file.js
@@ -179,7 +179,8 @@ class SourceFile extends File {
             : empty
         const callableSignatures = []
         if (callStyles.positional) {
-            callableSignatures.push(`// positional\n(${parameterTypes}): ${returns}`)
+            const paramTypesPositional = parameters.map(([n, , t]) => `${normalise(n)}: ${t}`).join(', ') // must not include ? modifiers
+            callableSignatures.push(`// positional\n(${paramTypesPositional}): ${returns}`)
         }
         if (callStyles.named) {
             const parameterNames = createObjectOf(parameters.map(([n]) => normalise(n)).join(', '))

--- a/lib/resolution/resolver.js
+++ b/lib/resolution/resolver.js
@@ -59,6 +59,15 @@ class Resolver {
     }
 
     /**
+     * @param {EntityCSN} type - a CSN type
+     * @returns {boolean} whether the type is configured to be optional
+     */
+    isOptional(type) {
+        // TODO temporary solution to determine optional parameters. Align w/ compiler/importer.
+        return Object.keys(type).some(k => k.startsWith('@Core.OptionalParameter'))
+    }
+
+    /**
      * Returns all libraries that have been referenced at least once.
      * @returns {Library[]}
      */

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -369,18 +369,17 @@ class Visitor {
      * Also filters out parameters that indicate a binding parameter ({@link https://cap.cloud.sap/docs/releases/jan23#simplified-syntax-for-binding-parameters}).
      * @param {{[key:string]: EntityCSN}} params - parameter list as found in CSN.
      * @param {SourceFile} file - source file relative to which the parameter types should be resolved.
-     * @returns {[string, string][]} pair of names and types.
+     * @returns {[string, string, string][]} tuple of name, modifier and type.
      */
     #stringifyFunctionParams(params, file) {
-        return params
-            ? Object.entries(params)
-                // filter params of type '[many] $self', as they are not to be part of the implementation
-                .filter(([, type]) => type?.type !== '$self' && type.items?.type !== '$self')
-                .map(([name, type]) => [
-                    name,
-                    this.#stringifyFunctionParamType(type, file)
-                ])
-            : []
+        return Object.entries(params ?? {})
+            // filter params of type '[many] $self', as they are not to be part of the implementation
+            .filter(([, type]) => type?.type !== '$self' && type.items?.type !== '$self')
+            .map(([name, type]) => [
+                name,
+                this.resolver.isOptional(type) ? '?' : '',
+                this.#stringifyFunctionParamType(type, file)
+            ])
     }
 
     /**

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -178,7 +178,7 @@ describe('Actions', () => {
 
     test ('Optional Action Params', async () => {
         checkFunction(astwBound.tree.find(fn => fn.name === 'aOptionalParam'), {
-            parameterCheck: ({members: [first, second]}) => !check.isOptional(first) && check.isOptional(second)
+            parameterCheck: ({members: [p1, p2, p3]}) => !check.isOptional(p1) && check.isOptional(p2) && !check.isOptional(p3),
         })
     })
 

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -176,6 +176,12 @@ describe('Actions', () => {
         })
     })
 
+    test ('Optional Action Params', async () => {
+        checkFunction(astwBound.tree.find(fn => fn.name === 'aOptionalParam'), {
+            parameterCheck: ({members: [first, second]}) => !check.isOptional(first) && check.isOptional(second)
+        })
+    })
+
     test ('Empty .actions typed as empty Record', async () => {
         const { type } = astwUnbound.getAspectProperty('_NoActionAspect', 'actions')
         expect(type.full === 'Record'

--- a/test/unit/files/actions/model.cds
+++ b/test/unit/files/actions/model.cds
@@ -31,6 +31,12 @@ service S {
     action   aSingleParamManyReturn(val: E)          returns array of E;
     action   aManyParamManyReturn(val: array of E)   returns array of E;
     action   aManyParamSingleReturn(val: array of E) returns E;
+
+    action   aOptionalParam(
+        val: E,
+        @Core.OptionalParameter: {$Type : 'Core.OptionalParameterType'}
+        opt: E
+    ) returns E;
 }
 
 action free (param: String) returns { a: Integer; b: String } ;

--- a/test/unit/files/actions/model.cds
+++ b/test/unit/files/actions/model.cds
@@ -35,7 +35,8 @@ service S {
     action   aOptionalParam(
         val: E,
         @Core.OptionalParameter: {$Type : 'Core.OptionalParameterType'}
-        opt: E
+        opt: E,
+        val2: E
     ) returns E;
 }
 


### PR DESCRIPTION
If a `@Core.OptionalParameter` annotation is set on an operation parameter, mark the property as optional in the named call style.
The actual annotation is not fixed yet, but this is the state of discussion.

Resulting `.ts` file with `?` modifiers:
```ts
export declare const submitOrder: {
  // positional
  (book: ..., quantity: number | null): ...
  // named
  ({book, quantity}: {book: ..., quantity?: number | null}): ...
  ...
}
```

The existing default for mandatory/optional is not changed, so no migration expected.

Continuation of https://github.com/cap-js/cds-typer/pull/291
