### PR TITLE
Snake case options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.27.0 - TBD
+### Changed
+- Any configuration variable (via CLI or `cds.env`) can now be passed in snake_case in addition to camelCase
 
 ## Version 0.26.0 - 2024-09-11
 ### Added

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,7 +3,6 @@
 'use strict'
 
 /**
- * @typedef {import('./typedefs').config.cli.EnrichedParameter} EnrichedParameter
  * @typedef {import('./typedefs').config.cli.Parameter} Parameter
  */
 
@@ -40,12 +39,11 @@ const parameterTypes = {
  */
 const enrichFlagSchema = flags => {
     for (const [key, value] of Object.entries(flags)) {
-        /** @type {EnrichedParameter} */(value).camel = key;
-        /** @type {EnrichedParameter} */(value).snake = camelToSnake(key)
+        /** @type {Parameter} */(value).camel = key;
+        /** @type {Parameter} */(value).snake = camelToSnake(key)
     }
     // @ts-expect-error
     flags.hasFlag = flag => Object.values(flags).some(f => f.snake === flag || f.camel === flag)
-    // @ts-expect-error - ts can't understand the morph from the parameter to the return type by adding properties
     return camelSnakeHybrid(flags)
 }
 
@@ -75,6 +73,7 @@ const parseCommandlineArgs = (argv, schema) => {
         let arg = originalArgName
         if (isFlag(arg)) {
             arg = camelToSnake(arg.slice(2))
+            // @ts-expect-error - cba to add hasFlag to the general dictionary
             if (!schema.hasFlag(arg)) {
                 throw new Error(`invalid named flag '${arg}'`)
             }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -2,20 +2,138 @@
 /* eslint-disable no-console */
 'use strict'
 
+/**
+ * @typedef {import('./typedefs').config.cli.EnrichedParameter} EnrichedParameter
+ * @typedef {import('./typedefs').config.cli.Parameter} Parameter
+ */
+
 const cds = require('@sap/cds')
 const { compileFromFile } = require('./compile')
 const { camelToSnake } = require('./util')
-const { parseCommandlineArgs, camelSnakeHybrid, paramsPlusEnv, parameterTypes } = require('./config')
 const { deprecated, _keyFor } = require('./logging')
 const path = require('path')
 const { EOL } = require('node:os')
-const { enrichFlagSchema } = require('./config')
+const { camelSnakeHybrid, configuration } = require('./config')
 
 const EOL2 = EOL + EOL
 const toolName = 'cds-typer'
-
 // @ts-expect-error - nope, it is actually there. Types just seem to be out of sync.
 const lls = cds.log.levels
+const parameterTypes = {
+    boolean:
+    /**
+     * @param {Parameter} props - additional parameter properties
+     * @returns {Parameter}
+     */
+    props => ({...{
+        allowed: ['true', 'false'],
+        type: 'boolean',
+        postprocess: (/** @type {string} */ value) => value === 'true'
+    },
+    ...props})
+}
+
+/**
+ * Adds additional properties to the CLI parameter schema.
+ * @param {{ [key: string]: import('./typedefs').config.cli.Parameter }} flags - The CLI parameter schema.
+ * @returns {import('./typedefs').config.cli.ParameterSchema} - The enriched schema.
+ */
+const enrichFlagSchema = flags => {
+    for (const [key, value] of Object.entries(flags)) {
+        /** @type {EnrichedParameter} */(value).camel = key;
+        /** @type {EnrichedParameter} */(value).snake = camelToSnake(key)
+    }
+    // @ts-expect-error
+    flags.hasFlag = flag => Object.values(flags).some(f => f.snake === flag || f.camel === flag)
+    // @ts-expect-error - ts can't understand the morph from the parameter to the return type by adding properties
+    return camelSnakeHybrid(flags)
+}
+
+/**
+ * Parses command line arguments into named and positional parameters.
+ * Named parameters are expected to start with a double dash (--).
+ * If the next argument `B` after a named parameter `A` is not a named parameter itself,
+ * `B` is used as value for `A`.
+ * If `A` and `B` are both named parameters, `A` is just treated as a flag (and may receive a default value).
+ * Only named parameters that occur in validFlags are allowed. Specifying named flags that are not listed there
+ * will cause an error.
+ * Named parameters that are either not specified or do not have a value assigned to them may draw a default value
+ * from their definition in validFlags.
+ * @param {string[]} argv - list of command line arguments
+ * @param {import('./typedefs').config.cli.ParameterSchema} schema - allowed flags. May specify default values.
+ * @returns {{ positional: string[], named: { [key: string]: import('./typedefs').config.cli.EffectiveParameter } }} - parsed arguments
+ */
+const parseCommandlineArgs = (argv, schema) => {
+    const isFlag = (/** @type {string} */ arg) => arg.startsWith('--')
+    const positional = []
+    /** @type {{[key: string]: import('./typedefs').config.cli.EffectiveParameter}} */
+    const named = {}
+
+    let i = 0
+    while (i < argv.length) {
+        const originalArgName = argv[i]  // so our feedback to the user is less confusing
+        let arg = originalArgName
+        if (isFlag(arg)) {
+            arg = camelToSnake(arg.slice(2))
+            if (!schema.hasFlag(arg)) {
+                throw new Error(`invalid named flag '${arg}'`)
+            }
+            const next = argv[i + 1]
+            if (next && !isFlag(next)) {
+                named[arg] = { value: next, isDefault: false }
+                i++
+            } else {
+                named[arg] = { value: schema[arg].default, isDefault: true }
+            }
+
+            const { allowed, allowedHint } = schema[arg]
+            if (allowed && !allowed.includes(named[arg].value)) {
+                throw new Error(`invalid value '${named[arg]}' for flag ${originalArgName}. Must be one of ${(allowedHint ?? allowed.join(', '))}`)
+            }
+        } else {
+            positional.push(arg)
+        }
+        i++
+    }
+
+    // enrich with defaults
+    /** @type {{[key: string]: import('./typedefs').config.cli.EffectiveParameter}} */
+    const defaults = Object.entries(schema)
+        .filter(e => !!e[1].default)
+        .reduce((dict, [k, v]) => {
+            // @ts-expect-error - can't infer type of initial {}
+            dict[camelToSnake(k)] = { value: v.default, isDefault: true }
+            return dict
+        }, {})
+
+    const namedWithDefaults = {...defaults, ...named}
+
+    // apply postprocessing
+    for (const [key, {value}] of Object.entries(namedWithDefaults)) {
+        const { postprocess } = schema[key]
+        if (typeof postprocess === 'function') {
+            namedWithDefaults[key].value = postprocess(value)
+        }
+    }
+
+    return {
+        named: namedWithDefaults,
+        positional,
+    }
+}
+
+/**
+ * Adds CLI parameters to the configuration object.
+ * Precedence: CLI > env > default.
+ * @param {ReturnType<parseCommandlineArgs>['named']} params - CLI parameters.
+ */
+const addCLIParamsToConfig = params => {
+    for (const [key, value] of Object.entries(params)) {
+        if (!value.isDefault || Object.hasOwn(configuration, key)) {
+            configuration[key] = value.value
+        }
+    }
+}
 
 const flags = enrichFlagSchema({
     outputDirectory: {
@@ -106,7 +224,9 @@ const help = () => `SYNOPSIS${EOL2}` +
 
 const version = () => require('../package.json').version
 
-const main = async (/** @type {any} */ args) => {
+const main = async (/** @type {any} */ argv) => {
+    const args = parseCommandlineArgs(argv, flags)
+
     if ('help' in args.named) {
         console.log(help())
         process.exit(0)
@@ -119,9 +239,12 @@ const main = async (/** @type {any} */ args) => {
         console.log(hint())
         process.exit(1)
     }
-    compileFromFile(args.positional, paramsPlusEnv(args.named, cds?.env?.typer ?? {}))
+
+    addCLIParamsToConfig(args.named)
+
+    compileFromFile(args.positional)
 }
 
 if (require.main === module) {
-    main(parseCommandlineArgs(process.argv.slice(2), flags))
+    main(process.argv.slice(2))
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -32,6 +32,14 @@ const flags = enrichFlagSchema({
         allowedHint: Object.keys(lls).join(' | '),  // FIXME: remove once old levels are faded out
         defaultHint: _keyFor(lls.ERROR),
         default: cds?.env?.log?.levels?.['cds-typer'] ?? _keyFor(lls.ERROR),
+        postprocess: level => {
+            const newLogLevel = deprecated[level]
+            if (newLogLevel) {
+                console.warn(`deprecated log level '${level}', use '${newLogLevel}' instead (changing this automatically for now).`)
+                return newLogLevel
+            }
+            return level
+        }
     },
     jsConfigPath: {
         desc: `Path to where the jsconfig.json should be written.${EOL}If specified, ${toolName} will create a jsconfig.json file and${EOL}set it up to restrict property usage in types entities to${EOL}existing properties only.`,
@@ -111,23 +119,7 @@ const main = async (/** @type {any} */ args) => {
         console.log(hint())
         process.exit(1)
     }
-    const newLogLevel = deprecated[args.named.logLevel]
-    if (newLogLevel) {
-        console.warn(`deprecated log level '${args.named.logLevel}', use '${newLogLevel}' instead (changing this automatically for now).`)
-        args.named.logLevel = newLogLevel
-    }
-
-    const effectiveParameters = paramsPlusEnv(args.named, cds?.env?.typer ?? {})
-    compileFromFile(args.positional, camelSnakeHybrid({
-        // temporary fix until rootDir is faded out
-        outputDirectory: [args.named.outputDirectory, args.named.rootDir].find(d => d !== './') ?? './',
-        logLevel: args.named.logLevel,
-        useEntitiesProxy: args.named.useEntitiesProxy === 'true',
-        jsConfigPath: args.named.jsConfigPath,
-        inlineDeclarations: args.named.inlineDeclarations,
-        propertiesOptional: args.named.propertiesOptional === 'true',
-        IEEE754Compatible: args.named.IEEE754Compatible === 'true'
-    }))
+    compileFromFile(args.positional, paramsPlusEnv(args.named, cds?.env?.typer ?? {}))
 }
 
 if (require.main === module) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,10 +4,12 @@
 
 const cds = require('@sap/cds')
 const { compileFromFile } = require('./compile')
-const { parseCommandlineArgs } = require('./util')
+const { camelToSnake } = require('./util')
+const { parseCommandlineArgs, camelSnakeHybrid, paramsPlusEnv, parameterTypes } = require('./config')
 const { deprecated, _keyFor } = require('./logging')
 const path = require('path')
 const { EOL } = require('node:os')
+const { enrichFlagSchema } = require('./config')
 
 const EOL2 = EOL + EOL
 const toolName = 'cds-typer'
@@ -15,7 +17,7 @@ const toolName = 'cds-typer'
 // @ts-expect-error - nope, it is actually there. Types just seem to be out of sync.
 const lls = cds.log.levels
 
-const flags = {
+const flags = enrichFlagSchema({
     outputDirectory: {
         desc: 'Root directory to write the generated files to.',
         default: './',
@@ -33,13 +35,13 @@ const flags = {
     },
     jsConfigPath: {
         desc: `Path to where the jsconfig.json should be written.${EOL}If specified, ${toolName} will create a jsconfig.json file and${EOL}set it up to restrict property usage in types entities to${EOL}existing properties only.`,
-        type: 'string'
+        type: 'string',
+        postprocess: file => file && !file.endsWith('jsconfig.json') ? path.join(file, 'jsconfig.json') : path
     },
-    useEntitiesProxy: {
+    useEntitiesProxy: parameterTypes.boolean({
         desc: `If set to true the 'cds.entities' exports in the generated 'index.js'${EOL}files will be wrapped in 'Proxy' objects\nso static import/require calls can be used everywhere.${EOL}${EOL}WARNING: entity properties can still only be accessed after${EOL}'cds.entities' has been loaded`,
-        allowed: ['true', 'false'],
         default: 'false'
-    },
+    }),
     version: {
         desc: 'Prints the version of this tool.'
     },
@@ -48,17 +50,15 @@ const flags = {
         allowed: ['flat', 'structured'],
         default: 'structured'
     },
-    propertiesOptional: {
+    propertiesOptional: parameterTypes.boolean({
         desc: `If set to true, properties in entities are${EOL}always generated as optional (a?: T).`,
-        allowed: ['true', 'false'],
         default: 'true'
-    },
-    IEEE754Compatible: {
+    }),
+    IEEE754Compatible: parameterTypes.boolean({
         desc: `If set to true, floating point properties are generated${EOL}as IEEE754 compatible '(number | string)' instead of 'number'.`,
-        allowed: ['true', 'false'],
         default: 'false'
-    }
-}
+    })
+})
 
 const hint = () => 'Missing or invalid parameter(s). Call with --help for more details.'
 /**
@@ -78,15 +78,17 @@ const help = () => `SYNOPSIS${EOL2}` +
                 .sort(([a], [b]) => a.localeCompare(b))
                 .map(([key, value]) => {
                     let s = indent(`--${key}`, '  ')
-                    // @ts-expect-error - not going to check presence of each property. Same for the following expect-errors.
+                    const snake = camelToSnake(key)
+                    if (key !== snake) s += EOL + indent(`--${snake}`, '  ')
+                    // ts-expect-error - not going to check presence of each property. Same for the following expect-errors.
                     if (value.allowedHint) s += ` ${value.allowedHint}`
-                    // @ts-expect-error
+                    // ts-expect-error
                     else if (value.allowed) s += `: <${value.allowed.join(' | ')}>`
                     else if ('type' in value && value.type) s += `: <${value.type}>`
-                    // @ts-expect-error
+                    // ts-expect-error
                     if (value.defaultHint || value.default) {
                         s += EOL
-                        // @ts-expect-error
+                        // ts-expect-error
                         s += indent(`(default: ${value.defaultHint ?? value.default})`, '    ')
                     }
                     s += `${EOL2}${indent(value.desc, '    ')}`
@@ -109,16 +111,14 @@ const main = async (/** @type {any} */ args) => {
         console.log(hint())
         process.exit(1)
     }
-    if (args.named.jsConfigPath && !args.named.jsConfigPath.endsWith('jsconfig.json')) {
-        args.named.jsConfigPath = path.join(args.named.jsConfigPath, 'jsconfig.json')
-    }
     const newLogLevel = deprecated[args.named.logLevel]
     if (newLogLevel) {
         console.warn(`deprecated log level '${args.named.logLevel}', use '${newLogLevel}' instead (changing this automatically for now).`)
         args.named.logLevel = newLogLevel
     }
 
-    compileFromFile(args.positional, {
+    const effectiveParameters = paramsPlusEnv(args.named, cds?.env?.typer ?? {})
+    compileFromFile(args.positional, camelSnakeHybrid({
         // temporary fix until rootDir is faded out
         outputDirectory: [args.named.outputDirectory, args.named.rootDir].find(d => d !== './') ?? './',
         logLevel: args.named.logLevel,
@@ -127,7 +127,7 @@ const main = async (/** @type {any} */ args) => {
         inlineDeclarations: args.named.inlineDeclarations,
         propertiesOptional: args.named.propertiesOptional === 'true',
         IEEE754Compatible: args.named.IEEE754Compatible === 'true'
-    })
+    }))
 }
 
 if (require.main === module) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -34,7 +34,7 @@ const parameterTypes = {
 
 /**
  * Adds additional properties to the CLI parameter schema.
- * @param {{ [key: string]: import('./typedefs').config.cli.Parameter }} flags - The CLI parameter schema.
+ * @param {import('./typedefs').config.cli.ParameterSchema } flags - The CLI parameter schema.
  * @returns {import('./typedefs').config.cli.ParameterSchema} - The enriched schema.
  */
 const enrichFlagSchema = flags => {
@@ -59,12 +59,12 @@ const enrichFlagSchema = flags => {
  * from their definition in validFlags.
  * @param {string[]} argv - list of command line arguments
  * @param {import('./typedefs').config.cli.ParameterSchema} schema - allowed flags. May specify default values.
- * @returns {{ positional: string[], named: { [key: string]: import('./typedefs').config.cli.EffectiveParameter } }} - parsed arguments
+ * @returns {import('./typedefs').config.cli.ParsedParameters} - parsed arguments
  */
 const parseCommandlineArgs = (argv, schema) => {
     const isFlag = (/** @type {string} */ arg) => arg.startsWith('--')
     const positional = []
-    /** @type {{[key: string]: import('./typedefs').config.cli.EffectiveParameter}} */
+    /** @type {import('./typedefs').config.cli.ParsedParameters['named']} */
     const named = {}
 
     let i = 0
@@ -75,7 +75,7 @@ const parseCommandlineArgs = (argv, schema) => {
             arg = camelToSnake(arg.slice(2))
             // @ts-expect-error - cba to add hasFlag to the general dictionary
             if (!schema.hasFlag(arg)) {
-                throw new Error(`invalid named flag '${arg}'`)
+                throw new Error(`invalid named flag '${originalArgName}'`)
             }
             const next = argv[i + 1]
             if (next && !isFlag(next)) {
@@ -87,7 +87,7 @@ const parseCommandlineArgs = (argv, schema) => {
 
             const { allowed, allowedHint } = schema[arg]
             if (allowed && !allowed.includes(named[arg].value)) {
-                throw new Error(`invalid value '${named[arg]}' for flag ${originalArgName}. Must be one of ${(allowedHint ?? allowed.join(', '))}`)
+                throw new Error(`invalid value '${named[arg]?.value ?? named[arg]}' for flag ${originalArgName}. Must be one of ${(allowedHint ?? allowed.join(', '))}`)
             }
         } else {
             positional.push(arg)
@@ -96,7 +96,7 @@ const parseCommandlineArgs = (argv, schema) => {
     }
 
     // enrich with defaults
-    /** @type {{[key: string]: import('./typedefs').config.cli.EffectiveParameter}} */
+    /** @type {import('./typedefs').config.cli.ParameterSchema} */
     const defaults = Object.entries(schema)
         .filter(e => !!e[1].default)
         .reduce((dict, [k, v]) => {
@@ -223,7 +223,7 @@ const help = () => `SYNOPSIS${EOL2}` +
 
 const version = () => require('../package.json').version
 
-const main = async (/** @type {any} */ argv) => {
+const prepareParameters = (/** @type {any[]} */ argv) => {
     const args = parseCommandlineArgs(argv, flags)
 
     if ('help' in args.named) {
@@ -240,10 +240,19 @@ const main = async (/** @type {any} */ argv) => {
     }
 
     addCLIParamsToConfig(args.named)
+    return args
+}
 
-    compileFromFile(args.positional)
+const main = async (/** @type {any[]} */ argv) => {
+    const { positional } = prepareParameters(argv)
+    compileFromFile(positional)
 }
 
 if (require.main === module) {
     main(process.argv.slice(2))
+}
+
+module.exports = {
+    flags,
+    prepareParameters
 }

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -10,10 +10,6 @@ const { LOG, setLevel } = require('./logging')
 const { configuration } = require('./config')
 
 /**
- * @typedef {import('./typedefs').visitor.CompileParameters} CompileParameters
- */
-
-/**
  * Writes the accompanying jsconfig.json file to the specified paths.
  * Tries to merge nicely if an existing file is found.
  * @param {string} path - filepath to jsconfig.json.

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -7,6 +7,7 @@ const util = require('./util')
 const { writeout } = require('./file')
 const { Visitor } = require('./visitor')
 const { LOG, setLevel } = require('./logging')
+const { configuration } = require('./config')
 
 /**
  * @typedef {import('./typedefs').visitor.CompileParameters} CompileParameters
@@ -40,31 +41,28 @@ const writeJsConfig = path => {
 /**
  * Compiles a CSN object to Typescript types.
  * @param {{xtended: import('./typedefs').resolver.CSN, inferred: import('./typedefs').resolver.CSN}} csn - csn tuple
- * @param {CompileParameters} parameters - path to root directory for all generated files, min log level
  */
-const compileFromCSN = async (csn, parameters) => {
-    const envSettings = cds.env?.typer ?? {}
-    parameters = { ...envSettings, ...parameters }
-    setLevel(parameters.logLevel)
-    if (parameters.jsConfigPath) {
-        writeJsConfig(parameters.jsConfigPath)
+const compileFromCSN = async csn => {
+
+    setLevel(configuration.logLevel)
+    if (configuration.jsConfigPath) {
+        writeJsConfig(configuration.jsConfigPath)
     }
     return writeout(
-        parameters.outputDirectory,
-        Object.values(new Visitor(csn, parameters).getWriteoutFiles())
+        configuration.outputDirectory,
+        Object.values(new Visitor(csn).getWriteoutFiles())
     )
 }
 
 /**
  * Compiles a .cds file to Typescript types.
  * @param {string | string[]} inputFile - path to input .cds file
- * @param {ReturnType<import('./config').paramsPlusEnv>} parameters - path to root directory for all generated files, min log level, etc.
  */
-const compileFromFile = async (inputFile, parameters) => {
+const compileFromFile = async inputFile => {
     const paths = typeof inputFile === 'string' ? normalize(inputFile) : inputFile.map(f => normalize(f))
     const xtended = await cds.linked(await cds.load(paths, { docs: true, flavor: 'xtended' }))
     const inferred = await cds.linked(await cds.load(paths, { docs: true }))
-    return compileFromCSN({xtended, inferred}, parameters)
+    return compileFromCSN({xtended, inferred})
 }
 
 module.exports = {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -58,7 +58,7 @@ const compileFromCSN = async (csn, parameters) => {
 /**
  * Compiles a .cds file to Typescript types.
  * @param {string | string[]} inputFile - path to input .cds file
- * @param {CompileParameters} parameters - path to root directory for all generated files, min log level, etc.
+ * @param {ReturnType<import('./config').paramsPlusEnv>} parameters - path to root directory for all generated files, min log level, etc.
  */
 const compileFromFile = async (inputFile, parameters) => {
     const paths = typeof inputFile === 'string' ? normalize(inputFile) : inputFile.map(f => normalize(f))

--- a/lib/components/inline.js
+++ b/lib/components/inline.js
@@ -1,3 +1,4 @@
+const { configuration } = require('../config')
 const { SourceFile, Buffer } = require('../file')
 const { normalise } = require('./identifier')
 const { docify } = require('./wrappers')
@@ -94,7 +95,7 @@ class InlineDeclarationResolver {
      * @returns {'?:'|':'}
      */
     getPropertyTypeSeparator() {
-        return this.visitor.options.propertiesOptional ? '?:' : ':'
+        return configuration.propertiesOptional ? '?:' : ':'
     }
 
     /**

--- a/lib/config.js
+++ b/lib/config.js
@@ -38,7 +38,7 @@ class Config {
     }
 
     constructor() {
-        this.values = {...Config.#defaults, ...(cds?.env?.typer ?? {})}
+        this.values = {...Config.#defaults, ...(cds.env.typer ?? {})}
         this.proxy = camelSnakeHybrid(this.values)
         // proxy around config still allows arbitrary property access:
         // require('config').configuration.logLevel = 'warn' will work

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,11 @@
 const { camelToSnake } = require('./util')
 
 /**
+ * @typedef {import('./typedefs').config.cli.EnrichedParameter} EnrichedParameter
+ * @typedef {import('./typedefs').config.cli.Parameter} Parameter
+ */
+
+/**
  * Makes properties of an object accessible in both camelCase and snake_case.
  * Snake_case gets precedence over camelCase.
  * @template T
@@ -8,19 +13,25 @@ const { camelToSnake } = require('./util')
  * @returns {T} - The proxied object.
  */
 const camelSnakeHybrid = target => {
+    // @ts-expect-error - expecting target to be of type {}, which is not T (same for following)
     const proxy = new Proxy(target, {
         get(target, prop) {
+            // @ts-expect-error
             return target[camelToSnake(prop)] ?? target[prop]
         },
         set(target, p, v) {
+            // @ts-expect-error
             target[camelToSnake(p)] = v
             return true
         }
     })
     // need to make sure all properties are initially available in snake_case
+    // @ts-expect-error
     for (const [k,v] of Object.entries(target)) {
+        // @ts-expect-error
         proxy[k] = v
     }
+    // @ts-expect-error
     return proxy
 }
 
@@ -31,8 +42,8 @@ const camelSnakeHybrid = target => {
  */
 const enrichFlagSchema = flags => {
     for (const [key, value] of Object.entries(flags)) {
-        /** @type {import('./typedefs').config.cli.EnrichedParameter} */(value).camel = key;
-        /** @type {import('./typedefs').config.cli.EnrichedParameter} */(value).snake = camelToSnake(key)
+        /** @type {EnrichedParameter} */(value).camel = key;
+        /** @type {EnrichedParameter} */(value).snake = camelToSnake(key)
     }
     // @ts-expect-error
     flags.hasFlag = flag => Object.values(flags).some(f => f.snake === flag || f.camel === flag)
@@ -121,12 +132,12 @@ const parseCommandlineArgs = (argv, schema) => {
  * @returns {{[key: string]: any}} merged parameters
  */
 const paramsPlusEnv = (params, env) => camelSnakeHybrid({
-    ...Object.entries(params).reduce((acc, [k, v]) => {
+    ...Object.entries(params).reduce((/** @type {{[key: string]: any}} */ acc, [k, v]) => {
         if (v.isDefault) acc[k] = v.value
         return acc
     }, {}),
     ...env,
-    ...Object.entries(params).reduce((acc, [k, v]) => {
+    ...Object.entries(params).reduce((/** @type {{[key: string]: any}} */ acc, [k, v]) => {
         if (!v.isDefault) acc[k] = v.value
         return acc
     }, {})
@@ -135,8 +146,8 @@ const paramsPlusEnv = (params, env) => camelSnakeHybrid({
 const parameterTypes = {
     boolean:
     /**
-     * @param {import('./typedefs').config.cli.Parameter} props
-     * @returns {import('./typedefs').config.cli.Parameter}
+     * @param {Parameter} props - additional parameter properties
+     * @returns {Parameter}
      */
     props => ({...{
         allowed: ['true', 'false'],

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,9 +1,5 @@
+const cds = require('@sap/cds')
 const { camelToSnake } = require('./util')
-
-/**
- * @typedef {import('./typedefs').config.cli.EnrichedParameter} EnrichedParameter
- * @typedef {import('./typedefs').config.cli.Parameter} Parameter
- */
 
 /**
  * Makes properties of an object accessible in both camelCase and snake_case.
@@ -34,133 +30,69 @@ const camelSnakeHybrid = target => {
     // @ts-expect-error
     return proxy
 }
-
-/**
- * Adds additional properties to the CLI parameter schema.
- * @param {{ [key: string]: import('./typedefs').config.cli.Parameter }} flags - The CLI parameter schema.
- * @returns {import('./typedefs').config.cli.ParameterSchema} - The enriched schema.
- */
-const enrichFlagSchema = flags => {
-    for (const [key, value] of Object.entries(flags)) {
-        /** @type {EnrichedParameter} */(value).camel = key;
-        /** @type {EnrichedParameter} */(value).snake = camelToSnake(key)
+class Config {
+    static #defaults = {
+        propertiesOptional: true,
+        useEntitiesProxy: false,
+        inlineDeclarations: 'flat'
     }
-    // @ts-expect-error
-    flags.hasFlag = flag => Object.values(flags).some(f => f.snake === flag || f.camel === flag)
-    // @ts-expect-error - ts can't understand the morph from the parameter to the return type by adding properties
-    return camelSnakeHybrid(flags)
-}
 
-/**
- * Parses command line arguments into named and positional parameters.
- * Named parameters are expected to start with a double dash (--).
- * If the next argument `B` after a named parameter `A` is not a named parameter itself,
- * `B` is used as value for `A`.
- * If `A` and `B` are both named parameters, `A` is just treated as a flag (and may receive a default value).
- * Only named parameters that occur in validFlags are allowed. Specifying named flags that are not listed there
- * will cause an error.
- * Named parameters that are either not specified or do not have a value assigned to them may draw a default value
- * from their definition in validFlags.
- * @param {string[]} argv - list of command line arguments
- * @param {import('./typedefs').config.cli.ParameterSchema} schema - allowed flags. May specify default values.
- * @returns {{ positional: string[], named: { [key: string]: import('./typedefs').config.cli.EffectiveParameter } }} - parsed arguments
- */
-const parseCommandlineArgs = (argv, schema) => {
-    const isFlag = (/** @type {string} */ arg) => arg.startsWith('--')
-    const positional = []
-    /** @type {{[key: string]: import('./typedefs').config.cli.EffectiveParameter}} */
-    const named = {}
-
-    let i = 0
-    while (i < argv.length) {
-        const originalArgName = argv[i]  // so our feedback to the user is less confusing
-        let arg = originalArgName
-        if (isFlag(arg)) {
-            arg = camelToSnake(arg.slice(2))
-            if (!schema.hasFlag(arg)) {
-                throw new Error(`invalid named flag '${arg}'`)
-            } else {
-                //arg = flagsWithSnakeKeys[arg].canonicalName
-                const next = argv[i + 1]
-                if (next && !isFlag(next)) {
-                    named[arg] = { value: next, isDefault: false }
-                    i++
+    constructor() {
+        this.values = {...Config.#defaults, ...(cds?.env?.typer ?? {})}
+        this.proxy = camelSnakeHybrid(this.values)
+        // proxy around config still allows arbitrary property access:
+        // require('config').configuration.logLevel = 'warn' will work
+        // eslint-disable-next-line no-constructor-return
+        return new Proxy(this, {
+            get(target, prop) {
+                return target[prop] ?? target.proxy[prop]
+            },
+            set(target, p, v) {
+                if (target[p]) {
+                    target[p] = v
                 } else {
-                    named[arg] = { value: schema[arg].default, isDefault: true }
+                    target.proxy[p] = v
                 }
-
-                const { allowed, allowedHint } = schema[arg]
-                if (allowed && !allowed.includes(named[arg].value)) {
-                    throw new Error(`invalid value '${named[arg]}' for flag ${originalArgName}. Must be one of ${(allowedHint ?? allowed.join(', '))}`)
-                }
+                return true
             }
-        } else {
-            positional.push(arg)
-        }
-        i++
+        })
     }
 
-    // enrich with defaults
-    /** @type {{[key: string]: import('./typedefs').config.cli.EffectiveParameter}} */
-    const defaults = Object.entries(schema)
-        .filter(e => !!e[1].default)
-        .reduce((dict, [k, v]) => {
-            // @ts-expect-error - can't infer type of initial {}
-            dict[camelToSnake(k)] = { value: v.default, isDefault: true }
-            return dict
-        }, {})
-
-    const namedWithDefaults = {...defaults, ...named}
-
-    // apply postprocessing
-    for (const [key, {value}] of Object.entries(namedWithDefaults)) {
-        const { postprocess } = schema[key]
-        if (typeof postprocess === 'function') {
-            namedWithDefaults[key].value = postprocess(value)
-        }
-    }
-
-    return {
-        named: namedWithDefaults,
-        positional,
-    }
-}
-
-/**
- * @param {ReturnType<parseCommandlineArgs>['named']} params - CLI parameters.
- * @param {{[key: string]: any}} env - cds.env.typer
- * @returns {{[key: string]: any}} merged parameters
- */
-const paramsPlusEnv = (params, env) => camelSnakeHybrid({
-    ...Object.entries(params).reduce((/** @type {{[key: string]: any}} */ acc, [k, v]) => {
-        if (v.isDefault) acc[k] = v.value
-        return acc
-    }, {}),
-    ...env,
-    ...Object.entries(params).reduce((/** @type {{[key: string]: any}} */ acc, [k, v]) => {
-        if (!v.isDefault) acc[k] = v.value
-        return acc
-    }, {})
-})
-
-const parameterTypes = {
-    boolean:
     /**
-     * @param {Parameter} props - additional parameter properties
-     * @returns {Parameter}
+     * @param {string} key - The key to set.
+     * @param {any} value - The value to set
      */
-    props => ({...{
-        allowed: ['true', 'false'],
-        type: 'boolean',
-        postprocess: (/** @type {string} */ value) => value === 'true'
-    },
-    ...props})
+    setOne (key, value) {
+        this.proxy[key] = value
+    }
+
+    /**
+     * @param {object} props - The properties to set.
+     */
+    setMany (props) {
+        for (const [k,v] of Object.entries(props)) {
+            this.proxy[k] = v
+        }
+    }
+
+    /**
+     * Resets the config value and sets all its values from another passed
+     * config object. This allows to keep the reference to the same object.
+     * @param {Config} config - Another config object to set all config entries from.
+     */
+    setFrom (config) {
+        this.values = camelSnakeHybrid({})
+        this.setMany(config.values)
+    }
+
+    clone () {
+        const res = new Config()
+        res.setMany(this.values)
+        return res
+    }
 }
 
 module.exports = {
     camelSnakeHybrid,
-    enrichFlagSchema,
-    parseCommandlineArgs,
-    paramsPlusEnv,
-    parameterTypes
+    configuration: new Config()
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -48,6 +48,7 @@ class Config {
                 return target[prop] ?? target.proxy[prop]
             },
             set(target, p, v) {
+                // this.value, this.proxy etc should not be forwarded to the wrapped values
                 if (target[p]) {
                     target[p] = v
                 } else {
@@ -94,5 +95,7 @@ class Config {
 
 module.exports = {
     camelSnakeHybrid,
+    /** @type {import('./typedefs').config.Configuration} */
+    // @ts-ignore
     configuration: new Config()
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,155 @@
+const { camelToSnake } = require('./util')
+
+/**
+ * Makes properties of an object accessible in both camelCase and snake_case.
+ * Snake_case gets precedence over camelCase.
+ * @template T
+ * @param {T} target - The object to proxy.
+ * @returns {T} - The proxied object.
+ */
+const camelSnakeHybrid = target => {
+    const proxy = new Proxy(target, {
+        get(target, prop) {
+            return target[camelToSnake(prop)] ?? target[prop]
+        },
+        set(target, p, v) {
+            target[camelToSnake(p)] = v
+            return true
+        }
+    })
+    // need to make sure all properties are initially available in snake_case
+    for (const [k,v] of Object.entries(target)) {
+        proxy[k] = v
+    }
+    return proxy
+}
+
+/**
+ * Adds additional properties to the CLI parameter schema.
+ * @param {{ [key: string]: import('./typedefs').config.cli.Parameter }} flags - The CLI parameter schema.
+ * @returns {import('./typedefs').config.cli.ParameterSchema} - The enriched schema.
+ */
+const enrichFlagSchema = flags => {
+    for (const [key, value] of Object.entries(flags)) {
+        /** @type {import('./typedefs').config.cli.EnrichedParameter} */(value).camel = key;
+        /** @type {import('./typedefs').config.cli.EnrichedParameter} */(value).snake = camelToSnake(key)
+    }
+    // @ts-expect-error
+    flags.hasFlag = flag => Object.values(flags).some(f => f.snake === flag || f.camel === flag)
+    // @ts-expect-error - ts can't understand the morph from the parameter to the return type by adding properties
+    return camelSnakeHybrid(flags)
+}
+
+/**
+ * Parses command line arguments into named and positional parameters.
+ * Named parameters are expected to start with a double dash (--).
+ * If the next argument `B` after a named parameter `A` is not a named parameter itself,
+ * `B` is used as value for `A`.
+ * If `A` and `B` are both named parameters, `A` is just treated as a flag (and may receive a default value).
+ * Only named parameters that occur in validFlags are allowed. Specifying named flags that are not listed there
+ * will cause an error.
+ * Named parameters that are either not specified or do not have a value assigned to them may draw a default value
+ * from their definition in validFlags.
+ * @param {string[]} argv - list of command line arguments
+ * @param {import('./typedefs').config.cli.ParameterSchema} schema - allowed flags. May specify default values.
+ * @returns {{ positional: string[], named: { [key: string]: import('./typedefs').config.cli.EffectiveParameter } }} - parsed arguments
+ */
+const parseCommandlineArgs = (argv, schema) => {
+    const isFlag = (/** @type {string} */ arg) => arg.startsWith('--')
+    const positional = []
+    /** @type {{[key: string]: import('./typedefs').config.cli.EffectiveParameter}} */
+    const named = {}
+
+    let i = 0
+    while (i < argv.length) {
+        const originalArgName = argv[i]  // so our feedback to the user is less confusing
+        let arg = originalArgName
+        if (isFlag(arg)) {
+            arg = camelToSnake(arg.slice(2))
+            if (!schema.hasFlag(arg)) {
+                throw new Error(`invalid named flag '${arg}'`)
+            } else {
+                //arg = flagsWithSnakeKeys[arg].canonicalName
+                const next = argv[i + 1]
+                if (next && !isFlag(next)) {
+                    named[arg] = { value: next, isDefault: false }
+                    i++
+                } else {
+                    named[arg] = { value: schema[arg].default, isDefault: true }
+                }
+
+                const { allowed, allowedHint } = schema[arg]
+                if (allowed && !allowed.includes(named[arg].value)) {
+                    throw new Error(`invalid value '${named[arg]}' for flag ${originalArgName}. Must be one of ${(allowedHint ?? allowed.join(', '))}`)
+                }
+            }
+        } else {
+            positional.push(arg)
+        }
+        i++
+    }
+
+    // enrich with defaults
+    /** @type {{[key: string]: import('./typedefs').config.cli.EffectiveParameter}} */
+    const defaults = Object.entries(schema)
+        .filter(e => !!e[1].default)
+        .reduce((dict, [k, v]) => {
+            // @ts-expect-error - can't infer type of initial {}
+            dict[camelToSnake(k)] = { value: v.default, isDefault: true }
+            return dict
+        }, {})
+
+    const namedWithDefaults = {...defaults, ...named}
+
+    // apply postprocessing
+    for (const [key, {value}] of Object.entries(namedWithDefaults)) {
+        const { postprocess } = schema[key]
+        if (typeof postprocess === 'function') {
+            namedWithDefaults[key].value = postprocess(value)
+        }
+    }
+
+    return {
+        named: namedWithDefaults,
+        positional,
+    }
+}
+
+/**
+ * @param {ReturnType<parseCommandlineArgs>['named']} params - CLI parameters.
+ * @param {{[key: string]: any}} env - cds.env.typer
+ * @returns {{[key: string]: any}} merged parameters
+ */
+const paramsPlusEnv = (params, env) => camelSnakeHybrid({
+    ...Object.entries(params).reduce((acc, [k, v]) => {
+        if (v.isDefault) acc[k] = v.value
+        return acc
+    }, {}),
+    ...env,
+    ...Object.entries(params).reduce((acc, [k, v]) => {
+        if (!v.isDefault) acc[k] = v.value
+        return acc
+    }, {})
+})
+
+const parameterTypes = {
+    boolean:
+    /**
+     * @param {import('./typedefs').config.cli.Parameter} props
+     * @returns {import('./typedefs').config.cli.Parameter}
+     */
+    props => ({...{
+        allowed: ['true', 'false'],
+        type: 'boolean',
+        postprocess: (/** @type {string} */ value) => value === 'true'
+    },
+    ...props})
+}
+
+module.exports = {
+    camelSnakeHybrid,
+    enrichFlagSchema,
+    parseCommandlineArgs,
+    paramsPlusEnv,
+    parameterTypes
+}

--- a/lib/file.js
+++ b/lib/file.js
@@ -8,6 +8,7 @@ const { normalise } = require('./components/identifier')
 const { empty } = require('./components/typescript')
 const { proxyAccessFunction } = require('./components/javascript')
 const { createObjectOf } = require('./components/wrappers')
+const { configuration } = require('./config')
 
 const AUTO_GEN_NOTE = '// This is an automatically generated file. Please do not change its contents manually!'
 
@@ -109,11 +110,9 @@ class Library extends File {
 class SourceFile extends File {
     /**
      * @param {string | Path} path - path to the file
-     * @param {FileOptions} [options] - options for file output
      */
-    constructor(path, options) {
+    constructor(path) {
         super()
-        this.options = options ?? { useEntitiesProxy: false }
         /** @type {Path} */
         this.path = path instanceof Path ? path : new Path(path.split('.'))
         /** @type {{[key:string]: any}} */
@@ -437,7 +436,7 @@ class SourceFile extends File {
         const namespace = this.path.asNamespace()
 
         const boilerplate = [AUTO_GEN_NOTE]
-        if (this.options.useEntitiesProxy) {
+        if (configuration.useEntitiesProxy) {
             if (namespace === '_') {
                 boilerplate.push('const cds = require(\'@sap/cds\')', this.#getEntityProxyFunctionExport())
             } else {
@@ -460,7 +459,7 @@ class SourceFile extends File {
      * @returns {{singularRhs: string, pluralRhs: string}}
      */
     #getEntityExportsRhs(singular, original) {
-        if (this.options.useEntitiesProxy) {
+        if (configuration.useEntitiesProxy) {
             const namespace = this.path.asNamespace()
             // determine the custom properties for the proxy function call
             const customProps = this.entityProxies[singular] ?? []
@@ -698,13 +697,6 @@ class FileRepository {
     #files = {}
 
     /**
-     * @param {FileOptions} options - options to control file
-     */
-    constructor(options) {
-        this.options = options
-    }
-
-    /**
      * @param {string} name - file name
      * @param {SourceFile} file - the file
      */
@@ -720,7 +712,7 @@ class FileRepository {
      */
     getNamespaceFile(path) {
         const key = path instanceof Path ? path.asNamespace() : path
-        return (this.#files[key] ??= new SourceFile(path, this.options))
+        return (this.#files[key] ??= new SourceFile(path))
     }
 
     /**

--- a/lib/file.js
+++ b/lib/file.js
@@ -13,7 +13,6 @@ const { configuration } = require('./config')
 const AUTO_GEN_NOTE = '// This is an automatically generated file. Please do not change its contents manually!'
 
 /** @typedef {import('./typedefs').file.Namespace} Namespace */
-/** @typedef {import('./typedefs').file.FileOptions} FileOptions */
 
 class File {
     /**

--- a/lib/resolution/resolver.js
+++ b/lib/resolution/resolver.js
@@ -13,6 +13,7 @@ const { BuiltinResolver } = require('./builtin')
 const { LOG } = require('../logging')
 const { last } = require('../components/identifier')
 const { getPropertyModifiers } = require('../components/property')
+const { configuration } = require('../config')
 
 /** @typedef {import('../visitor').Visitor} Visitor */
 /** @typedef {import('../typedefs').resolver.CSN} CSN */
@@ -30,7 +31,7 @@ class Resolver {
         this.visitor = visitor
 
         /** @type {BuiltinResolver} */
-        this.builtinResolver = new BuiltinResolver(visitor.options)
+        this.builtinResolver = new BuiltinResolver({ IEEE754Compatible: configuration.IEEE754Compatible })
 
         /** @type {Library[]} */
         this.libraries = [new Library(require.resolve('../../library/cds.hana.ts'))]

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -118,13 +118,7 @@ export module util {
 
 export module visitor {
     export type CompileParameters = {
-        outputDirectory: string,
-        logLevel: number,
-        useEntitiesProxy: boolean,
-        jsConfigPath?: string,
-        inlineDeclarations: 'flat' | 'structured',
-        propertiesOptional: boolean,
-        IEEE754Compatible: boolean,
+
     }
 
     export type VisitorOptions = {
@@ -168,17 +162,14 @@ export module config {
             type?: 'string' | 'boolean' | 'number',
             default?: string,
             defaultHint?: string,
-            postprocess?: (value: string) => any
-        }
-    
-        export type EnrichedParameter = Parameter & {
-            camel: string,
-            snake: string
+            postprocess?: (value: string) => any,
+            camel?: string,
+            snake?: string
         }
     
         export type ParameterSchema = {
-            [key: string]: CLIParameter,
-            hasFlag: (flag: string) => boolean
+            [key: string]: Parameter,
+            //hasFlag: (flag: RuntimeParameters) => boolean
         }
     
         export type EffectiveParameter = {
@@ -188,8 +179,21 @@ export module config {
 
         export type ParseParameters = {
             positional: string[],
-            named: { [key: string]: EffectiveParameter }
+            named: { [key: keyof RuntimeParameters]: EffectiveParameter }
         }
+
+        export type CLIFlags = 'version' | 'help'
+    }
+
+    export type Configuration = { //'logLevel' | 'outputDirectory' | 'useEntitiesProxy' | 'inlineDeclarations' | 'propertiesOptional' | 'IEEE754Compatible'
+    //export type Configuration = {
+        outputDirectory: string,
+        logLevel: number,
+        useEntitiesProxy: boolean,
+        jsConfigPath?: string,
+        inlineDeclarations: 'flat' | 'structured',
+        propertiesOptional: boolean,
+        IEEE754Compatible: boolean
     }
 }
 

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -99,7 +99,7 @@ export module resolver {
 
 export module util {
     export type Annotations = {
-        name?: string,
+        name: string,
         '@singular'?: string,
         '@plural'?: string
     }

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -117,20 +117,6 @@ export module util {
 }
 
 export module visitor {
-    export type VisitorOptions = {
-        /** `propertiesOptional = true` -> all properties are generated as optional ?:. (standard CAP behaviour, where properties be unavailable) */
-        propertiesOptional: boolean,
-        /**
-         * `inlineDeclarations = 'structured'` -> @see {@link inline.StructuredInlineDeclarationResolver}
-         * `inlineDeclarations = 'flat'` -> @see {@link inline.FlatInlineDeclarationResolver}
-         */
-        inlineDeclarations: 'flat' | 'structured',
-        /**
-         * `useEntitiesProxy = true` will wrap the `module.exports.<entityName>` in `Proxy` objects
-         */
-        useEntitiesProxy: boolean
-    }
-
     export type Inflection = {
         typeName?: string,
         singular: string,
@@ -184,10 +170,21 @@ export module config {
     export type Configuration = {
         outputDirectory: string,
         logLevel: number,
+        /**
+         * `useEntitiesProxy = true` will wrap the `module.exports.<entityName>` in `Proxy` objects
+         */
         useEntitiesProxy: boolean,
         jsConfigPath?: string,
+        /**
+         * `inlineDeclarations = 'structured'` -> @see {@link inline.StructuredInlineDeclarationResolver}
+         * `inlineDeclarations = 'flat'` -> @see {@link inline.FlatInlineDeclarationResolver}
+         */
         inlineDeclarations: 'flat' | 'structured',
+        /** `propertiesOptional = true` -> all properties are generated as optional ?:. (standard CAP behaviour, where properties be unavailable) */
         propertiesOptional: boolean,
+        /**
+         * `IEEE754Compatible = true` -> any cds.Decimal will become `number | string`
+         */
         IEEE754Compatible: boolean
     }
 }

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -117,10 +117,6 @@ export module util {
 }
 
 export module visitor {
-    export type CompileParameters = {
-
-    }
-
     export type VisitorOptions = {
         /** `propertiesOptional = true` -> all properties are generated as optional ?:. (standard CAP behaviour, where properties be unavailable) */
         propertiesOptional: boolean,
@@ -185,8 +181,7 @@ export module config {
         export type CLIFlags = 'version' | 'help'
     }
 
-    export type Configuration = { //'logLevel' | 'outputDirectory' | 'useEntitiesProxy' | 'inlineDeclarations' | 'propertiesOptional' | 'IEEE754Compatible'
-    //export type Configuration = {
+    export type Configuration = {
         outputDirectory: string,
         logLevel: number,
         useEntitiesProxy: boolean,

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -103,17 +103,6 @@ export module util {
         '@singular'?: string,
         '@plural'?: string
     }
-
-    export type CommandLineFlags = {
-        desc: string,
-        default?: any,
-        canonicalName?: string
-    }
-
-    export type ParsedFlag = {
-        positional: string[],
-        named: { [key: string]: any }
-    }
 }
 
 export module visitor {
@@ -137,34 +126,28 @@ export module visitor {
 
 export module config {
     export module cli {
-        export type Parameter = {
-            desc: string,
-            allowed?: string[],
-            allowedHint?: string,
-            type?: 'string' | 'boolean' | 'number',
-            default?: string,
-            defaultHint?: string,
-            postprocess?: (value: string) => any,
-            camel?: string,
-            snake?: string
-        }
-    
-        export type ParameterSchema = {
-            [key: string]: Parameter,
-            //hasFlag: (flag: RuntimeParameters) => boolean
-        }
-    
-        export type EffectiveParameter = {
-            value: any,
-            isDefault: boolean,
-        }
-
-        export type ParseParameters = {
-            positional: string[],
-            named: { [key: keyof RuntimeParameters]: EffectiveParameter }
-        }
-
         export type CLIFlags = 'version' | 'help'
+        export type ParameterSchema = {
+            [key: string]: {
+                desc: string,
+                allowed?: string[],
+                allowedHint?: string,
+                type?: 'string' | 'boolean' | 'number',
+                default?: string,
+                defaultHint?: string,
+                postprocess?: (value: string) => any,
+                camel?: string,
+                snake?: string
+            }
+        }
+
+        export type ParsedParameters = {
+            positional: string[],
+            named: { [key: keyof RuntimeParameters]: {
+                value: any,
+                isDefault: boolean,
+            } }
+        }
     }
 
     export type Configuration = {
@@ -191,7 +174,4 @@ export module config {
 
 export module file {
     export type Namespace = Object<string, Buffer>
-    export type FileOptions = {
-        useEntitiesProxy: boolean
-    }
 }

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -106,7 +106,8 @@ export module util {
 
     export type CommandLineFlags = {
         desc: string,
-        default?: any
+        default?: any,
+        canonicalName?: string
     }
 
     export type ParsedFlag = {
@@ -155,6 +156,40 @@ export module visitor {
         modifier: '' | '?',
         type: string,
         doc?: string
+    }
+}
+
+export module config {
+    export module cli {
+        export type Parameter = {
+            desc: string,
+            allowed?: string[],
+            allowedHint?: string,
+            type?: 'string' | 'boolean' | 'number',
+            default?: string,
+            defaultHint?: string,
+            postprocess?: (value: string) => any
+        }
+    
+        export type EnrichedParameter = Parameter & {
+            camel: string,
+            snake: string
+        }
+    
+        export type ParameterSchema = {
+            [key: string]: CLIParameter,
+            hasFlag: (flag: string) => boolean
+        }
+    
+        export type EffectiveParameter = {
+            value: any,
+            isDefault: boolean,
+        }
+
+        export type ParseParameters = {
+            positional: string[],
+            named: { [key: string]: EffectiveParameter }
+        }
     }
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -37,6 +37,7 @@ const camelToSnake = camel => camel
  * @param {EntityCSN} csn - the CSN of an entity to check
  * @returns {string | undefined} the singular annotation or undefined
  */
+// @ts-expect-error - can not use possible undefined from find as key
 const getSingularAnnotation = csn => csn[annotations.singular.find(a => Object.hasOwn(csn, a))]
 
 /**
@@ -47,6 +48,7 @@ const getSingularAnnotation = csn => csn[annotations.singular.find(a => Object.h
  * @param {EntityCSN} csn - the CSN of an entity to check
  * @returns {string | undefined} the plural annotation or undefined
  */
+// @ts-expect-error - can not use possible undefined from find as key
 const getPluralAnnotation = csn => csn[annotations.plural.find(a => Object.hasOwn(csn, a))]
 
 /**
@@ -72,9 +74,9 @@ const unlocalize = name => {
  * @param {boolean?} stripped - if true, leading namespace will be stripped
  */
 const singular4 = (dn, stripped = false) => {
-    let n = dn.name || dn
+    let n = dn.name ?? dn
     if (stripped) {
-        n = n.match(last)[0]
+        n = n.match(last)?.[0] ?? ''
     }
     return (
         getSingularAnnotation(dn) ??
@@ -104,9 +106,9 @@ const singular4 = (dn, stripped = false) => {
  * @param {boolean} stripped - if true, leading namespace will be stripped
  */
 const plural4 = (dn, stripped) => {
-    let n = dn.name || dn
+    let n = dn.name ?? dn
     if (stripped) {
-        n = n.match(last)[0]
+        n = n.match(last)?.[0]
     }
     return (
         getPluralAnnotation(dn) ??

--- a/lib/util.js
+++ b/lib/util.js
@@ -20,6 +20,16 @@ const annotations = {
 }
 
 /**
+ * Converts a camelCase string to snake_case.
+ * @param {string} camel - The camelCase string.
+ * @returns {string} - The snake_case string.
+ */
+const camelToSnake = camel => camel
+    .replace(/([a-z])([A-Z])/g, '$1_$2') // Handle camelCase
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2') // Handle sequences of uppercase letters
+    .toLowerCase()
+
+/**
  * Tries to retrieve an annotation that specifies the singular name
  * from a CSN. Valid annotations are listed in util.annotations
  * and their precedence is in order of definition.
@@ -123,72 +133,13 @@ const deepMerge = (target, source) => {
     Object.assign(target, source)
 }
 
-/**
- * Parses command line arguments into named and positional parameters.
- * Named parameters are expected to start with a double dash (--).
- * If the next argument `B` after a named parameter `A` is not a named parameter itself,
- * `B` is used as value for `A`.
- * If `A` and `B` are both named parameters, `A` is just treated as a flag (and may receive a default value).
- * Only named parameters that occur in validFlags are allowed. Specifying named flags that are not listed there
- * will cause an error.
- * Named parameters that are either not specified or do not have a value assigned to them may draw a default value
- * from their definition in validFlags.
- * @param {string[]} argv - list of command line arguments
- * @param {{[key: string]: CommandlineFlag}} validFlags - allowed flags. May specify default values.
- * @returns {ParsedFlags}
- */
-const parseCommandlineArgs = (argv, validFlags) => {
-    const isFlag = (/** @type {string} */ arg) => arg.startsWith('--')
-    const positional = []
-    const named = {}
-
-    let i = 0
-    while (i < argv.length) {
-        let arg = argv[i]
-        if (isFlag(arg)) {
-            arg = arg.slice(2)
-            if (!(arg in validFlags)) {
-                throw new Error(`invalid named flag '${arg}'`)
-            } else {
-                const next = argv[i + 1]
-                if (next && !isFlag(next)) {
-                    named[arg] = next
-                    i++
-                } else {
-                    named[arg] = validFlags[arg].default
-                }
-
-                const { allowed, allowedHint } = validFlags[arg]
-                if (allowed && !allowed.includes(named[arg])) {
-                    throw new Error(`invalid value '${named[arg]}' for flag ${arg}. Must be one of ${(allowedHint ?? allowed.join(', '))}`)
-                }
-            }
-        } else {
-            positional.push(arg)
-        }
-        i++
-    }
-
-    const defaults = Object.entries(validFlags)
-        .filter(e => !!e[1].default)
-        .reduce((dict, [k, v]) => {
-            dict[k] = v.default
-            return dict
-        }, {})
-
-    return {
-        named: Object.assign(defaults, named),
-        positional,
-    }
-}
-
 module.exports = {
     annotations,
+    camelToSnake,
     getSingularAnnotation,
     getPluralAnnotation,
     unlocalize,
     singular4,
     plural4,
-    parseCommandlineArgs,
     deepMerge
 }

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -51,7 +51,7 @@ class Visitor {
     constructor(csn, options = {}) {
         amendCSN(csn.xtended)
         propagateForeignKeys(csn.inferred)
-        this.options = { ...defaults, ...options }
+        this.options = util.camelSnakeHybrid({ ...defaults, ...options })
         this.csn = csn
 
         /** @type {Context[]} **/

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -20,8 +20,6 @@ const { configuration } = require('./config')
 
 /** @typedef {import('./file').File} File */
 /** @typedef {import('./typedefs').visitor.Context} Context */
-/** @typedef {import('./typedefs').visitor.CompileParameters} CompileParameters */
-/** @typedef {import('./typedefs').visitor.VisitorOptions} VisitorOptions */
 /** @typedef {import('./typedefs').visitor.Inflection} Inflection */
 /** @typedef {import('./typedefs').resolver.CSN} CSN */
 /** @typedef {import('./typedefs').resolver.EntityCSN} EntityCSN */

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -16,6 +16,7 @@ const { baseDefinitions } = require('./components/basedefs')
 const { EntityRepository, asIdentifier } = require('./resolution/entity')
 const { last } = require('./components/identifier')
 const { getPropertyModifiers } = require('./components/property')
+const { camelSnakeHybrid } = require('./config')
 
 /** @typedef {import('./file').File} File */
 /** @typedef {import('./typedefs').visitor.Context} Context */
@@ -51,7 +52,7 @@ class Visitor {
     constructor(csn, options = {}) {
         amendCSN(csn.xtended)
         propagateForeignKeys(csn.inferred)
-        this.options = util.camelSnakeHybrid({ ...defaults, ...options })
+        this.options = camelSnakeHybrid({ ...defaults, ...options })
         this.csn = csn
 
         /** @type {Context[]} **/

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -16,7 +16,7 @@ const { baseDefinitions } = require('./components/basedefs')
 const { EntityRepository, asIdentifier } = require('./resolution/entity')
 const { last } = require('./components/identifier')
 const { getPropertyModifiers } = require('./components/property')
-const { camelSnakeHybrid } = require('./config')
+const { configuration } = require('./config')
 
 /** @typedef {import('./file').File} File */
 /** @typedef {import('./typedefs').visitor.Context} Context */
@@ -47,12 +47,10 @@ class Visitor {
 
     /**
      * @param {{xtended: CSN, inferred: CSN}} csn - root CSN
-     * @param {VisitorOptions | {}} options - the options
      */
-    constructor(csn, options = {}) {
+    constructor(csn) {
         amendCSN(csn.xtended)
         propagateForeignKeys(csn.inferred)
-        this.options = camelSnakeHybrid({ ...defaults, ...options })
         this.csn = csn
 
         /** @type {Context[]} **/
@@ -65,12 +63,10 @@ class Visitor {
         this.entityRepository = new EntityRepository(this.resolver)
 
         /** @type {FileRepository} */
-        this.fileRepository = new FileRepository(this.options)
-        // REVISIT: better way to pass options to base source file ???
-        baseDefinitions.options = this.options
+        this.fileRepository = new FileRepository()
         this.fileRepository.add(baseDefinitions.path.asNamespace(), baseDefinitions)
         this.inlineDeclarationResolver =
-            this.options.inlineDeclarations === 'structured'
+            configuration.inlineDeclarations === 'structured'
                 ? new StructuredInlineDeclarationResolver(this)
                 : new FlatInlineDeclarationResolver(this)
 
@@ -489,12 +485,13 @@ class Visitor {
         buffer.add('// event')
         // only declare classes, as their properties are not optional, so we don't have to do awkward initialisation thereof.
         buffer.addIndentedBlock(`export declare class ${entityName} {`, () => {
-            const propOpt = this.options.propertiesOptional
-            this.options.propertiesOptional = false
+            const propOpt = configuration.propertiesOptional
+            // FIXME: shouldn't need to change config here! Idea: init Visitor with .options fed from config, then manipulate that
+            configuration.propertiesOptional = false
             for (const [ename, element] of Object.entries(event.elements ?? {})) {
                 this.visitElement(ename, element, file, buffer)
             }
-            this.options.propertiesOptional = propOpt
+            configuration.propertiesOptional = propOpt
         }, '}')
     }
 

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -25,13 +25,6 @@ const { configuration } = require('./config')
 /** @typedef {import('./typedefs').resolver.EntityCSN} EntityCSN */
 /** @typedef {import('./typedefs').resolver.EnumCSN} EnumCSN */
 
-const defaults = {
-    // FIXME: add defaults for remaining parameters
-    propertiesOptional: true,
-    useEntitiesProxy: false,
-    inlineDeclarations: 'flat'
-}
-
 class Visitor {
     /**
      * Gathers all files that are supposed to be written to

--- a/test/unit/cliopts.test.js
+++ b/test/unit/cliopts.test.js
@@ -4,7 +4,6 @@ process.env.cds_typer_IEEE754Compatible = 'true'
 const { describe, beforeAll, test, expect } = require('@jest/globals')
 const cli = require('../../lib/cli')
 const { configuration } = require('../../lib/config')
-const cds = require('@sap/cds')
 
 describe('CLI Options', () => {
     beforeAll(async () => cli.prepareParameters(['"*"', '--outputDirectory', 'y', '--inline_declarations', 'flat']))

--- a/test/unit/cliopts.test.js
+++ b/test/unit/cliopts.test.js
@@ -1,0 +1,15 @@
+'use strict'
+// hacking this into process.env as very first thing before cds.env is loaded
+process.env.cds_typer_IEEE754Compatible = 'true'
+const { describe, beforeAll, test, expect } = require('@jest/globals')
+const cli = require('../../lib/cli')
+const { configuration } = require('../../lib/config')
+const cds = require('@sap/cds')
+
+describe('CLI Options', () => {
+    beforeAll(async () => cli.prepareParameters(['"*"', '--outputDirectory', 'y', '--inline_declarations', 'flat']))
+    test('cds.env Overridden By CLI', async () => expect(configuration.outputDirectory).toBe('y'))
+    test('Set Parameter Via CLI Using camelCase', async () => expect(configuration.inlineDeclarations).toBe('flat'))
+    test('Default Value', async () => expect(''+configuration.useEntitiesProxy).toBe(cli.flags.useEntitiesProxy.default))  // stringify, as config will contain a postprocessed boolean
+    test('Set Via process.env File', async () => expect(configuration.IEEE754Compatible).toBe(true))
+})

--- a/test/unit/cliopts/db/schema.cds
+++ b/test/unit/cliopts/db/schema.cds
@@ -1,0 +1,1 @@
+entity E {}

--- a/test/unit/cliopts/package.json
+++ b/test/unit/cliopts/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "cliopts",
+  "version": "1.0.0",
+  "description": "A simple CAP project.",
+  "repository": "<Add your repository here>",
+  "license": "UNLICENSED",
+  "private": true,
+  "dependencies": {
+    "@sap/cds": "^8",
+    "express": "^4"
+  },
+  "devDependencies": {
+    "@cap-js/sqlite": "^1",
+    "@cap-js/cds-types": "^0.6"
+  },
+  "scripts": {
+    "start": "cds-serve"
+  },
+  "cds": {
+    "typer": {
+      "outputDirectory": "x",
+      "log_level": 42
+    }
+  }
+}

--- a/test/unit/tsCheckAndRun.test.js
+++ b/test/unit/tsCheckAndRun.test.js
@@ -1,3 +1,4 @@
+const { configuration } = require('../../lib/config')
 const { basename, join } = require('path')
 const { describe, test } = require('@jest/globals')
 const cds = require('@sap/cds')
@@ -47,8 +48,8 @@ async function runTyperAndTsCheck(model, testTsFile, outputDirectory, parameters
     }
     parameters = { ...defaults, ...parameters }
 
-    const options = {...{ outputDirectory, inlineDeclarations: 'structured' }, ...parameters.typerOptions}
-    const paths = await typer.compileFromFile(model, options)
+    configuration.setMany({...{ outputDirectory, inlineDeclarations: 'structured' }, ...parameters.typerOptions})
+    const paths = await typer.compileFromFile(model)
     const tsFiles = paths.map(p => join(p, 'index.ts'))
     const emitDir = join(outputDirectory, '__tsc-emit')
     await checkTranspilation([testTsFile, ...tsFiles], {


### PR DESCRIPTION
Configuration parameters can now be passed either in camelCase or snake_case. This mechanism works for both CLI parameters, as well as for options passed via `cds.env`. The order of precedence is (still):

CLI parameters > `cds.env` > default values