### PR TITLE
Fix array-like params in CDS functions/actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 - Entity elements of named structured types are flattened when using the option `--inlineDeclarations flat`
+- Properly support mandatory (`not null`) action parameters with `array of` types
 
 ## Version 0.27.0 - 2024-10-02
 ### Changed

--- a/lib/resolution/resolver.js
+++ b/lib/resolution/resolver.js
@@ -64,7 +64,7 @@ class Resolver {
      * @returns {boolean} whether the type is configured to be optional
      */
     isOptional(type) {
-        return !type.notNull
+        return type.items ? !type.items.notNull : !type.notNull
     }
 
     /**

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -178,7 +178,7 @@ describe('Actions', () => {
 
     test ('Optional Action Params', async () => {
         checkFunction(astwBound.tree.find(fn => fn.name === 'aMandatoryParam'), {
-            parameterCheck: ({members: [p1, p2, p3]}) => !check.isOptional(p1) && check.isOptional(p2) && !check.isOptional(p3),
+            parameterCheck: ({members: [p1, p2, p3]}) => !check.isOptional(p1) && !check.isOptional(p2) && check.isOptional(p3),
         })
     })
 

--- a/test/unit/files/actions/model.cds
+++ b/test/unit/files/actions/model.cds
@@ -34,9 +34,9 @@ service S {
     action   aManyParamSingleReturn(val: array of E) returns E;
 
     action   aMandatoryParam(
-        val: E not null,
+        val1: E not null,
+        val2: array of E not null,
         opt: E,
-        val2: E not null
     ) returns E;
 
     /** the action */

--- a/test/unit/files/actions/model.ts
+++ b/test/unit/files/actions/model.ts
@@ -49,7 +49,7 @@ export class S extends cds.ApplicationService { async init(){
   this.on(aManyParamSingleReturn,    req => { const {val} = req.data; return {e1:val[0].e1} satisfies E })
 
   this.on(aMandatoryParam,  req => {
-    false satisfies IsKeyOptional<typeof req.data, 'val'>
+    false satisfies IsKeyOptional<typeof req.data, 'val1'>
     false satisfies IsKeyOptional<typeof req.data, 'val2'>
     true satisfies IsKeyOptional<typeof req.data, 'opt'>
   })


### PR DESCRIPTION
The fix on #332.

Explaining comment is [here](https://github.com/cap-js/cds-typer/pull/332#discussion_r1799647831).