### PR TITLE
Add docs for enums, fix it for entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Action parameters can be optional in the named call style (`service.action({one:1, ...})`).
 - Actions for ABAP RFC modules cannot be called with positional parameters, but only with named ones. They have 'parameter categories' (import/export/changing/tables) that cannot be called in a flat order.
 - Services now have their own export (named like the service itself). The current default export is not usable in some scenarios from CommonJS modules.
-- Operation parameters can have doc comments
+- Enums and operation parameters can have doc comments
 
 ## Version 0.25.0 - 2024-08-13
 ### Added

--- a/lib/components/enum.js
+++ b/lib/components/enum.js
@@ -22,7 +22,7 @@ const stringifyEnumType = kvs => [...uniqueValues(kvs)].join(' | ')
 /**
  * @param {string} key - the key of the enum
  * @param {any} value - the value of the enum
- * @param {string | import('@sap/cds').ref} enumType - the type of the enum
+ * @param {string | import('../typedefs').resolver.ref} enumType - the type of the enum
  */
 const enumVal = (key, value, enumType) => enumType === 'cds.String' ? JSON.stringify(`${value ?? key}`) : value
 
@@ -50,10 +50,12 @@ const enumVal = (key, value, enumType) => enumType === 'cds.String' ? JSON.strin
  * @param {string} name - local name of the enum, i.e. the name under which it should be created in the .ts file
  * @param {[string, string][]} kvs - list of key-value pairs
  * @param {object} options - options for printing the enum
+ * @param {string[]} doc - the enum docs
  */
-function printEnum(buffer, name, kvs, options = {}) {
+function printEnum(buffer, name, kvs, options = {}, doc=[]) {
     const opts = {...{export: true}, ...options}
     buffer.add('// enum')
+    if (opts.export) doc.forEach(d => { buffer.add(d) })
     buffer.addIndentedBlock(`${opts.export ? 'export ' : ''}const ${name} = {`, () =>
         kvs.forEach(([k, v]) => { buffer.add(`${normalise(k)}: ${v},`) })
     , '} as const;')

--- a/lib/file.js
+++ b/lib/file.js
@@ -254,10 +254,11 @@ class SourceFile extends File {
      * @param {string} fq - fully qualified name of the enum (entity name within CSN)
      * @param {string} name - local name of the enum
      * @param {[string, string][]} kvs - list of key-value pairs
+     * @param {string[]} doc - the enum docs
      */
-    addEnum(fq, name, kvs) {
+    addEnum(fq, name, kvs, doc) {
         this.enums.data.push({ name, fq, kvs })
-        printEnum(this.enums.buffer, name, kvs)
+        printEnum(this.enums.buffer, name, kvs, {}, doc)
     }
 
     /**
@@ -266,6 +267,7 @@ class SourceFile extends File {
      * @param {string} entityFqName - name of the entity the enum is attached to with namespace
      * @param {string} propertyName - property to which the enum is attached.
      * @param {[string, string][]} kvs - list of key-value pairs
+     * @param {string[]} doc - the enum docs
      *  If given, the enum is considered to be an inline definition of an enum.
      *  If not, it is considered to be regular, named enum.
      * @example
@@ -289,14 +291,14 @@ class SourceFile extends File {
      * }
      * ```
      */
-    addInlineEnum(entityCleanName, entityFqName, propertyName, kvs) {
+    addInlineEnum(entityCleanName, entityFqName, propertyName, kvs, doc=[]) {
         this.enums.data.push({
             name: `${entityCleanName}.${propertyName}`,
             property: propertyName,
             kvs,
             fq: `${entityCleanName}.${propertyName}`
         })
-        printEnum(this.inlineEnums.buffer, propertyToInlineEnumName(entityCleanName, propertyName), kvs, {export: false})
+        printEnum(this.inlineEnums.buffer, propertyToInlineEnumName(entityCleanName, propertyName), kvs, {export: false}, doc)
     }
 
     /**

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -263,8 +263,10 @@ class Visitor {
 
                 buffer.addIndented(() => {
                     for (const e of enums) {
+                        const eDoc = docify(e.doc)
+                        eDoc.forEach(d => { buffer.add(d) })
                         buffer.add(`static ${e.name} = ${propertyToInlineEnumName(clean, e.name)}`)
-                        file.addInlineEnum(clean, fq, e.name, csnToEnumPairs(e, {unwrapVals: true}))
+                        file.addInlineEnum(clean, fq, e.name, csnToEnumPairs(e, {unwrapVals: true}), eDoc)
                     }
                     this.#printStaticActions(entity, buffer, ancestorInfos, file)
                 })
@@ -273,6 +275,7 @@ class Visitor {
 
         // CLASS WITH ADDED ASPECTS
         file.addImport(baseDefinitions.path)
+        docify(entity.doc).forEach(d => { buffer.add(d) })
         buffer.add(`export class ${identSingular(clean)} extends ${identAspect(toLocalIdent({clean, fq}))}(${baseDefinitions.path.asIdentifier()}.Entity) {${this.#staticClassContents(clean, entity).join('\n')}}`)
         this.contexts.pop()
     }
@@ -332,7 +335,6 @@ class Visitor {
         // which would not be possible while already in singular form, as "Book.text" could not be resolved in CSN.
         // edge case: @singular annotation present. singular4 will take care of that.
         file.addInflection(util.singular4(entity, true), plural, clean)
-        docify(entity.doc).forEach(d => { buffer.add(d) })
 
         // in case of projections `entity` is empty -> retrieve from inferred csn where the actual properties are rolled out
         const target = isProjection(entity) || isView(entity)
@@ -359,6 +361,7 @@ class Visitor {
             // so it can get passed as value to CQL functions.
             const additionalProperties = this.#staticClassContents(singular, entity)
             additionalProperties.push('$count?: number')
+            docify(entity.doc).forEach(d => { buffer.add(d) })
             buffer.add(`export class ${plural} extends Array<${singular}> {${additionalProperties.join('\n')}}`)
             buffer.add(overrideNameProperty(plural, entity.name))
         }
@@ -445,7 +448,7 @@ class Visitor {
         // "Base" enums will always have a builtin type (don't skip those).
         // A type referencing an enum E will be considered an enum itself and have .type === E (skip).
         if (isEnum(type) && !isReferenceType(type) && this.resolver.builtinResolver.resolveBuiltin(type.type)) {
-            file.addEnum(fq, entityName, csnToEnumPairs(type))
+            file.addEnum(fq, entityName, csnToEnumPairs(type), docify(type.doc))
         } else {
             const isEnumReference = typeof type.type === 'string' && isEnum(this.csn.inferred.definitions[type?.type])
             // alias

--- a/test/unit/files/enums/model.cds
+++ b/test/unit/files/enums/model.cds
@@ -1,7 +1,12 @@
 namespace enums_test;
 
+/** Gender */
 type Gender : String enum { male; female; non_binary = 'non-binary'; }
+
+/** Truthy */
 type Truthy : Boolean enum { yes = true; no = false; yesnt = false; catchall = 42 }
+
+/** Status */
 type Status : Integer enum {
     submitted =  1;
     unknown = 0;
@@ -14,17 +19,20 @@ type TypeWithInlineEnum {
 }
 
 entity InlineEnums {
-    gender: String enum { 
-        male; 
-        female; 
+    /** gender */
+    gender: String enum {
+        male;
+        female;
         non_binary = 'non-binary';
     };
+    /** status */
     status : Integer enum {
         submitted =  1;
         fulfilled =  2;
         shipped   =  42;
         canceled  = -1;
     };
+    /** bool */
     yesno: Boolean enum {
         yes = true;
         no = false;
@@ -33,6 +41,9 @@ entity InlineEnums {
     };
 }
 
+/**
+ * entity with enums
+ */
 entity ExternalEnums {
     status : Status;
     gender: Gender;


### PR DESCRIPTION
Add docs to exposed artifacts so that they appear in code completion etc.

- for enums: on the exported const and the element pointing to it
- for entities: on the exported class, not the aspect
