### PR TITLE
Avoid duplicates in --help

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,7 +3,7 @@
 'use strict'
 
 /**
- * @typedef {import('./typedefs').config.cli.Parameter} Parameter
+ * @typedef {import('./typedefs').config.cli.ParameterSchema[number]} Parameter
  */
 
 const cds = require('@sap/cds')
@@ -38,12 +38,20 @@ const parameterTypes = {
  * @returns {import('./typedefs').config.cli.ParameterSchema} - The enriched schema.
  */
 const enrichFlagSchema = flags => {
+    const flagKeys = Object.keys(flags)
     for (const [key, value] of Object.entries(flags)) {
         /** @type {Parameter} */(value).camel = key;
         /** @type {Parameter} */(value).snake = camelToSnake(key)
     }
-    // @ts-expect-error
-    flags.hasFlag = flag => Object.values(flags).some(f => f.snake === flag || f.camel === flag)
+    // non-enumerable utilities
+    Object.defineProperties(flags, {
+        hasFlag: {
+            value: (/** @type {string} **/ flag) => Object.values(flags).some(f => f.snake === flag || f.camel === flag)
+        },
+        keys: {
+            value: flagKeys
+        }
+    })
     return camelSnakeHybrid(flags)
 }
 
@@ -199,9 +207,10 @@ const help = () => `SYNOPSIS${EOL2}` +
         indent('cds-typer [cds file | "*"]', '  ') + EOL2 +
         indent(`Generates type information based on a CDS model.${EOL}Call with at least one positional parameter pointing${EOL}to the (root) CDS file you want to compile.`, '  ') + EOL2 +
             `OPTIONS${EOL2}` +
-            Object.entries(flags)
+            flags.keys
                 .sort(([a], [b]) => a.localeCompare(b))
-                .map(([key, value]) => {
+                .map(key => {
+                    const value = flags[key]
                     let s = indent(`--${key}`, '  ')
                     const snake = camelToSnake(key)
                     if (key !== snake) s += EOL + indent(`--${snake}`, '  ')


### PR DESCRIPTION
`cds-typer --help` would display each option twice. This PR groups them instead.