### PR TITLE
Fixes cds.entities and entity name issues in proxy function

### DIFF
--- a/lib/components/javascript.js
+++ b/lib/components/javascript.js
@@ -7,7 +7,7 @@ const proxyAccessFunction = function (fqParts, opts = {}) {
     return new Proxy(target, {
         get: function (target, prop) {
             if (cds.entities) {
-                target.__proto__ = cds.entities(fqParts[0], fqParts[1])
+                target.__proto__ = cds.entities(fqParts[0])[fqParts[1]]
                 // overwrite/simplify getter after cds.entities is accessible
                 this.get = (target, prop) => target[prop]
                 return target[prop]

--- a/lib/components/javascript.js
+++ b/lib/components/javascript.js
@@ -7,7 +7,7 @@ const proxyAccessFunction = function (fqParts, opts = {}) {
     return new Proxy(target, {
         get: function (target, prop) {
             if (cds.entities) {
-                target.__proto__ = cds.entities[fq]
+                target.__proto__ = cds.entities(fqParts[0], fqParts[1])
                 // overwrite/simplify getter after cds.entities is accessible
                 this.get = (target, prop) => target[prop]
                 return target[prop]

--- a/lib/components/javascript.js
+++ b/lib/components/javascript.js
@@ -3,7 +3,7 @@
 // @ts-nocheck
 const proxyAccessFunction = function (fqParts, opts = {}) {
     const { target, customProps } = { target: {}, customProps: [], ...opts }
-    const fq = fqParts.join('.')
+    const fq = fqParts.filter(p => !!p).join('.')
     return new Proxy(target, {
         get: function (target, prop) {
             if (cds.entities) {

--- a/test/unit/entitiesproxy.test.js
+++ b/test/unit/entitiesproxy.test.js
@@ -70,7 +70,7 @@ describe('Compilation/Runtime - with Entities Proxies', () => {
             async () =>
                 ({ paths } = await prepareUnitTest(
                     'entitiesproxy/service.cds',
-                    locations.testOutput('entities_proxy_test/runtime'),
+                    path.join(__dirname, 'files', 'entitiesproxy', '_out'),
                     {
                         typerOptions: { useEntitiesProxy: true },
                     }

--- a/test/unit/entitiesproxy.test.js
+++ b/test/unit/entitiesproxy.test.js
@@ -1,16 +1,23 @@
 'use strict'
 
 const path = require('path')
-const { beforeAll, describe, test, expect } = require('@jest/globals')
+const cds = require('@sap/cds')
+const { beforeAll, afterEach, describe, test, expect } = require('@jest/globals')
 const { JSASTWrapper } = require('../ast')
 const { locations, prepareUnitTest } = require('../util')
 
-describe('Compilation - with Entities Proxies', () => {
+describe('Compilation/Runtime - with Entities Proxies', () => {
     let paths
 
-    describe('Bookshoplet', () => {
-
-        beforeAll(async () => ({paths} = await prepareUnitTest('bookshoplet/model.cds', locations.testOutput('entities_proxy_test/bookshoplet'), {typerOptions: {useEntitiesProxy: true}})))
+    describe('Compile Bookshoplet', () => {
+        beforeAll(
+            async () =>
+                ({ paths } = await prepareUnitTest(
+                    'bookshoplet/model.cds',
+                    locations.testOutput('entities_proxy_test/bookshoplet'),
+                    { typerOptions: { useEntitiesProxy: true } }
+                ))
+        )
 
         test('index.js', async () => {
             const jsw = await JSASTWrapper.initialise(path.join(paths[1], 'index.js'), true)
@@ -35,19 +42,95 @@ describe('Compilation - with Entities Proxies', () => {
                 ['E_', 'E'],
                 ['E', 'E'],
                 ['QueryEntity_', 'QueryEntity'],
-                ['QueryEntity', 'QueryEntity']
+                ['QueryEntity', 'QueryEntity'],
             ])
         })
     })
 
-    describe('Enums', () => {
-        beforeAll(async () => ({paths} = await prepareUnitTest('enums/model.cds', locations.testOutput('entities_proxy_test/enums'), {typerOptions: {useEntitiesProxy: true}})))
+    describe('Inline Enum compilation', () => {
+        beforeAll(
+            async () =>
+                ({ paths } = await prepareUnitTest(
+                    'enums/model.cds',
+                    locations.testOutput('entities_proxy_test/enums'),
+                    { typerOptions: { useEntitiesProxy: true } }
+                ))
+        )
 
         test('Inline enum names passed to proxy function call', async () => {
             const jsw = await JSASTWrapper.initialise(path.join(paths[1], 'index.js'), true)
 
             jsw.hasProxyExport('InlineEnum', ['gender', 'status', 'yesno'])
             jsw.hasProxyExport('TypeWithInlineEnum', ['inlineEnumProperty'])
+        })
+    })
+
+    describe('Runtime Checks for Entity Proxies', () => {
+        beforeAll(
+            async () =>
+                ({ paths } = await prepareUnitTest(
+                    'entitiesproxy/service.cds',
+                    locations.testOutput('entities_proxy_test/runtime'),
+                    {
+                        typerOptions: { useEntitiesProxy: true },
+                    }
+                ))
+        )
+        afterEach(() => {
+            // tear down loaded cds model
+            cds.model = undefined
+        })
+
+        test('Invalid \'elements\' access via proxy before cds is loaded', async () => {
+            const { Books } = require(paths[1])
+
+            expect(() => Books.elements).toThrow(
+                new Error(
+                    'Property elements does not exist on entity \'bookshop.CatalogService.Books\' or cds.entities is not yet defined. Ensure the CDS runtime is fully booted before accessing properties.'
+                )
+            )
+        })
+
+        test('Inline enum access via proxy export without cds runtime', () => {
+            const { Book } = require(paths[1])
+
+            expect(Book.genre).toStrictEqual({ Fantasy: 'Fantasy', SciFi: 'Science-Fiction' })
+        })
+
+        test('Use entity proxy as stand-in for definition from cds.entities', async () => {
+            const { Books, Book } = require(paths[1])
+            const base = path.join(__dirname, 'files', 'entitiesproxy')
+            cds.root = base
+            cds.model = cds.linked(await cds.load(path.join(base, 'service.cds')))
+            await cds.serve('all')
+
+            expect(Books.name).toBe('bookshop.CatalogService.Books')
+            expect(Book.name).toBe('bookshop.CatalogService.Books')
+
+            expect(Book.elements).toBe(cds.entities('bookshop.CatalogService').Books.elements)
+
+            // test service registration with proxy
+            const catService = cds.services['bookshop.CatalogService']
+            catService.prepend(srv => {
+                expect(srv.after('READ', Books, () => {})).toBe(srv)
+            })
+        })
+
+        test('Use entity proxy for entity without namespace', async () => {
+            const { Publishers, Publisher } = require(paths[2])
+
+            // access name property before cds runtime is loaded
+            expect(Publisher.name).toBe('Publishers')
+            expect(Publishers.name).toBe('Publishers')
+
+            const base = path.join(__dirname, 'files', 'entitiesproxy')
+            cds.root = base
+            cds.model = cds.linked(await cds.load(path.join(base, 'nonamespace.cds')))
+            await cds.serve('all')
+
+            // access name after cds runtime is loaded
+            expect(Publisher.name).toBe('Publishers')
+            expect(Publishers.name).toBe('Publishers')
         })
     })
 })

--- a/test/unit/files/entitiesproxy/nonamespace.cds
+++ b/test/unit/files/entitiesproxy/nonamespace.cds
@@ -1,0 +1,3 @@
+entity Publishers {
+    key name : String;
+}

--- a/test/unit/files/entitiesproxy/service.cds
+++ b/test/unit/files/entitiesproxy/service.cds
@@ -1,0 +1,16 @@
+using {cuid} from '@sap/cds/common';
+using {Publishers as p} from './nonamespace';
+
+namespace bookshop;
+
+service CatalogService {
+    entity Books : cuid {
+        title : String;
+        genre : String enum {
+            Fantasy = 'Fantasy';
+            SciFi   = 'Science-Fiction'
+        }
+    };
+
+    entity Publishers as projection on p;
+}


### PR DESCRIPTION
I discovered some bugs in my proxy creator function.

1. The fully qualified name will be wrong if an empty namespace is passed to the function
2. for some reason the cds.entities[name] variant can only used if at least 2 CDS files are located in the `/db` folder.

Only runtime tests could discover those issues.

@daogrady  Are there runtime tests in the project or is it planned to have them? For features such as the proxy function it would be great.