### PR TITLE
Reintroduce declare modifier on actions

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -556,6 +556,15 @@ class Buffer {
     }
 
     /**
+     * @returns {Buffer} an empty Buffer that starts at this Buffer's current indentation.
+     */
+    createSubBuffer() {
+        const sub = new Buffer(this.indentation)
+        sub.currentIndent = this.currentIndent
+        return sub
+    }
+
+    /**
      * Indents by the predefined spacing.
      */
     indent() {

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -193,7 +193,7 @@ class Visitor {
         buffer.add(createMember({
             name: 'elements',
             type: createElementsOf(clean),
-            //isDeclare: true,
+            isDeclare: true,
             isStatic: true,
             isReadonly: true
         }))

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -18,6 +18,7 @@ const { last } = require('./components/identifier')
 const { getPropertyModifiers } = require('./components/property')
 const { configuration } = require('./config')
 const { createMember } = require('./components/class')
+const { type } = require('@sap/cds')
 
 /** @typedef {import('./file').File} File */
 /** @typedef {import('./typedefs').visitor.Context} Context */
@@ -141,8 +142,10 @@ class Visitor {
         const inherited = ancestors.length
             ? ancestors.map(a => `typeof ${asIdentifier({info: a, relative: file.path})}.actions`).join(' & ') + ' & '
             : ''
+
+        const typeBuffer = buffer.createSubBuffer()
         if (actions.length) {
-            buffer.addIndentedBlock(`declare static readonly actions: ${inherited}{`,
+            typeBuffer.addIndentedBlock(`${inherited}{`,
                 () => {
                     for (const [aname, action] of actions) {
                         const [opener, content, closer] = SourceFile.stringifyLambda({
@@ -153,18 +156,19 @@ class Visitor {
                                 : 'any',
                             kind: action.kind,
                             doc: docify(action.doc)})
-                        buffer.addIndentedBlock(opener, content, closer)
+                        typeBuffer.addIndentedBlock(opener, content, closer)
                     }
-                }, '}'
-            ) // end of actions
+                }, '}')
         } else {
-            buffer.add(createMember({
-                name: 'actions',
-                type: `${inherited}${empty}`,
-                isStatic: true,
-                isReadonly: true
-            }))
+            typeBuffer.add(`${inherited}${empty}`)
         }
+        buffer.add(createMember({
+            name: 'actions',
+            type: typeBuffer.join().trimStart(),  // remove leading whitespace from indentation, as type is printed in line
+            isStatic: true,
+            isReadonly: true,
+            isDeclare: true,
+        }))
     }
 
     /**
@@ -189,7 +193,7 @@ class Visitor {
         buffer.add(createMember({
             name: 'elements',
             type: createElementsOf(clean),
-            isDeclare: true,
+            //isDeclare: true,
             isStatic: true,
             isReadonly: true
         }))

--- a/test/tscheck.js
+++ b/test/tscheck.js
@@ -1,5 +1,12 @@
 const ts = require('typescript')
 
+const defaultTranspilationOptions = {
+    noEmit: true,
+    esModuleInterop: true,
+    strict: true,
+    noImplicitOverride: true
+}
+
 /**
  * Checks a parsed TS program for error diagnostics.
  * @param {any} program - the parsed TS program
@@ -29,7 +36,7 @@ function checkProgram (program) {
  * @param {import('typescript').CompilerOptions} opts - the options to pass to the TS compiler
  */
 async function checkTranspilation (apiFiles, opts = {}) {
-    const options = {...{ noEmit: true, esModuleInterop: true, strict: true }, ...opts}
+    const options = {...defaultTranspilationOptions, ...opts}
     const program = ts.createProgram({ rootNames: apiFiles, options })
     checkProgram(program)
 }

--- a/test/unit/files/actions/model.cds
+++ b/test/unit/files/actions/model.cds
@@ -85,3 +85,13 @@ service S2 {
     action a1 (p1: String, p2: many ExternalType2) returns ExternalType;
     action a2 (p1: String not null, p2: many ExternalType2, p3: Integer not null) returns ExternalType
 }
+
+entity Parent {}
+    actions {
+        action a()
+    }
+
+entity Child: Parent {}
+    actions {
+        action b()
+    }

--- a/test/unit/files/actions/model.ts
+++ b/test/unit/files/actions/model.ts
@@ -32,7 +32,7 @@ import { ExternalInRoot } from '#cds-models';
 type IsKeyOptional<T extends Record<string | number | symbol, unknown>, Keys extends keyof T> =
     {[Key in Keys]?: T[Key]} extends Pick<T, Keys> ? true : false;
 
-export class S extends cds.ApplicationService { async init(){
+export class S extends cds.ApplicationService { override async init(){
 
   const s_  = await cds.connect.to(S_)
 

--- a/test/unit/files/draft/model.ts
+++ b/test/unit/files/draft/model.ts
@@ -3,7 +3,7 @@ import {DraftEntity} from '#cds-models/_'
 import {Books, Publishers} from '#cds-models/bookshop/service/CatalogService'
 
 export class CatalogService extends cds.ApplicationService {
-    async init() {
+    override async init() {
 
         this.after("READ", Publishers.drafts, publishers => {
             if (!publishers?.length) return


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/391

We recently introduced a distinction between entities that have no actions ( = empty `.actions` property) and ones that do. In one of these branches, the required `overrides` modifier got lost. This PR streamlines both cases and reintroduces the modifier.
It also strictens the effective tsconfig that is used for transpilation tests to catch this kind of regression in the future.