### PR TITLE
Make import of cds conditional

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -377,7 +377,10 @@ class SourceFile extends File {
      */
     getImports() {
         const buffer = new Buffer()
-        buffer.add('import cds from \'@sap/cds\'') // TODO should go to visitor#printService, but can't express this as Path
+        if (this.services.names.length) {
+            // currently only needed to extend cds.Service and would trigger unused-variable-errors in strict configs
+            buffer.add('import cds from \'@sap/cds\'') // TODO should go to visitor#printService, but can't express this as Path
+        }
         for (const imp of Object.values(this.imports)) {
             if (!imp.isCwd(this.path.asDirectory())) {
                 buffer.add(`import * as ${imp.asIdentifier()} from '${imp.asDirectory({relative: this.path.asDirectory()})}';`)


### PR DESCRIPTION
Only import `@sap/cds` iff at least one class extending `cds.Service` is present in that file. Otherwise, strict configs would find fault with the unused variable.