### PR TITLE
Enable service names with non-alphanum characters

### DIFF
--- a/lib/components/identifier.js
+++ b/lib/components/identifier.js
@@ -17,7 +17,24 @@ const normalise = ident => ident && !isValidIdent.test(ident)
  */
 const last = ident => ident.split('.').at(-1) ?? ident
 
+/**
+ * Normalises the name of a service.
+ * @param {string} name - name of the service or fq thereof.
+ */
+const normalisedServiceName = name => {
+    const simple = /** @type {string} */ (name.split('.').at(-1))
+    const normalised = simple.match(/^[a-zA-Z]+\w*$/)
+        ? simple
+        : `__${simple.replaceAll(/[^a-zA-Z0-9]/g, '_')}`
+    return {
+        simple,
+        normalised,
+        isNormalised: simple !== normalised
+    }
+}
+
 module.exports = {
     normalise,
-    last
+    last,
+    normalisedServiceName
 }

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -14,7 +14,7 @@ const { isReferenceType } = require('./components/reference')
 const { empty } = require('./components/typescript')
 const { baseDefinitions } = require('./components/basedefs')
 const { EntityRepository, asIdentifier } = require('./resolution/entity')
-const { last } = require('./components/identifier')
+const { last, normalisedServiceName } = require('./components/identifier')
 const { getPropertyModifiers } = require('./components/property')
 const { configuration } = require('./config')
 
@@ -514,14 +514,21 @@ class Visitor {
         const serviceNameSimple = service.name.split('.').pop()
 
         docify(service.doc).forEach(d => { buffer.add(d) })
-        // file.addImport(new Path(['cds'], '')) TODO make sap/cds import work
-        buffer.addIndentedBlock(`export class ${serviceNameSimple} extends cds.Service {`, () => {
+
+        const { simple, normalised, isNormalised } = normalisedServiceName(service.name)
+
+        buffer.addIndentedBlock(`${isNormalised ? '' : 'export '}class ${normalised} extends cds.Service {`, () => {
             Object.entries(service.operations ?? {}).forEach(([name, {doc}]) => {
                 docify(doc).forEach(d => { buffer.add(d) })
                 buffer.add(`declare ${name}: typeof ${name}`)
             })
         }, '}')
-        buffer.add(`export default ${serviceNameSimple}`)
+
+        buffer.add(isNormalised
+            ? `export { ${normalised} as '${simple}' }`
+            : `export default ${serviceNameSimple}`)
+        // file.addImport(new Path(['cds'], '')) TODO make sap/cds import work
+
         buffer.add('')
         file.addService(service.name)
     }

--- a/test/unit/files/services/model.cds
+++ b/test/unit/files/services/model.cds
@@ -1,0 +1,5 @@
+namespace service_test;
+
+service FooService {}
+
+service ![Foo/Serviceöß%] {}

--- a/test/unit/services.test.js
+++ b/test/unit/services.test.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const { beforeAll, describe, test, expect } = require('@jest/globals')
+const { check } = require('../ast')
+const { locations, prepareUnitTest } = require('../util')
+
+describe('services', () => {
+    let astw
+
+    beforeAll(async () => astw = (await prepareUnitTest('services/model.cds', locations.testOutput('services_test'))).astw)
+
+    describe('Service', () => {
+        test('Top Level Event', async () => {
+            console.log(1)
+        })
+    })
+})


### PR DESCRIPTION
Allows "proper" naming of service containing non-alphanumeric names:

```cds
service "Foo/Bar" {}
```

would become

```ts
class __Foo_Bar {}  // not exported directly
export { __Foo_Bar as "Foo/Bar" }
```

and users would have to import like so:

```ts
import { "Foo/Bar" as FooBar } from ...
//                      ^ any alias
```

Note that this creates a discrepancy between service that don't contain special characters, as they are exported as `default` export, and ones that have names containing special characters, that are only exported in named style.

- [ ] add tests
- [ ] output warning when such a service name is used, as this [requires](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#support-for-arbitrary-module-identifiers) the use of typescript@5.6 or higher. -> only debug message