### PR TITLE
Fix CDS prop nullability if `@mandatory` is used

### DIFF
--- a/lib/resolution/resolver.js
+++ b/lib/resolution/resolver.js
@@ -452,7 +452,7 @@ class Resolver {
             isArray: false,
             isNotNull: element?.isRefNotNull !== undefined
                 ? element?.isRefNotNull
-                : element?.key || element?.notNull || cardinality > 1,
+                : element?.key || element?.notNull || element?.['@mandatory'] || cardinality > 1,
         }
 
         if (element?.type === undefined) {

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -243,7 +243,7 @@ class Visitor {
                                     LOG.error(`Attempting to generate a foreign key reference called '${foreignKey}' in type definition for entity ${fq}. But a property of that name is already defined explicitly. Consider renaming that property.`)
                                 } else {
                                     const kelement = Object.assign(Object.create(originalKeyElement), {
-                                        isRefNotNull: !!element.notNull || !!element.key
+                                        isRefNotNull: !!element.notNull || !!element['@mandatory'] || !!element.key
                                     })
                                     this.visitElement(foreignKey, kelement, file, buffer)
                                 }


### PR DESCRIPTION
Hi @daogrady 👋 ,

Since the version `8.0.2`, CDS has introduced the new logic for CDS params in CDS functions/actions. Now, we have to use `@mandatory` annotation instead of setting `not null` keyword. Whereas `not null` is still working on CDS entity layer.. 
Therefore, I have added a check on `@mandatory` existence in order to determine if the property should/shouldn't be marked as nullable in the compiled TypeScript files.