### PR TITLE
Safely override `.kind` and `Buffer` improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 - Entity elements of named structured types are flattened when using the option `--inlineDeclarations flat`
+- `override` modifier on `.kind` property is now only generated if the property is actually inherited, satisfying strict `tsconfig.json`s
 
 ## Version 0.27.0 - 2024-10-02
 ### Changed

--- a/lib/components/class.js
+++ b/lib/components/class.js
@@ -11,19 +11,17 @@
  * @param {boolean} [options.isOverride] - whether the member is an override
  */
 function createMember ({name, type = undefined, initialiser = undefined, statementEnd = ';', isDeclare = false,  isStatic = false, isReadonly = false, isOverride = false}) {
-    if (isDeclare && isOverride) {
-        throw new Error(`cannot have a member '${name}' with both declare and override modifiers`)
-    }
+    if (isDeclare && isOverride) throw new Error('member cannot have both declare and override modifiers')
+
     const parts = []
 
     if (isDeclare) parts.push('declare')
     if (isStatic) parts.push('static')
     if (isOverride) parts.push('override')
     if (isReadonly) parts.push('readonly')
-    const nameAndType = type
-        ? `${name}: ${type}`
-        : name
-    parts.push(nameAndType)
+
+    parts.push(type ? `${name}: ${type}` : name)
+
     if (initialiser) parts.push(`= ${initialiser}`)
 
     const member = parts.join(' ')

--- a/lib/components/class.js
+++ b/lib/components/class.js
@@ -20,10 +20,11 @@ function createMember ({name, type = undefined, initialiser = undefined, stateme
     if (isStatic) parts.push('static')
     if (isOverride) parts.push('override')
     if (isReadonly) parts.push('readonly')
-
-    parts.push(name)
-    if (type) parts.push(`: ${type}`)
-    if (initialiser) parts.push(` = ${initialiser}`)
+    const nameAndType = type
+        ? `${name}: ${type}`
+        : name
+    parts.push(nameAndType)
+    if (initialiser) parts.push(`= ${initialiser}`)
 
     const member = parts.join(' ')
     return statementEnd

--- a/lib/components/class.js
+++ b/lib/components/class.js
@@ -1,0 +1,36 @@
+/**
+ * Create a class member with given modifiers in the right order.
+ * @param {object} options - options
+ * @param {string} options.name - the name of the member
+ * @param {string} [options.type] - the type of the member
+ * @param {string} [options.initialiser] - the initialiser for the member
+ * @param {string} [options.statementEnd] - the closing character for the member
+ * @param {boolean} [options.isDeclare] - whether the member is declared
+ * @param {boolean} [options.isStatic] - whether the member is static
+ * @param {boolean} [options.isReadonly] - whether the member is readonly
+ * @param {boolean} [options.isOverride] - whether the member is an override
+ */
+function createMember ({name, type = undefined, initialiser = undefined, statementEnd = ';', isDeclare = false,  isStatic = false, isReadonly = false, isOverride = false}) {
+    if (isDeclare && isOverride) {
+        throw new Error(`cannot have a member '${name}' with both declare and override modifiers`)
+    }
+    const parts = []
+
+    if (isDeclare) parts.push('declare')
+    if (isStatic) parts.push('static')
+    if (isOverride) parts.push('override')
+    if (isReadonly) parts.push('readonly')
+
+    parts.push(name)
+    if (type) parts.push(`: ${type}`)
+    if (initialiser) parts.push(` = ${initialiser}`)
+
+    const member = parts.join(' ')
+    return statementEnd
+        ? `${member}${statementEnd}`
+        : member
+}
+
+module.exports = {
+    createMember
+}

--- a/lib/components/enum.js
+++ b/lib/components/enum.js
@@ -55,12 +55,12 @@ const enumVal = (key, value, enumType) => enumType === 'cds.String' ? JSON.strin
 function printEnum(buffer, name, kvs, options = {}, doc=[]) {
     const opts = {...{export: true}, ...options}
     buffer.add('// enum')
-    if (opts.export) doc.forEach(d => { buffer.add(d) })
+    if (opts.export) buffer.add(doc)
     buffer.addIndentedBlock(`${opts.export ? 'export ' : ''}const ${name} = {`, () =>
         kvs.forEach(([k, v]) => { buffer.add(`${normalise(k)}: ${v},`) })
     , '} as const;')
     buffer.add(`${opts.export ? 'export ' : ''}type ${name} = ${stringifyEnumType(kvs)}`)
-    buffer.add('')
+    buffer.blankLine()
 }
 
 /**

--- a/lib/components/inline.js
+++ b/lib/components/inline.js
@@ -276,7 +276,7 @@ class StructuredInlineDeclarationResolver extends InlineDeclarationResolver {
     printInlineType({fq, type, buffer, modifiers, statementEnd}) {
         const sub = new Buffer()
         this.flatten({fq, type, buffer: sub, modifiers, statementEnd})
-        sub.parts.forEach(p => { buffer.add(p) })
+        buffer.add(sub.parts)
     }
 
     /**

--- a/lib/components/wrappers.js
+++ b/lib/components/wrappers.js
@@ -98,6 +98,13 @@ const docify = doc => {
     return ['/**'].concat(lines.map(line => `* ${line}`)).concat(['*/'])
 }
 
+/**
+ * Wraps a string in single quotes. No escaping is done, so use with caution.
+ * @param {string} s - the string to wrap.
+ * @returns {string}
+ */
+const stringIdent = s => `'${s}'`
+
 module.exports = {
     createArrayOf,
     createKey,
@@ -110,5 +117,6 @@ module.exports = {
     createCompositionOfOne,
     createCompositionOfMany,
     deepRequire,
-    docify
+    docify,
+    stringIdent
 }

--- a/lib/file.js
+++ b/lib/file.js
@@ -400,7 +400,7 @@ class SourceFile extends File {
                 buffer.add(`import * as ${imp.asIdentifier()} from '${imp.asDirectory({relative: this.path.asDirectory()})}';`)
             }
         }
-        buffer.add('') // empty line after imports
+        buffer.blankLine()
         return buffer
     }
 
@@ -590,10 +590,27 @@ class Buffer {
 
     /**
      * Adds an element to the buffer with the current indentation level.
-     * @param {string} part  - what to attach to the buffer
+     * @param {string | (() => string) | ((() => string) | string)[]} part  - what to attach to the buffer
      */
     add(part) {
-        this.parts.push(this.currentIndent + part)
+        if (typeof part === 'string') {
+            this.parts.push(this.currentIndent + part)
+        } else if (Array.isArray(part)) {
+            for (const p of part) {
+                this.add(p)  // recurse to have proper indentation
+            }
+        } else if (typeof part === 'function') {
+            this.parts.push(part())
+        } else {
+            throw new Error(`trying to add something of type ${typeof part} to a Buffer`)
+        }
+    }
+
+    /**
+     * Adds a blank line to the buffer.
+     */
+    blankLine() {
+        this.add('')
     }
 
     /**

--- a/lib/resolution/entity.js
+++ b/lib/resolution/entity.js
@@ -61,6 +61,7 @@ class EntityInfo {
     /** @type {import('../typedefs').resolver.EntityCSN | undefined} */
     #csn
 
+    /** @returns the **inferred** csn for this entity. */
     get csn () {
         return this.#csn ??= this.#resolver.csn.definitions[this.fullyQualifiedName]
     }

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -8,7 +8,7 @@ const { SourceFile, FileRepository, Buffer, Path } = require('./file')
 const { FlatInlineDeclarationResolver, StructuredInlineDeclarationResolver } = require('./components/inline')
 const { Resolver } = require('./resolution/resolver')
 const { LOG } = require('./logging')
-const { docify, createPromiseOf, createUnionOf, createKeysOf } = require('./components/wrappers')
+const { docify, createPromiseOf, createUnionOf, createKeysOf, stringIdent } = require('./components/wrappers')
 const { csnToEnumPairs, propertyToInlineEnumName, isInlineEnumType, stringifyEnumType } = require('./components/enum')
 const { isReferenceType } = require('./components/reference')
 const { empty } = require('./components/typescript')
@@ -300,8 +300,8 @@ class Visitor {
                         isStatic: true,
                         isReadonly: true,
                         isDeclare: false,
-                        isOverride: entity.includes?.some(ancestor => this.csn.inferred.definitions[ancestor]?.kind),
-                        initialiser: `'${entity.kind}'`
+                        isOverride: ancestorInfos.some(ancestor => ancestor.csn.kind),
+                        initialiser: stringIdent(entity.kind)
                     }))
                 }
                 this.#printStaticKeys(buffer, clean)

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -184,7 +184,13 @@ class Visitor {
      * @param {string} clean - the clean name of the entity
      */
     #printStaticElements(buffer, clean) {
-        buffer.add(`declare static readonly elements: ${createElementsOf(clean)}`)
+        buffer.add(createMember({
+            name: 'elements',
+            type: createElementsOf(clean),
+            isDeclare: true,
+            isStatic: true,
+            isReadonly: true
+        }))
     }
 
     /**

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -17,6 +17,7 @@ const { EntityRepository, asIdentifier } = require('./resolution/entity')
 const { last } = require('./components/identifier')
 const { getPropertyModifiers } = require('./components/property')
 const { configuration } = require('./config')
+const { createMember } = require('./components/class')
 
 /** @typedef {import('./file').File} File */
 /** @typedef {import('./typedefs').visitor.Context} Context */
@@ -155,7 +156,12 @@ class Visitor {
                 }, '}'
             ) // end of actions
         } else {
-            buffer.add(`declare static readonly actions: ${inherited}${empty}`)
+            buffer.add(createMember({
+                name: 'actions',
+                type: `${inherited}${empty}`,
+                isStatic:true,
+                isReadonly: true
+            }))
         }
     }
 
@@ -164,7 +170,13 @@ class Visitor {
      * @param {string} clean - the clean name of the entity
      */
     #printStaticKeys(buffer, clean) {
-        buffer.add(`declare static readonly keys: ${createKeysOf(clean)}`)
+        buffer.add(createMember({
+            name: 'keys',
+            type: createKeysOf(clean),
+            isDeclare: true,
+            isStatic: true,
+            isReadonly: true,
+        }))
     }
 
     /**
@@ -271,14 +283,25 @@ class Visitor {
                 }
 
                 for (const e of enums) {
-                    const eDoc = docify(e.doc)
-                    eDoc.forEach(d => { buffer.add(d) })
-                    buffer.add(`static ${e.name} = ${propertyToInlineEnumName(clean, e.name)}`)
+                    buffer.add(docify(e.doc))
+                    buffer.add(createMember({
+                        name: e.name,
+                        initialiser: propertyToInlineEnumName(clean, e.name),
+                        isStatic: true,
+                    }))
                     file.addInlineEnum(clean, fq, e.name, csnToEnumPairs(e, {unwrapVals: true}), eDoc)
                 }
 
                 if ('kind' in entity) {
-                    buffer.add(`static readonly kind: 'entity' | 'type' | 'aspect' = '${entity.kind}';`)
+                    buffer.add(createMember({
+                        name: 'kind',
+                        type: '"entity" | "type" | "aspect"',
+                        isStatic: true,
+                        isReadonly: true,
+                        isDeclare: false,
+                        isOverride: entity.includes?.some(ancestor => this.csn.inferred.definitions[ancestor]?.kind),
+                        initialiser: `'${entity.kind}'`
+                    }))
                 }
                 this.#printStaticKeys(buffer, clean)
                 this.#printStaticActions(entity, buffer, ancestorInfos, file)
@@ -287,7 +310,7 @@ class Visitor {
 
         // CLASS WITH ADDED ASPECTS
         file.addImport(baseDefinitions.path)
-        docify(entity.doc).forEach(d => { buffer.add(d) })
+        buffer.add(docify(entity.doc))
         buffer.add(`export class ${identSingular(clean)} extends ${identAspect(toLocalIdent({clean, fq}))}(${baseDefinitions.path.asIdentifier()}.Entity) {${this.#staticClassContents(clean, entity).join('\n')}}`)
         this.contexts.pop()
     }
@@ -373,11 +396,11 @@ class Visitor {
             // so it can get passed as value to CQL functions.
             const additionalProperties = this.#staticClassContents(singular, entity)
             additionalProperties.push('$count?: number')
-            docify(entity.doc).forEach(d => { buffer.add(d) })
+            buffer.add(docify(entity.doc))
             buffer.add(`export class ${plural} extends Array<${singular}> {${additionalProperties.join('\n')}}`)
             buffer.add(overrideNameProperty(plural, entity.name))
         }
-        buffer.add('')
+        buffer.blankLine()
     }
 
     /**
@@ -522,12 +545,12 @@ class Visitor {
         // file.addImport(new Path(['cds'], '')) TODO make sap/cds import work
         buffer.addIndentedBlock(`export class ${serviceNameSimple} extends cds.Service {`, () => {
             Object.entries(service.operations ?? {}).forEach(([name, {doc}]) => {
-                docify(doc).forEach(d => { buffer.add(d) })
+                buffer.add(docify(doc))
                 buffer.add(`declare ${name}: typeof ${name}`)
             })
         }, '}')
         buffer.add(`export default ${serviceNameSimple}`)
-        buffer.add('')
+        buffer.blankLine()
         file.addService(service.name)
     }
 

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -159,7 +159,7 @@ class Visitor {
             buffer.add(createMember({
                 name: 'actions',
                 type: `${inherited}${empty}`,
-                isStatic:true,
+                isStatic: true,
                 isReadonly: true
             }))
         }

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -283,7 +283,8 @@ class Visitor {
                 }
 
                 for (const e of enums) {
-                    buffer.add(docify(e.doc))
+                    const eDoc = docify(e.doc)
+                    buffer.add(eDoc)
                     buffer.add(createMember({
                         name: e.name,
                         initialiser: propertyToInlineEnumName(clean, e.name),

--- a/library/cds.hana.ts
+++ b/library/cds.hana.ts
@@ -9,7 +9,7 @@ export class VARCHAR extends String {};
 export class CLOB extends String {};
 export class BINARY extends String {}
 export class ST_POINT {
-    public x: number;
-    public y: number;
+    declare public x: number;
+    declare public y: number;
 }
 export class ST_GEOMETRY { /* FIXME */ }

--- a/test/tscheck.js
+++ b/test/tscheck.js
@@ -29,7 +29,7 @@ function checkProgram (program) {
  * @param {import('typescript').CompilerOptions} opts - the options to pass to the TS compiler
  */
 async function checkTranspilation (apiFiles, opts = {}) {
-    const options = {...{ noEmit: true, esModuleInterop: true }, ...opts}
+    const options = {...{ noEmit: true, esModuleInterop: true, strict: true }, ...opts}
     const program = ts.createProgram({ rootNames: apiFiles, options })
     checkProgram(program)
 }

--- a/test/unit/files/actions/model.ts
+++ b/test/unit/files/actions/model.ts
@@ -38,15 +38,15 @@ export class S extends cds.ApplicationService { async init(){
 
   this.on(getOneExternalType,        req => { return {extType:1} satisfies ExternalType})
   this.on(getManyExternalTypes,      req => { return [{extType:1}] satisfies ExternalType[] })
-  this.on(fSingleParamSingleReturn,  req => { const {val} = req.data; return {e1:val.e1} satisfies E })
-  this.on(fSingleParamManyReturn,    req => { const {val} = req.data; return [{e1:val.e1}] satisfies E[] })
-  this.on(fManyParamManyReturn,      req => { const {val} = req.data; return val satisfies E[] })
-  this.on(fManyParamSingleReturn,    req => { const {val} = req.data; return {e1:val[0].e1} satisfies E })
+  this.on(fSingleParamSingleReturn,  req => { const {val} = req.data; return {e1:val?.e1} satisfies E })
+  this.on(fSingleParamManyReturn,    req => { const {val} = req.data; return [{e1:val?.e1}] satisfies E[] })
+  this.on(fManyParamManyReturn,      req => { const {val} = req.data; return val! satisfies E[] })
+  this.on(fManyParamSingleReturn,    req => { const {val} = req.data; return {e1:val?.at(0)?.e1} satisfies E })
 
-  this.on(aSingleParamSingleReturn,  req => { const {val} = req.data; return {e1:val.e1} satisfies E })
-  this.on(aSingleParamManyReturn,    req => { const {val} = req.data; return [{e1:val.e1}] satisfies E[] })
-  this.on(aManyParamManyReturn,      req => { const {val} = req.data; return val satisfies E[] })
-  this.on(aManyParamSingleReturn,    req => { const {val} = req.data; return {e1:val[0].e1} satisfies E })
+  this.on(aSingleParamSingleReturn,  req => { const {val} = req.data; return {e1:val?.e1} satisfies E })
+  this.on(aSingleParamManyReturn,    req => { const {val} = req.data; return [{e1:val?.e1}] satisfies E[] })
+  this.on(aManyParamManyReturn,      req => { const {val} = req.data; return val! satisfies E[] })
+  this.on(aManyParamSingleReturn,    req => { const {val} = req.data; return {e1:val?.at(0)?.e1} satisfies E })
 
   this.on(aMandatoryParam,  req => {
     false satisfies IsKeyOptional<typeof req.data, 'val1'>
@@ -59,27 +59,27 @@ export class S extends cds.ApplicationService { async init(){
   this.on(free2,      req => { return {extType:1} satisfies ExternalType })
   this.on(free3,      req => { return {extRoot:1} satisfies ExternalInRoot})
   this.on(freevoid,   req => { return undefined satisfies void })
-  this.on(freetypeof, req => { req.data.p satisfies number })
+  this.on(freetypeof, req => { req.data.p! satisfies number })
   this.on(free4,      req => { return { extType2:1 } satisfies ExternalType2 })
 
   // calling actions
-  const s2  = await cds.connect.to(S2)
-  await s2.a1({p1: '', p2: [ { extType2: 1 } ]}) satisfies ExternalType
-  await s2.a1('', [ { extType2: 1 } ]) satisfies ExternalType
-  await s2.a2({p1: '', p3: 1}) satisfies ExternalType
-  await s2.a2('', [], 1) satisfies ExternalType
+  const s2:S2  = await cds.connect.to(S2)
+  await s2.a1({p1: '', p2: [ { extType2: 1 } ]}) satisfies ExternalType | null
+  await s2.a1('', [ { extType2: 1 } ]) satisfies ExternalType | null
+  await s2.a2({p1: '', p3: 1}) satisfies ExternalType | null
+  await s2.a2('', [], 1) satisfies ExternalType | null
 
-  await s_.aRfcStyle({INPUT: ''}) satisfies ExternalType
+  await s_.aRfcStyle({INPUT: ''}) satisfies ExternalType | null
   //@ts-expect-error
   await s_.aRfcStyle('') // no positional call style allowed for RFC actions
 
   // docs -> hover over actions
   // provider side
-  this.on(aDocOneLine,    req => { const {val1, val2} = req.data; return {e1:val1[0].e1} satisfies E })
+  this.on(aDocOneLine,    req => { const {val1, val2} = req.data; return {e1:val1?.e1} satisfies E  | null})
   // caller side
   s_.aDocOneLine({val1: {}, val2: {}})
   // provider side
-  this.on(aDocMoreLinesWithBadChar, req => { const {val} = req.data; return {e1:val[0].e1} satisfies E })
+  this.on(aDocMoreLinesWithBadChar, req => { const {val} = req.data; return {e1:val?.e1} satisfies E | null})
   // caller side
   s_.aDocMoreLinesWithBadChar({val: {}})
 

--- a/test/unit/files/keys/model.ts
+++ b/test/unit/files/keys/model.ts
@@ -8,6 +8,6 @@ C.keys.e2 // inherited from E2
 C.keys.c  // own key
 // @ts-expect-error - own non-key property not contained in .keys
 C.keys.d 
-new C().c.toLowerCase()  // still a regular string
+new C().c?.toLowerCase()  // still a regular string
 // @ts-expect-error - Symbol marker not accessible
 new C().c.key


### PR DESCRIPTION
Only add `override` modifier to `kind` property iff any parent class actually has such a property to override.
This change is implicitly tested by having added `strict: true` to the transpilation tests in `tscheck.js`.
Fixes https://github.com/cap-js/cds-typer/issues/273

Generally, the creation of class members has been streamlined to avoid typos and incorrect order/ combination of modifiers via `lib/components.class::createMember` instead of concatenating strings manually.

Also streamlined use of `Buffer.add` to accept scalar strings, array of strings, and functions returning strings, to enable `buffer.add(xs)` over `xs.forEach(x => buffer.add(x))`.
Also added `buffer.blankLine()` to replace the somewhat obscure `buffer.add('')`