### PR TITLE
Add enforce changelog workflow

### DIFF
--- a/.github/workflows/enforce-changelog.yml
+++ b/.github/workflows/enforce-changelog.yml
@@ -10,4 +10,4 @@ jobs:
     - uses: dangoslen/changelog-enforcer@v3
       with:
         skipLabels: "skip changelog"
-        missingUpdateErrorMessage: "PR does not update CHANGELOG.md! If this was done on purpose, at the 'skip changelog' label."
+        missingUpdateErrorMessage: "PR does not update CHANGELOG.md! If this was done on purpose, add the 'skip changelog' label."

--- a/.github/workflows/enforce-changelog.yml
+++ b/.github/workflows/enforce-changelog.yml
@@ -1,0 +1,13 @@
+name: "Enforce Changelog"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dangoslen/changelog-enforcer@v3
+      with:
+        skipLabels: "skip changelog"
+        missingUpdateErrorMessage: "PR does not update CHANGELOG.md! If this was done on purpose, at the 'skip changelog' label."


### PR DESCRIPTION
Adds a workflow that enforces changes to CHANGELOG.md in new PRs.
Check can be bypassed by adding the `skip changelog` label to a PR.

See: https://github.com/cap-js/cds-typer/actions/runs/11934582832/job/33263999681?pr=401