### PR TITLE
Relaxed check for path config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 - `cds build` no longer fails on Windows with an `EINVAL` error.
+- `cds build` also supports custom model paths in `tsconfig.json` that do not end with `/index.ts`.  This is the case for projects running with `tsx`.
 
 ## Version 0.28.0 - 24-10-24
 ### Added

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -75,12 +75,12 @@ cds.build?.register?.('typescript', class extends cds.build.Plugin {
         const outputDirectory = cds.env.typer?.outputDirectory
         if (outputDirectory) return outputDirectory
         try {
-            // expected format: { '#cds-models/*': [ './@cds-models/*/index.ts' ] }
+            // expected format: { '#cds-models/*': [ './@cds-models/*' ] }
             //                                          ^^^^^^^^^^^
             //                             relevant part - may be changed by user
             const config = JSON.parse(fs.readFileSync ('tsconfig.json', 'utf8'))
             const alias = config.compilerOptions.paths['#cds-models/*'][0]
-            const directory = alias.match(/(?:\.\/)?(.*)\/\*\/index\.ts/)[1]
+            const directory = alias.match(/(?:\.\/)?(.*)\/\*/)[1]
             return normalize(directory)  // could contain forward slashes in tsconfig.json
         } catch {
             DEBUG?.('tsconfig.json not found, not parsable, or inconclusive. Using default model directory name')


### PR DESCRIPTION
Newer projects no longer have the `.../index.ts` file in their tsconfig, to support running with `tsx`.  Don't rely on this file segment here.