### PR TITLE
Propagate keys from parents down to child entities

### DIFF
--- a/lib/components/wrappers.js
+++ b/lib/components/wrappers.js
@@ -88,6 +88,13 @@ const createObjectOf = t => `{${t}}`
 const createUnionOf = (...types) => types.join(' | ')
 
 /**
+ * Wraps types into a intersection type string
+ * @param {string[]} types - an array of types
+ * @returns {string}
+ */
+const createIntersectionOf = (...types) => types.join(' & ')
+
+/**
  * Wraps type into a promise
  * @param {string} t - the type to wrap.
  * @returns {string}
@@ -97,6 +104,17 @@ const createUnionOf = (...types) => types.join(' | ')
  * ```
  */
 const createPromiseOf = t => `Promise<${t}>`
+
+/**
+ * Wraps type into `ReturnType`
+ * @param {string} t - the type to wrap.
+ * @returns {string}
+ * @example
+ * ```js
+ * createReturnTypeOf('typeof myFunction') // -> 'ReturnType<typeof myFunction>'
+ * ```
+ */
+const createReturnTypeOf = t => `ReturnType<${t}>`
 
 /**
  * Wraps type into a deep require (removes all posibilities of undefined recursively).
@@ -135,7 +153,9 @@ module.exports = {
     createElementsOf,
     createObjectOf,
     createPromiseOf,
+    createReturnTypeOf,
     createUnionOf,
+    createIntersectionOf,
     createToOneAssociation,
     createToManyAssociation,
     createCompositionOfOne,

--- a/lib/components/wrappers.js
+++ b/lib/components/wrappers.js
@@ -106,17 +106,6 @@ const createIntersectionOf = (...types) => types.join(' & ')
 const createPromiseOf = t => `Promise<${t}>`
 
 /**
- * Wraps type into `ReturnType`
- * @param {string} t - the type to wrap.
- * @returns {string}
- * @example
- * ```js
- * createReturnTypeOf('typeof myFunction') // -> 'ReturnType<typeof myFunction>'
- * ```
- */
-const createReturnTypeOf = t => `ReturnType<${t}>`
-
-/**
  * Wraps type into a deep require (removes all posibilities of undefined recursively).
  * @param {string} t - the singular type name.
  * @param {string?} lookup - a property lookup of the required type (`['Foo']`)
@@ -153,7 +142,6 @@ module.exports = {
     createElementsOf,
     createObjectOf,
     createPromiseOf,
-    createReturnTypeOf,
     createUnionOf,
     createIntersectionOf,
     createToOneAssociation,

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -8,7 +8,7 @@ const { SourceFile, FileRepository, Buffer, Path } = require('./file')
 const { FlatInlineDeclarationResolver, StructuredInlineDeclarationResolver } = require('./components/inline')
 const { Resolver } = require('./resolution/resolver')
 const { LOG } = require('./logging')
-const { docify, createPromiseOf, createUnionOf, createKeysOf, createElementsOf, stringIdent, createDraftsOf, createDraftOf } = require('./components/wrappers')
+const { docify, createPromiseOf, createUnionOf, createKeysOf, createElementsOf, stringIdent, createDraftsOf, createDraftOf, createIntersectionOf, createReturnTypeOf } = require('./components/wrappers')
 const { csnToEnumPairs, propertyToInlineEnumName, isInlineEnumType, stringifyEnumType } = require('./components/enum')
 const { isReferenceType } = require('./components/reference')
 const { empty } = require('./components/typescript')
@@ -18,7 +18,6 @@ const { last } = require('./components/identifier')
 const { getPropertyModifiers } = require('./components/property')
 const { configuration } = require('./config')
 const { createMember } = require('./components/class')
-const { type } = require('@sap/cds')
 
 /** @typedef {import('./file').File} File */
 /** @typedef {import('./typedefs').visitor.Context} Context */
@@ -174,11 +173,13 @@ class Visitor {
     /**
      * @param {Buffer} buffer - the buffer to write the keys into
      * @param {string} clean - the clean name of the entity
+     * @param {string[]} ancestorAspects - a list of ancestor aspects (`['__.FooAspect', '__.BarAspect']`) to derive inherited keys from
      */
-    #printStaticKeys(buffer, clean) {
+    #printStaticKeys(buffer, clean, ancestorAspects = []) {
+        const ancestorKeys = ancestorAspects.map(a => createReturnTypeOf(`typeof ${a}`) + '["keys"]')
         buffer.add(createMember({
             name: 'keys',
-            type: createKeysOf(clean),
+            type: createIntersectionOf(createKeysOf(clean), ...ancestorKeys),
             isDeclare: true,
             isStatic: true,
             isReadonly: true,
@@ -259,6 +260,9 @@ class Visitor {
             .reverse() // reverse so that own aspect A is applied before extensions B,C: B(C(A(Entity)))
             .reduce((wrapped, ancestor) => `${asIdentifier({info: ancestor, wrapper: name => `_${name}Aspect`, relative: file.path})}(${wrapped})`, 'Base')
 
+        const ancestorsAspectFunctions = ancestorInfos
+            .map(ancestor => `${asIdentifier({info: ancestor, wrapper: name => `_${name}Aspect`, relative: file.path})}`, 'Base')
+
         this.contexts.push({ entity: fq })
 
         // CLASS ASPECT
@@ -324,7 +328,7 @@ class Visitor {
                         initialiser: stringIdent(entity.kind)
                     }))
                 }
-                this.#printStaticKeys(buffer, clean)
+                this.#printStaticKeys(buffer, clean, ancestorsAspectFunctions)
                 this.#printStaticElements(buffer, clean)
                 this.#printStaticActions(entity, buffer, ancestorInfos, file)
             }, '};') // end of generated class

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -259,7 +259,7 @@ class Visitor {
 
         const ancestorsAspects = ancestorInfos
             .reverse() // reverse so that own aspect A is applied before extensions B,C: B(C(A(Entity)))
-            .reduce((wrapped, ancestor) => `${`${asIdentifier({info: ancestor, wrapper: name => `_${name}Aspect`, relative: file.path})}`}(${wrapped})`, 'Base')
+            .reduce((wrapped, ancestor) => `${asIdentifier({info: ancestor, wrapper: name => `_${name}Aspect`, relative: file.path})}(${wrapped})`, 'Base')
 
         this.contexts.push({ entity: fq })
 
@@ -318,7 +318,7 @@ class Visitor {
                 if ('kind' in entity) {
                     buffer.add(createMember({
                         name: 'kind',
-                        type: '"entity" | "type" | "aspect"',
+                        type: createUnionOf(...['entity', 'type', 'aspect'].map(stringIdent)),
                         isStatic: true,
                         isReadonly: true,
                         isDeclare: false,

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -138,13 +138,11 @@ class Visitor {
     #printStaticActions(entity, buffer, ancestors, file) {
         // TODO: refactor away! All these printing functionalities need to go
         const actions = Object.entries(entity.actions ?? {})
-        const inherited = ancestors.length
-            ? ancestors.map(a => `typeof ${asIdentifier({info: a, relative: file.path})}.actions`).join(' & ') + ' & '
-            : ''
+        const inherited = ancestors.map(a => `typeof ${asIdentifier({info: a, relative: file.path})}.actions`)
 
         const typeBuffer = buffer.createSubBuffer()
         if (actions.length) {
-            typeBuffer.addIndentedBlock(`${inherited}{`,
+            typeBuffer.addIndentedBlock(createIntersectionOf(...inherited, '{'),
                 () => {
                     for (const [aname, action] of actions) {
                         const [opener, content, closer] = SourceFile.stringifyLambda({
@@ -159,7 +157,7 @@ class Visitor {
                     }
                 }, '}')
         } else {
-            typeBuffer.add(`${inherited}${empty}`)
+            typeBuffer.add(createIntersectionOf(...inherited, empty))
         }
         buffer.add(createMember({
             name: 'actions',
@@ -173,10 +171,13 @@ class Visitor {
     /**
      * @param {Buffer} buffer - the buffer to write the keys into
      * @param {string} clean - the clean name of the entity
-     * @param {string[]} ancestorAspects - a list of ancestor aspects (`['__.FooAspect', '__.BarAspect']`) to derive inherited keys from
+     * @param {import('./typedefs').resolver.EntityInfo[]} ancestors - ancestors infos to include in they type
+     * @param {SourceFile} file - the file the entity is being printed into
      */
-    #printStaticKeys(buffer, clean, ancestorAspects = []) {
-        const ancestorKeys = ancestorAspects.map(a => createReturnTypeOf(`typeof ${a}`) + '["keys"]')
+    #printStaticKeys(buffer, clean, ancestors, file) {
+        const ancestorKeys = ancestors
+            .filter(a => Object.entries(a.csn.keys ?? {}).length)
+            .map(a => `typeof ${asIdentifier({info: a, relative: file.path})}.keys`)
         buffer.add(createMember({
             name: 'keys',
             type: createIntersectionOf(createKeysOf(clean), ...ancestorKeys),
@@ -247,21 +248,18 @@ class Visitor {
         // will produce an error if bar also has a property ID which now clashes with foo.ID
         // WARNING: annotations from entities without properties should actually be propagated this way!
         // So once we start caring about annotations, we have to revisit this part.
-        /** @type {{ info: import('./typedefs').resolver.EntityInfo, aspectFunction: string}[]} */
+        /** @type {import('./typedefs').resolver.EntityInfo[]} */
         const ancestorInfos = ((!isViewOrProjection(entity) ? entity.includes : []) ?? [])
             .map(ancestor => {
                 const info = this.entityRepository.getByFq(ancestor)
                 if (!info) throw new Error(`could not resolve ancestor ${ancestor} for ${fq}`)
                 file.addImport(info.namespace)
-                return {
-                    info,
-                    aspectFunction: `${asIdentifier({info, wrapper: name => `_${name}Aspect`, relative: file.path})}`
-                }
+                return info
             })
 
         const ancestorsAspects = ancestorInfos
             .reverse() // reverse so that own aspect A is applied before extensions B,C: B(C(A(Entity)))
-            .reduce((wrapped, { aspectFunction }) => `${aspectFunction}(${wrapped})`, 'Base')
+            .reduce((wrapped, ancestor) => `${`${asIdentifier({info: ancestor, wrapper: name => `_${name}Aspect`, relative: file.path})}`}(${wrapped})`, 'Base')
 
         this.contexts.push({ entity: fq })
 
@@ -324,17 +322,13 @@ class Visitor {
                         isStatic: true,
                         isReadonly: true,
                         isDeclare: false,
-                        isOverride: ancestorInfos.some(({info}) => info.csn.kind),
+                        isOverride: ancestorInfos.some(({csn}) => csn.kind),
                         initialiser: stringIdent(entity.kind)
                     }))
                 }
-
-                const ancestorFunctionsWithKeys = ancestorInfos
-                    .filter(({ info }) => Object.entries(info.csn.keys ?? {}).length)
-                    .map(({ aspectFunction }) => aspectFunction)
-                this.#printStaticKeys(buffer, clean, ancestorFunctionsWithKeys)
+              this.#printStaticKeys(buffer, clean, ancestorInfos, file)
                 this.#printStaticElements(buffer, clean)
-                this.#printStaticActions(entity, buffer, ancestorInfos.map(({info}) => info), file)
+                this.#printStaticActions(entity, buffer, ancestorInfos, file)
             }, '};') // end of generated class
         }, '}') // end of aspect
 

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -326,7 +326,7 @@ class Visitor {
                         initialiser: stringIdent(entity.kind)
                     }))
                 }
-              this.#printStaticKeys(buffer, clean, ancestorInfos, file)
+                this.#printStaticKeys(buffer, clean, ancestorInfos, file)
                 this.#printStaticElements(buffer, clean)
                 this.#printStaticActions(entity, buffer, ancestorInfos, file)
             }, '};') // end of generated class

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -247,21 +247,21 @@ class Visitor {
         // will produce an error if bar also has a property ID which now clashes with foo.ID
         // WARNING: annotations from entities without properties should actually be propagated this way!
         // So once we start caring about annotations, we have to revisit this part.
-        /** @type {import('./typedefs').resolver.EntityInfo[]} */
+        /** @type {{ info: import('./typedefs').resolver.EntityInfo, aspectFunction: string}[]} */
         const ancestorInfos = ((!isViewOrProjection(entity) ? entity.includes : []) ?? [])
             .map(ancestor => {
                 const info = this.entityRepository.getByFq(ancestor)
                 if (!info) throw new Error(`could not resolve ancestor ${ancestor} for ${fq}`)
                 file.addImport(info.namespace)
-                return info
+                return {
+                    info,
+                    aspectFunction: `${asIdentifier({info, wrapper: name => `_${name}Aspect`, relative: file.path})}`
+                }
             })
 
         const ancestorsAspects = ancestorInfos
             .reverse() // reverse so that own aspect A is applied before extensions B,C: B(C(A(Entity)))
-            .reduce((wrapped, ancestor) => `${asIdentifier({info: ancestor, wrapper: name => `_${name}Aspect`, relative: file.path})}(${wrapped})`, 'Base')
-
-        const ancestorsAspectFunctions = ancestorInfos
-            .map(ancestor => `${asIdentifier({info: ancestor, wrapper: name => `_${name}Aspect`, relative: file.path})}`, 'Base')
+            .reduce((wrapped, { aspectFunction }) => `${aspectFunction}(${wrapped})`, 'Base')
 
         this.contexts.push({ entity: fq })
 
@@ -324,13 +324,17 @@ class Visitor {
                         isStatic: true,
                         isReadonly: true,
                         isDeclare: false,
-                        isOverride: ancestorInfos.some(ancestor => ancestor.csn.kind),
+                        isOverride: ancestorInfos.some(({info}) => info.csn.kind),
                         initialiser: stringIdent(entity.kind)
                     }))
                 }
-                this.#printStaticKeys(buffer, clean, ancestorsAspectFunctions)
+
+                const ancestorFunctionsWithKeys = ancestorInfos
+                    .filter(({ info }) => Object.entries(info.csn.keys ?? {}).length)
+                    .map(({ aspectFunction }) => aspectFunction)
+                this.#printStaticKeys(buffer, clean, ancestorFunctionsWithKeys)
                 this.#printStaticElements(buffer, clean)
-                this.#printStaticActions(entity, buffer, ancestorInfos, file)
+                this.#printStaticActions(entity, buffer, ancestorInfos.map(({info}) => info), file)
             }, '};') // end of generated class
         }, '}') // end of aspect
 

--- a/test/ast.js
+++ b/test/ast.js
@@ -523,11 +523,14 @@ const check = {
     isNull: node => checkKeyword(node, 'literaltype') && checkKeyword(node.literal, 'null'),
     isUnionType: (node, of = []) => checkKeyword(node, 'uniontype')
         && of.reduce((acc, predicate) => acc && node.subtypes.some(st => predicate(st)), true),
+    isIntersectionType: (node, of = []) => checkKeyword(node, 'intersectiontype')
+        && of.reduce((acc, predicate) => acc && node.subtypes.some(st => predicate(st)), true),
     isNullable: (node, of = []) => check.isUnionType(node, of.concat([check.isNull])),
     isOptional: node => node.optional,
     hasDeclareModifier: node => node?.modifiers?.some(mod => checkKeyword(mod, 'declare')),
     isLiteral: (node, literal = undefined) => checkKeyword(node, 'literaltype') && (literal === undefined || node.literal === literal),
     isTypeReference: (node, full = undefined) => checkNodeType(node, 'typeReference') && (!full || node.full === full),
+    isTypeQuery: node => checkKeyword(node, 'typequery'),  // FIXME: should actually check what is being queried
     isTypeAliasDeclaration: node => checkNodeType(node, 'typeAliasDeclaration'),
     isVariableDeclaration: node => checkNodeType(node, 'variableStatement'),
     isCallExpression: (node, expression) => checkNodeType(node, 'callExpression') && (!expression || node.expression === expression),

--- a/test/unit/files/keys/model.cds
+++ b/test/unit/files/keys/model.cds
@@ -21,7 +21,9 @@ entity C: A, E2 {
 // mutual association, while also both extending cuid
 using { cuid } from '@sap/cds/common';
 
-entity Foo: cuid {
+entity SomethingWithoutKey {}
+
+entity Foo: cuid, SomethingWithoutKey {
     bar: Association to Bar
 }
 

--- a/test/unit/files/keys/model.cds
+++ b/test/unit/files/keys/model.cds
@@ -17,3 +17,14 @@ entity C: A, E2 {
     key c: String;
     d: Integer;
 }
+
+// mutual association, while also both extending cuid
+using { cuid } from '@sap/cds/common';
+
+entity Foo: cuid {
+    bar: Association to Bar
+}
+
+entity Bar: cuid {
+    foo: Association to Foo
+}

--- a/test/unit/keys.test.js
+++ b/test/unit/keys.test.js
@@ -20,4 +20,15 @@ describe('KeyOf', () => {
         expect(astw.getAspectProperty('_CAspect', 'keys')).toBeTruthy()
         expect(check.isStaticMember(keys)).toBeTruthy()
     })
+
+    test('Key Type Inherited', () => {
+        const keys = astw.getAspectProperty('_FooAspect', 'keys')
+        expect(astw.getAspectProperty('_CAspect', 'keys')).toBeTruthy()
+        expect(check.isStaticMember(keys)).toBeTruthy()
+        expect(keys.type.subtypes.length === 2)  // just Foo and cuid, no type for SomethingWithoutKey -> 2
+        expect(check.isIntersectionType(keys.type, [
+            st => check.isTypeReference(st, '___.KeysOf'),
+            st => check.isTypeQuery(st)
+        ])).toBeTruthy()
+    })
 })


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/391

Having two entities that mutually reference each other, and also extend a common ancestors that has a key would throw of the `KeysOf` type.

In the minimal model
```cds
using { cuid } from '@sap/cds/common';

entity Foo: cuid {
  bar: Association to Bar
}

entity Bar: cuid {
  foo: Association to Foo
}
```
TS would complain about at least one resulting aspect function, as the inherited `ID` property was supposedly missing from the descendents `.keys` property.

```ts
class cuid {
  ID: Key<string>
  static keys: KeysOf<cuid>
}

class Foo extends cuid {
  static keys: KeysOf<Foo>  // error: .keys should have a property "ID", which is missing
}
```

With this PR, each parent's `typeof .keys` is explicitly repeated:

```ts
class cuid {
  ID: Key<string>
  static keys: KeysOf<cuid>
}

class Foo extends cuid {
  static keys: KeysOf<Foo> & KeysOf<cuid>
}
```