### PR TITLE
feat: cds schema for typescript build task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## Version 0.28.0 - TBD
 ### Added
 - Schema definition for `cds.typer` options in `package.json` and `.cdsrc-*.json` files
+- Schema definition for `typescript` cds build task.
 
 ## Version 0.27.0 - 2024-10-02
 ### Changed

--- a/package.json
+++ b/package.json
@@ -64,6 +64,10 @@
   },
   "cds": {
     "schema": {
+      "buildTaskType": {
+        "name": "typescript",
+        "description": "A text describing the new build task type."
+      },
       "cds": {
         "typer": {
           "type": "object",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "schema": {
       "buildTaskType": {
         "name": "typescript",
-        "description": "A text describing the new build task type."
+        "description": "Typescript build plugin. For use after the nodejs build task."
       },
       "cds": {
         "typer": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "schema": {
       "buildTaskType": {
         "name": "typescript",
-        "description": "Typescript build plugin. For use after the nodejs build task."
+        "description": "TypeScript build plugin. For use after the nodejs build task."
       },
       "cds": {
         "typer": {


### PR DESCRIPTION
Adds the build task, so that it is recognized for validation & autocomplete in the package.json.