### PR TITLE
Act on finding "type":"module"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 ### Fixed
 - type-referencing a property that is a key no longer breaks the referring property
+- leaving `target_module_type` at `'auto'` now properly acts on a detected `"type":"module"`
 
 ### Added
 - new release workflow

--- a/lib/config.js
+++ b/lib/config.js
@@ -59,13 +59,15 @@ class Config {
         this.proxy = camelSnakeHybrid(this.values)
         if (this.proxy.targetModuleType === 'auto') {
             const type = getProjectTargetType(cds.root)
+            let detectedType = 'cjs'
             if (type) {
                 LOG.info(`automatically detected module type '${type}' in ${cds.root}`)
-                this.values.targetModuleType = type
+                detectedType = type
             } else {
                 LOG.warn(`target module type was set to 'auto', but could not detect module type in ${cds.root}. Falling back to cjs`)
-                this.values.targetModuleType = 'cjs'
             }
+            this.values.targetModuleType = detectedType
+            this.proxy.targetModuleType = detectedType
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/432