### PR TITLE
Disable positional call style for ABAP RFC actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Apps need to provide `@cap-js/cds-types` version `0.6.4` or higher.
 - Typed methods are now generated for calls of unbound actions. Named and positional call styles are supported, e.g. `service.action({one, two})` and `service.action(one, two)`.
 - Action parameters can be optional in the named call style (`service.action({one:1, ...})`).
+- Actions for ABAP RFC modules cannot be called with positional parameters, but only with named ones. They have 'parameter categories' (import/export/changing/tables) that cannot be called in a flat order.
 - Services now have their own export (named like the service itself). The current default export is not usable in some scenarios from CommonJS modules.
 - Operation parameters can have doc comments
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -218,7 +218,7 @@ class SourceFile extends File {
      * @param {import('./typedefs').visitor.ParamInfo[]} parameters - list of parameters, passed as [name, modifier, type] tuple
      * @param {string} returns - the return type of the function
      * @param {'function' | 'action'} kind - kind of the node
-     * @param {?string[]} doc - documentation for the function
+     * @param {string[]} doc - documentation for the function
      * @param {{positional?: boolean, named?: boolean}} callStyles - how the operation can be called
      */
     addOperation(name, parameters, returns, kind, doc, callStyles) {

--- a/lib/file.js
+++ b/lib/file.js
@@ -218,12 +218,13 @@ class SourceFile extends File {
      * @param {import('./typedefs').visitor.ParamInfo[]} parameters - list of parameters, passed as [name, modifier, type] tuple
      * @param {string} returns - the return type of the function
      * @param {'function' | 'action'} kind - kind of the node
-     * @param {string[]?} doc - documentation for the function
+     * @param {?string[]} doc - documentation for the function
+     * @param {{positional?: boolean, named?: boolean}} callStyles - how the operation can be called
      */
-    addOperation(name, parameters, returns, kind, doc) {
+    addOperation(name, parameters, returns, kind, doc, callStyles) {
         // this.operations.buffer.add(`// ${kind}`)
         if (doc) this.operations.buffer.add(doc.join('\n')) // docs shows up on action provider side: `.on(action,...)`
-        this.operations.buffer.add(`export declare const ${SourceFile.stringifyLambda({name, parameters, returns, kind, doc})};`)
+        this.operations.buffer.add(`export declare const ${SourceFile.stringifyLambda({name, parameters, returns, kind, doc, callStyles})};`)
         this.operations.names.push(name)
     }
 

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -426,7 +426,11 @@ class Visitor {
             // operation results may be a Promise
             returns = createUnionOf(createPromiseOf(returns), returns)
         }
-        file.addOperation(last(fq), params, returns, kind, docify(operation.doc))
+        // Actions for ABAP RFC modules have 'parameter categories' (import/export/changing/tables) that cannot be called in a flat order.
+        // Prevent positional call style there.
+        // TODO find a better way to detect ABAP RFC actions
+        const isRFC = Object.values(operation.params ?? {}).some(p => Object.keys(p).some(k => k.startsWith('@RFC')))
+        file.addOperation(last(fq), params, returns, kind, docify(operation.doc), {named: true, positional: !isRFC})
     }
 
     /**

--- a/test/unit/files/actions/model.cds
+++ b/test/unit/files/actions/model.cds
@@ -54,6 +54,14 @@ service S {
          */
         val: E
     );
+
+    action aRfcStyle(
+        INPUT : String(1),
+        @RFCParameterType : 'Table' @Core.OptionalParameter : { $Type: 'Core.OptionalParameterType' }
+            TABLES : many ExternalType2,
+        @RFCParameterType : 'Export' @Core.OptionalParameter : { $Type: 'Core.OptionalParameterType' }
+            EXPORT: String(1)
+    ) returns ExternalType;
 }
 
 action free (param: String) returns { a: Integer; b: String } ;

--- a/test/unit/files/actions/model.ts
+++ b/test/unit/files/actions/model.ts
@@ -7,6 +7,7 @@ import {
     aManyParamManyReturn,
     aManyParamSingleReturn,
     aOptionalParam,
+    aRfcStyle,
     aSingleParamManyReturn,
     aSingleParamSingleReturn,
     E,
@@ -32,6 +33,8 @@ type IsKeyOptional<T extends Record<string | number | symbol, unknown>, Keys ext
     {[Key in Keys]?: T[Key]} extends Pick<T, Keys> ? true : false;
 
 export class S extends cds.ApplicationService { async init(){
+
+  const s_  = await cds.connect.to(S_)
 
   this.on(getOneExternalType,        req => { return {extType:1} satisfies ExternalType})
   this.on(getManyExternalTypes,      req => { return [{extType:1}] satisfies ExternalType[] })
@@ -66,8 +69,11 @@ export class S extends cds.ApplicationService { async init(){
   await s2.a2({p1: '', p3: 1}) satisfies ExternalType
   await s2.a2('', [], 1) satisfies ExternalType
 
+  await s_.aRfcStyle({INPUT: ''}) satisfies ExternalType
+  //@ts-expect-error
+  await s_.aRfcStyle('') // no positional call style allowed for RFC actions
+
   // docs -> hover over actions
-  const s_  = await cds.connect.to(S_)
   // provider side
   this.on(aDocOneLine,    req => { const {val1, val2} = req.data; return {e1:val1[0].e1} satisfies E })
   // caller side


### PR DESCRIPTION
Actions for ABAP RFC modules should only be callable with named parameters. Such modules have 'parameter categories' (import/export/changing/tables) that cannot be called in a flat order.