### PR TITLE
ci(enforce-changelog): use org workflow

### DIFF
--- a/.github/workflows/enforce-changelog.yml
+++ b/.github/workflows/enforce-changelog.yml
@@ -5,5 +5,7 @@ on:
 
 jobs:
   enforece-changelog:
+    permissions:
+      pull-requests: write
     uses: cap-js/.github/.github/workflows/enforce-changelog.yml@ci/addEnforceChangeLog
     secrets: inherit

--- a/.github/workflows/enforce-changelog.yml
+++ b/.github/workflows/enforce-changelog.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   enforce-changelog:
-    uses: cap-js/.github/.github/workflows/enforce-changelog.yml@ci/addEnforceChangeLog
+    uses: cap-js/.github/.github/workflows/enforce-changelog.yml@main
     secrets: inherit
     permissions:
       pull-requests: write

--- a/.github/workflows/enforce-changelog.yml
+++ b/.github/workflows/enforce-changelog.yml
@@ -4,35 +4,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:
-  label_dependabot:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Check if PR is by Dependabot
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prAuthor = context.payload.pull_request.user.login;
-            const prNumber = context.payload.pull_request.number;
-            const repoOwner = context.repo.owner;
-            const repoName = context.repo.repo;
-
-            if (prAuthor === 'dependabot[bot]' || prAuthor === 'dependabot') {
-              core.info(`PR #${prNumber} is authored by Dependabot. Adding label...`);
-              await github.rest.issues.addLabels({
-                owner: repoOwner,
-                repo: repoName,
-                issue_number: prNumber,
-                labels: ['skip changelog']
-              });
-            } else {
-              core.info(`PR #${prNumber} is not authored by Dependabot. No action taken.`);
-            }
-  changelog:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: dangoslen/changelog-enforcer@v3
-      with:
-        skipLabels: "skip changelog"
-        missingUpdateErrorMessage: "PR does not update CHANGELOG.md! If this was done on purpose, add the 'skip changelog' label."
+  enforece-changelog:
+    uses: cap-js/.github/.github/workflows/enforce-changelog.yml@ci/addEnforceChangeLog
+    secrets: inherit

--- a/.github/workflows/enforce-changelog.yml
+++ b/.github/workflows/enforce-changelog.yml
@@ -4,8 +4,8 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:
-  enforece-changelog:
-    permissions:
-      pull-requests: write
+  enforce-changelog:
     uses: cap-js/.github/.github/workflows/enforce-changelog.yml@ci/addEnforceChangeLog
     secrets: inherit
+    permissions:
+      pull-requests: write


### PR DESCRIPTION
```yaml
cap-js/.github/.github/workflows/enforce-changelog.yml@ci/addEnforceChangeLog
````
will be replaced by 
```yaml
cap-js/.github/.github/workflows/enforce-changelog.yml@main
```` 
once https://github.com/cap-js/.github/pull/15 is merged