### PR TITLE
Add script to automatically label dependabot prs

### DIFF
--- a/.github/workflows/dependabot-skip-changelog.yml
+++ b/.github/workflows/dependabot-skip-changelog.yml
@@ -1,0 +1,30 @@
+name: Label Dependabot PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  label_dependabot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR is by Dependabot
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prAuthor = context.payload.pull_request.user.login;
+            const prNumber = context.payload.pull_request.number;
+            const repoOwner = context.repo.owner;
+            const repoName = context.repo.repo;
+
+            if (prAuthor === 'dependabot[bot]' || prAuthor === 'dependabot') {
+              core.info(`PR #${prNumber} is authored by Dependabot. Adding label...`);
+              await github.rest.issues.addLabels({
+                owner: repoOwner,
+                repo: repoName,
+                issue_number: prNumber,
+                labels: ['skip changelog']
+              });
+            } else {
+              core.info(`PR #${prNumber} is not authored by Dependabot. No action taken.`);
+            }


### PR DESCRIPTION
Automatically ad the `skip changelog` label to avoid blocking PRs from Dependabot.