### PR TITLE
Do not fail on Windows with `EINVAL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 0.29.0 - TBD
+## Version 0.28.1 - TBD
+
+### Fixed
+- `cds build` no longer fails on Windows with an `EINVAL` error.
 
 ## Version 0.28.0 - 24-10-24
 ### Added

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -110,7 +110,7 @@ cds.build?.register?.('typescript', class extends cds.build.Plugin {
         DEBUG?.('building without config')
         // this will include gen/ that was created by the nodejs task
         // _within_ the project directory. So we need to remove it afterwards.
-        await exec(`npx tsc --outDir "${this.task.dest}"`)
+        await exec(`npx tsc --outDir "${this.task.dest.replace(/\\/g, '/')}"`) // see https://github.com/cap-js/cds-typer/issues/374
         rmDirIfExists(path.join(this.task.dest, cds.env.build.target))
         rmDirIfExists(path.join(this.task.dest, this.#appFolder))
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cap-js/cds-typer",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cap-js/cds-typer",
-      "version": "0.28.0",
+      "version": "0.28.1",
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
         "cds-typer": "lib/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/cds-typer",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "Generates .ts files for a CDS model to receive code completion in VS Code",
   "main": "index.js",
   "repository": "github:cap-js/cds-typer",


### PR DESCRIPTION
A bug somewhere in the mixture of Windows, shell quoting, `tsc`, and node's `exec` function leads to corrupt, partially quoted paths.

No better fix is known than to convert Windows' `\` to `/` with which the issue no longer occurs.

Fixes #374