### PR TITLE
Use full file path for package.json

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -148,6 +148,9 @@ const getProjectTargetType = root => {
 
     do {
         packageJson = fs.readdirSync(dir).find(f => f.endsWith('package.json'))
+        if (packageJson) {
+            packageJson = path.join(dir, packageJson)
+        }
         dir = path.dirname(dir)
     } while (!packageJson && !isFsRoot(dir))
 


### PR DESCRIPTION
Finding a package.json in a parent directory (mono repo scenario) would still try to open package.json in the CWD, which would then fail. This fix now prepends the directory the file was found in, making it an absolute path instead.