### PR TITLE
Determine optional action parameters from CSN's `notNull`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.27.0 - TBD
+### Changed
+- Action parameters are now generated as optional by default, which is how the runtime treats them. Mandatory parameters have to be marked as `not null` in CDS/CDL, or `notNull` in CSN.
 
 ## Version 0.26.0 - 2024-09-11
 ### Added

--- a/lib/resolution/resolver.js
+++ b/lib/resolution/resolver.js
@@ -63,8 +63,7 @@ class Resolver {
      * @returns {boolean} whether the type is configured to be optional
      */
     isOptional(type) {
-        // TODO temporary solution to determine optional parameters. Align w/ compiler/importer.
-        return Object.keys(type).some(k => k.startsWith('@Core.OptionalParameter'))
+        return !type.notNull
     }
 
     /**

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -177,7 +177,7 @@ describe('Actions', () => {
     })
 
     test ('Optional Action Params', async () => {
-        checkFunction(astwBound.tree.find(fn => fn.name === 'aOptionalParam'), {
+        checkFunction(astwBound.tree.find(fn => fn.name === 'aMandatoryParam'), {
             parameterCheck: ({members: [p1, p2, p3]}) => !check.isOptional(p1) && check.isOptional(p2) && !check.isOptional(p3),
         })
     })

--- a/test/unit/files/actions/model.cds
+++ b/test/unit/files/actions/model.cds
@@ -33,11 +33,10 @@ service S {
     action   aManyParamManyReturn(val: array of E)   returns array of E;
     action   aManyParamSingleReturn(val: array of E) returns E;
 
-    action   aOptionalParam(
-        val: E,
-        @Core.OptionalParameter: {$Type : 'Core.OptionalParameterType'}
+    action   aMandatoryParam(
+        val: E not null,
         opt: E,
-        val2: E
+        val2: E not null
     ) returns E;
 
     /** the action */
@@ -56,10 +55,10 @@ service S {
     );
 
     action aRfcStyle(
-        INPUT : String(1),
-        @RFCParameterType : 'Table' @Core.OptionalParameter : { $Type: 'Core.OptionalParameterType' }
+        INPUT : String(1) not null,
+        @RFCParameterType : 'Table'
             TABLES : many ExternalType2,
-        @RFCParameterType : 'Export' @Core.OptionalParameter : { $Type: 'Core.OptionalParameterType' }
+        @RFCParameterType : 'Export'
             EXPORT: String(1)
     ) returns ExternalType;
 }
@@ -83,5 +82,5 @@ entity ParameterlessActions {key id: Integer;}
 service S2 {
     entity E {key id: Integer;};
     action a1 (p1: String, p2: many ExternalType2) returns ExternalType;
-    action a2 (p1: String, @Core.OptionalParameter: {$Type : 'Core.OptionalParameterType'} p2: many ExternalType2, p3: Integer) returns ExternalType
+    action a2 (p1: String not null, p2: many ExternalType2, p3: Integer not null) returns ExternalType
 }

--- a/test/unit/files/actions/model.ts
+++ b/test/unit/files/actions/model.ts
@@ -6,7 +6,7 @@ import {
     aDocOneLine,
     aManyParamManyReturn,
     aManyParamSingleReturn,
-    aOptionalParam,
+    aMandatoryParam,
     aRfcStyle,
     aSingleParamManyReturn,
     aSingleParamSingleReturn,
@@ -48,7 +48,7 @@ export class S extends cds.ApplicationService { async init(){
   this.on(aManyParamManyReturn,      req => { const {val} = req.data; return val satisfies E[] })
   this.on(aManyParamSingleReturn,    req => { const {val} = req.data; return {e1:val[0].e1} satisfies E })
 
-  this.on(aOptionalParam,  req => {
+  this.on(aMandatoryParam,  req => {
     false satisfies IsKeyOptional<typeof req.data, 'val'>
     false satisfies IsKeyOptional<typeof req.data, 'val2'>
     true satisfies IsKeyOptional<typeof req.data, 'opt'>


### PR DESCRIPTION
Replace the use of `@Core.OptionalParameter` for optional parameters (which was an intermediate solution anyways) by evaluating CSN's `notNull` property.  This is in line with the decision in the CDS spec meeting and with what RFC importer now generates.

Note that this formally inverses the default for optional parameters:
- They are all optional by default, which is how the runtime treats it.
- Mandatory parameters now have to be marked with `notNull` (or `not null` in CDL).