### PR TITLE
Use getByFqOrThrow where appropriate

### DIFF
--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -169,8 +169,7 @@ class Visitor {
      * @param {{cleanName?: string}} options - additional options
      */
     #aspectify(fq, entity, buffer, options = {}) {
-        const info = this.entityRepository.getByFq(fq)
-        if (!info) throw new Error(`could not resolve entity ${fq}`)
+        const info = this.entityRepository.getByFqOrThrow(fq)
         const clean = options?.cleanName ?? info.withoutNamespace
         const { namespace } = info
         const file = this.fileRepository.getNamespaceFile(namespace)
@@ -297,9 +296,7 @@ class Visitor {
          * @param {string} content - the content to set the name property to
          */
         const overrideNameProperty = (clazz, content) => `Object.defineProperty(${clazz}, 'name', { value: '${content}' })`
-        const info = this.entityRepository.getByFq(fq)
-        if (!info) throw new Error(`could not resolve entity ${fq}`)
-        const { namespace: ns, entityName: clean, inflection } = info
+        const { namespace: ns, entityName: clean, inflection } = this.entityRepository.getByFqOrThrow(fq)
         const file = this.fileRepository.getNamespaceFile(ns)
         let { singular, plural } = inflection
 
@@ -413,9 +410,7 @@ class Visitor {
      */
     #printOperation(fq, operation, kind) {
         LOG.debug(`Printing operation ${fq}:\n${JSON.stringify(operation, null, 2)}`)
-        const info = this.entityRepository.getByFq(fq)
-        if (!info) throw new Error(`could not resolve operation ${fq}`)
-        const { namespace } = info
+        const { namespace } = this.entityRepository.getByFqOrThrow(fq)
         const file = this.fileRepository.getNamespaceFile(namespace)
         const params = this.#stringifyFunctionParams(operation.params, file)
         const returnType = operation.returns
@@ -440,9 +435,7 @@ class Visitor {
      */
     #printType(fq, type) {
         LOG.debug(`Printing type ${fq}:\n${JSON.stringify(type, null, 2)}`)
-        const info = this.entityRepository.getByFq(fq)
-        if (!info) throw new Error(`could not resolve type ${fq}`)
-        const { namespace, entityName } = info
+        const { namespace, entityName } = this.entityRepository.getByFqOrThrow(fq)
         const file = this.fileRepository.getNamespaceFile(namespace)
         // skip references to enums.
         // "Base" enums will always have a builtin type (don't skip those).
@@ -463,9 +456,7 @@ class Visitor {
      */
     #printAspect(fq, aspect) {
         LOG.debug(`Printing aspect ${fq}`)
-        const info = this.entityRepository.getByFq(fq)
-        if (!info) throw new Error(`could not resolve aspect ${fq}`)
-        const { namespace, entityName, inflection } = info
+        const { namespace, entityName, inflection } = this.entityRepository.getByFqOrThrow(fq)
         const file = this.fileRepository.getNamespaceFile(namespace)
         // aspects are technically classes and can therefore be added to the list of defined classes.
         // Still, when using them as mixins for a class, they need to already be defined.
@@ -480,10 +471,7 @@ class Visitor {
      * @param {EntityCSN} event - CSN
      */
     #printEvent(fq, event) {
-        LOG.debug(`Printing event ${fq}`)
-        const info = this.entityRepository.getByFq(fq)
-        if (!info) throw new Error(`could not resolve event ${fq}`)
-        const { namespace, entityName } = info
+        const { namespace, entityName } = this.entityRepository.getByFqOrThrow(fq)
         const file = this.fileRepository.getNamespaceFile(namespace)
         file.addEvent(entityName, fq)
         const buffer = file.events.buffer
@@ -505,8 +493,7 @@ class Visitor {
      */
     #printService(fq, service) {
         LOG.debug(`Printing service ${fq}:\n${JSON.stringify(service, null, 2)}`)
-        // @ts-expect-error
-        const { namespace } = this.entityRepository.getByFq(fq)
+        const { namespace } = this.entityRepository.getByFqOrThrow(fq)
         const file = this.fileRepository.getNamespaceFile(namespace)
         const buffer = file.services.buffer
         const serviceNameSimple = service.name.split('.').pop()


### PR DESCRIPTION
`EntityRepository` offers [`getByFqOrThrow`](https://github.com/cap-js/cds-typer/blob/main/lib/resolution/entity.js#L154) which returns `EntityInfo` (instead of `EntityInfo | null`,  as `getByFq` does), and thus eliminates the need to check for `null` to appease the type system.
Should only be used where we are certain the entity actually exists. For example, when iterating over all entitiy names and looking them up in our CSN.