### PR TITLE
Add permissions to label workflow

### DIFF
--- a/.github/workflows/dependabot-skip-changelog.yml
+++ b/.github/workflows/dependabot-skip-changelog.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   label_dependabot:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Check if PR is by Dependabot
         uses: actions/github-script@v7


### PR DESCRIPTION
All PRs are by default blocked if they didn't make any change to CHANGELOG.md, unless they have the `skip changelog` label. This requirement does not hold for dependabot PRs. So any PR opened by dependabot should automatically be assigned the `skip changelog` label. This [did not work before](https://github.com/cap-js/cds-typer/actions/runs/12353218335/job/34471863295?pr=441), likely because of the missing permissions that are added with this PR.