### PR TITLE
Read default output @cds-models from package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## Version 0.30.0 - TBD
 
 ### Changed
-- [breaking] when running cds-typer in a CAP project, the default for the `outputDirectory` option will be `./@cds-models` instead of `./`
+- [breaking] when running cds-typer in a CAP project, the default for the `outputDirectory` option will be `./@cds-models` instead of `./`. This default takes the lowest precedence after explicitly setting it in the project's `cds.env`, or explicitly as CLI argument.
 
 ### Fixed
 - cds-typer no longer ignores the selected `outputDirectory`, which would also cause an issue during build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.30.0 - TBD
 
-## Version 0.29.1 - TBD
+### Changed
+- [breaking] when running cds-typer in a CAP project, the default for the `outputDirectory` option will be `./@cds-models` instead of `./`
+
 ### Fixed
 - cds-typer no longer ignores the selected `outputDirectory`, which would also cause an issue during build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## Version 0.30.0 - TBD
 
 ### Changed
-- [breaking] when running cds-typer in a CAP project, the default for the `outputDirectory` option will be `./@cds-models` instead of `./`. This default takes the lowest precedence after explicitly setting it in the project's `cds.env`, or explicitly as CLI argument.
+- [breaking] when running cds-typer in a CAP project, the default for the `outputDirectory` option will be `./@cds-models` instead of `./`. This default takes the lowest precedence after setting it in the project's `cds.env`, or explicitly as CLI argument.
 
 ### Fixed
 - cds-typer no longer ignores the selected `outputDirectory`, which would also cause an issue during build

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -259,6 +259,9 @@ const prepareParameters = (/** @type {any[]} */ argv) => {
 }
 
 const main = async (/** @type {any[]} */ argv) => {
+    // when calling from CLI within a CAP project, make sure plugins (this includes cds-typer)
+    // are initialised and have their default values injected into cds.env
+    await cds.plugins
     const { positional } = prepareParameters(argv)
     compileFromFile(positional)
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -37,6 +37,9 @@ class Config {
     /** @type {Record<string, unknown>} */
     static #defaults = {}
     static get defaults () {
+        // these are the exact defaults that are used when cds-typer is loaded as cds plugin
+        // which will shove the values into cds.env. When executed standalone, without cds environment,
+        // we need to load them from package.json ourselves.
         if (Object.keys(Config.#defaults).length) return Config.#defaults
         try {
             const packageJsonPath = path.resolve(__dirname, '../package.json')

--- a/lib/config.js
+++ b/lib/config.js
@@ -51,7 +51,7 @@ class Config {
     values = undefined
     proxy = undefined
 
-    async init () {
+    init () {
         this.values = {...Config.defaults, ...(cds.env.typer ?? {})}
         this.proxy = camelSnakeHybrid(this.values)
         if (this.proxy.targetModuleType === 'auto') {

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,3 +1,5 @@
+const fs = require('node:fs')
+const path = require('node:path')
 const cds = require('@sap/cds')
 const { camelToSnake, getProjectTargetType } = require('./util')
 const { LOG } = require('./logging')
@@ -32,21 +34,27 @@ const camelSnakeHybrid = target => {
     return proxy
 }
 class Config {
-    static #defaults = {
-        propertiesOptional: true,
-        useEntitiesProxy: false,
-        inlineDeclarations: 'flat',
-        outputDirectory: '.',
-        targetModuleType: 'auto'
+    /** @type {Record<string, unknown>} */
+    static #defaults = {}
+    static get defaults () {
+        if (Object.keys(Config.#defaults).length) return Config.#defaults
+        try {
+            const packageJsonPath = path.resolve(__dirname, '../package.json')
+            const pjson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+            Config.#defaults = pjson.cds.typer
+        } catch (e) {
+            LOG.error(`Failed to load default configuration from package.json: ${e}`)
+        }
+        return Config.#defaults
     }
 
     values = undefined
     proxy = undefined
 
-    init () {
-        this.values = {...Config.#defaults, ...(cds.env.typer ?? {})}
+    async init () {
+        this.values = {...Config.defaults, ...(cds.env.typer ?? {})}
         this.proxy = camelSnakeHybrid(this.values)
-        if (this.values.targetModuleType === 'auto') {
+        if (this.proxy.targetModuleType === 'auto') {
             const type = getProjectTargetType(cds.root)
             if (type) {
                 LOG.info(`automatically detected module type '${type}' in ${cds.root}`)

--- a/lib/config.js
+++ b/lib/config.js
@@ -42,7 +42,7 @@ class Config {
         // we need to load them from package.json ourselves.
         if (Object.keys(Config.#defaults).length) return Config.#defaults
         try {
-            const packageJsonPath = path.resolve(__dirname, '../package.json')
+            const packageJsonPath = path.resolve(__dirname, path.join('..', 'package.json'))
             const pjson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
             Config.#defaults = pjson.cds.typer
         } catch (e) {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,13 @@
     ]
   },
   "cds": {
+    "typer": {
+      "output_directory": "@cds-models",
+      "inline_declarations": "flat",
+      "target_module_type": "auto",
+      "properties_optional": true,
+      "use_entities_proxy": false
+    },
     "schema": {
       "buildTaskType": {
         "name": "typescript",


### PR DESCRIPTION
Change default value for `outputDirectory` from `./` to `./@cds-models` when executed in a CAP project.

This PR does _not_ include changing the default for the target model files to `"*"`.