### PR TITLE
feat: add static property `elements` to entity classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.28.0 - TBD
+### Added
+- Added a static `elements` property to all entities, which allows access to the `LinkedDefinitions` instance of an entity's elements
 
 ## Version 0.27.0 - 2024-10-02
 ### Changed

--- a/lib/components/basedefs.js
+++ b/lib/components/basedefs.js
@@ -15,7 +15,7 @@ const baseDefinitions = new SourceFile('_')
 baseDefinitions.addPreamble(`
 import { entity } from '@sap/cds'
 
-export type ElementsOf<T> = {[name in keyof DeepRequired<T>]: entity["elements"][string]}
+export type ElementsOf<T> = {[name in keyof Required<T>]: entity["elements"][string]}
 
 export namespace Association {
     export type to <T> = T;

--- a/lib/components/basedefs.js
+++ b/lib/components/basedefs.js
@@ -13,6 +13,10 @@ const timeRegex = '`${number}${number}:${number}${number}:${number}${number}`'
 const baseDefinitions = new SourceFile('_')
 // FIXME: this should be a library someday
 baseDefinitions.addPreamble(`
+import { entity } from '@sap/cds'
+
+export type ElementsOf<T> = {[name in keyof DeepRequired<T>]: entity["elements"][string]}
+
 export namespace Association {
     export type to <T> = T;
     export namespace to {

--- a/lib/components/basedefs.js
+++ b/lib/components/basedefs.js
@@ -13,9 +13,9 @@ const timeRegex = '`${number}${number}:${number}${number}:${number}${number}`'
 const baseDefinitions = new SourceFile('_')
 // FIXME: this should be a library someday
 baseDefinitions.addPreamble(`
-import { entity } from '@sap/cds'
+import { type } from '@sap/cds'
 
-export type ElementsOf<T> = {[name in keyof Required<T>]: entity["elements"][string]}
+export type ElementsOf<T> = {[name in keyof Required<T>]: type }
 
 export namespace Association {
     export type to <T> = T;

--- a/lib/components/wrappers.js
+++ b/lib/components/wrappers.js
@@ -18,6 +18,13 @@ const createKey = t => `${base}.Key<${t}>`
 const createKeysOf = t => `${base}.KeysOf<${t}>`
 
 /**
+ * Wraps type into ElementsOf type.
+ * @param {string} t - the type name.
+ * @returns {string}
+ */
+const createElementsOf = t => `${base}.ElementsOf<${t}>`
+
+/**
  * Wraps type into association to scalar.
  * @param {string} t - the singular type name.
  * @returns {string}
@@ -102,6 +109,7 @@ module.exports = {
     createArrayOf,
     createKey,
     createKeysOf,
+    createElementsOf,
     createObjectOf,
     createPromiseOf,
     createUnionOf,

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -8,7 +8,7 @@ const { SourceFile, FileRepository, Buffer, Path } = require('./file')
 const { FlatInlineDeclarationResolver, StructuredInlineDeclarationResolver } = require('./components/inline')
 const { Resolver } = require('./resolution/resolver')
 const { LOG } = require('./logging')
-const { docify, createPromiseOf, createUnionOf, createKeysOf } = require('./components/wrappers')
+const { docify, createPromiseOf, createUnionOf, createKeysOf, createElementsOf } = require('./components/wrappers')
 const { csnToEnumPairs, propertyToInlineEnumName, isInlineEnumType, stringifyEnumType } = require('./components/enum')
 const { isReferenceType } = require('./components/reference')
 const { empty } = require('./components/typescript')
@@ -163,6 +163,14 @@ class Visitor {
     }
 
     /**
+     * @param {Buffer} buffer - the buffer to write the elements into
+     * @param {string} clean - the clean name of the entity
+     */
+    #printStaticElements(buffer, clean) {
+        buffer.add(`declare static readonly elements:${createElementsOf(clean)}`)
+    }
+
+    /**
      * Transforms an entity or CDS aspect into a JS aspect (aka mixin).
      * That is, for an element A we get:
      * - the function A(B) to mix the aspect into another class B
@@ -275,7 +283,7 @@ class Visitor {
                     }
                     this.#printStaticActions(entity, buffer, ancestorInfos, file)
                     this.#printStaticKeys(buffer, clean)
-
+                    this.#printStaticElements(buffer, clean)
                 })
             }, '};') // end of generated class
         }, '}') // end of aspect

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -167,7 +167,7 @@ class Visitor {
      * @param {string} clean - the clean name of the entity
      */
     #printStaticElements(buffer, clean) {
-        buffer.add(`declare static readonly elements:${createElementsOf(clean)}`)
+        buffer.add(`declare static readonly elements: ${createElementsOf(clean)}`)
     }
 
     /**

--- a/test/unit/files/elements/model.cds
+++ b/test/unit/files/elements/model.cds
@@ -1,0 +1,19 @@
+namespace elements_test;
+
+aspect A1 {
+    A_f1 : String;
+    A_f2 : String;
+}
+
+entity E1 {
+    key ID: Integer;
+    a : String;
+    b : Integer;
+}
+
+entity E2 : A1 {
+    key ID: String;
+    d: Integer;
+}
+
+entity P1 as projection on E2;

--- a/test/unit/files/elements/model.ts
+++ b/test/unit/files/elements/model.ts
@@ -1,0 +1,26 @@
+import cds from '@sap/cds'
+import { E1, E2, P1 } from '#cds-models/elements_test'
+
+E1.elements
+E1.elements.ID
+E1.elements.a
+E1.elements.b
+// @ts-expect-error
+E1.elements.nonExistent
+
+E2.elements
+E2.elements.d    // from entity E1
+E2.elements.A_f1 // from aspect A1
+
+// check projection
+P1.elements
+P1.elements.ID
+P1.elements.d
+P1.elements.A_f1
+P1.elements.A_f2
+
+// check LinkedDefinitions types
+E1.elements.a.type
+E1.elements.a.kind
+E1.elements.a.items
+E1.elements.a instanceof cds.builtin.classes.String


### PR DESCRIPTION
Enables proper access to all entity elements of the underlying `LinkedDefinition`.

e.g.

```cds
entity Books : cuid {
  title : String;
  stock : Integer;
}
```

new property `elements` allows access to all defined elements of the entity and access the underlying `LinkedDefinition` of those elements.

```ts
import { Book } from "#cds-models/my/bookshop";
import cds from "@sap/cds";

if (Book.elements.ID instanceof cds.builtin.classes.UUID) console.log("ID is of type UUID");
if (Book.elements.stock instanceof cds.builtin.classes.Integer) console.log("stock is of type Integer");
```