### PR TITLE
Add flag to explicitly disable the typescript build task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Support new `cds.Map` type, which is emitted as `{[key:string]: unknown}`. The most appropriate type would in fact be `{[key:string]: any}`, which would also allow any and all keys. But would also cause issues with strict project configurations. Therefore, to effectively use `cds.Map`, users will have to cast the `unknown`s to the effective type they expect.
-- Introduce `cds.env.typer.skip_build_task` to allow disabling the `typescript` build task shipped with cds-typer
+- Introduce `cds.env.typer.build_task` to allow disabling the `typescript` build task shipped with cds-typer by setting it to `false`
 
 ### Changed
 - `CHANGELOG.md` and `LICENSE` files are no longer part of the npm package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Support new `cds.Map` type, which is emitted as `{[key:string]: unknown}`. The most appropriate type would in fact be `{[key:string]: any}`, which would also allow any and all keys. But would also cause issues with strict project configurations. Therefore, to effectively use `cds.Map`, users will have to cast the `unknown`s to the effective type they expect.
+- Introduce `cds.env.typer.skip_build_task` to allow disabling the `typescript` build task shipped with cds-typer
+
 ### Changed
 - `CHANGELOG.md` and `LICENSE` files are no longer part of the npm package.
 

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -52,93 +52,101 @@ const rmFiles = async (dir, exts) => fs.existsSync(dir)
     )
     : undefined
 
-// FIXME: remove once cds7 has been phased out
-if (!cds?.version || cds.version < '8.0.0') {
-    DEBUG?.('typescript build task requires @sap/cds-dk version >= 8.0.0, skipping registration')
-    return
-}
+// IIFE to be able to return early
+;(() => {
+    // FIXME: remove once cds7 has been phased out
+    if (!cds?.version || cds.version < '8.0.0') {
+        DEBUG?.('typescript build task requires @sap/cds-dk version >= 8.0.0, skipping registration')
+        return
+    }
 
-// requires @sap/cds-dk version >= 7.5.0
-cds.build?.register?.('typescript', class extends cds.build.Plugin {
-    static taskDefaults = { src: '.' }
-    static hasTask() { return isTypeScriptProject() }
+    if (cds.env.typer?.skipBuildTask) {
+        DEBUG?.('skipping typescript build task registration based on configuration option')
+        return
+    }
 
-    // lower priority than the nodejs task
-    get priority() { return -1 }
+    // requires @sap/cds-dk version >= 7.5.0
+    cds.build?.register?.('typescript', class extends cds.build.Plugin {
+        static taskDefaults = { src: '.' }
+        static hasTask() { return isTypeScriptProject() }
 
-    get #appFolder () { return cds?.env?.folders?.app ?? 'app' }
+        // lower priority than the nodejs task
+        get priority() { return -1 }
 
-    /**
-     * cds.env > tsconfig.compilerOptions.paths > '@cds-models' (default)
-     */
-    get #modelDirectoryName () {
-        const outputDirectory = cds.env.typer?.outputDirectory
-        if (outputDirectory) return outputDirectory
-        try {
-            // expected format: { '#cds-models/*': [ './@cds-models/*' ] }
-            //                                          ^^^^^^^^^^^
-            //                             relevant part - may be changed by user
-            const config = JSON.parse(fs.readFileSync ('tsconfig.json', 'utf8'))
-            const alias = config.compilerOptions.paths['#cds-models/*'][0]
-            const directory = alias.match(/(?:\.\/)?(.*)\/\*/)[1]
-            return normalize(directory)  // could contain forward slashes in tsconfig.json
-        } catch {
-            DEBUG?.('tsconfig.json not found, not parsable, or inconclusive. Using default model directory name')
+        get #appFolder () { return cds?.env?.folders?.app ?? 'app' }
+
+        /**
+         * cds.env > tsconfig.compilerOptions.paths > '@cds-models' (default)
+         */
+        get #modelDirectoryName () {
+            const outputDirectory = cds.env.typer?.outputDirectory
+            if (outputDirectory) return outputDirectory
+            try {
+                // expected format: { '#cds-models/*': [ './@cds-models/*' ] }
+                //                                          ^^^^^^^^^^^
+                //                             relevant part - may be changed by user
+                const config = JSON.parse(fs.readFileSync ('tsconfig.json', 'utf8'))
+                const alias = config.compilerOptions.paths['#cds-models/*'][0]
+                const directory = alias.match(/(?:\.\/)?(.*)\/\*/)[1]
+                return normalize(directory)  // could contain forward slashes in tsconfig.json
+            } catch {
+                DEBUG?.('tsconfig.json not found, not parsable, or inconclusive. Using default model directory name')
+            }
+            return '@cds-models'
         }
-        return '@cds-models'
-    }
 
-    init() {
-        this.task.dest = path.join(cds.root, cds.env.build.target, cds.env.folders.srv)
-    }
-
-    async #runCdsTyper () {
-        DEBUG?.('running cds-typer')
-        cds.env.typer ??= {}
-        cds.env.typer.outputDirectory ??= this.#modelDirectoryName
-        await typer.compileFromFile('*')
-    }
-
-    async #buildWithConfig () {
-    // possibly referencing their tsconfig.json via "extends", specifying the "compilerOptions.outDir" and
-    // manually adding irrelevant folders (read: gen/ and app/) to the "exclude" array.
-        DEBUG?.(`building with config ${BUILD_CONFIG}`)
-        return exec(`npx tsc --project ${BUILD_CONFIG}`)
-    }
-
-    async #buildWithoutConfig () {
-        DEBUG?.('building without config')
-        // this will include gen/ that was created by the nodejs task
-        // _within_ the project directory. So we need to remove it afterwards.
-        await exec(`npx tsc --outDir "${this.task.dest.replace(/\\/g, '/')}"`) // see https://github.com/cap-js/cds-typer/issues/374
-        rmDirIfExists(path.join(this.task.dest, cds.env.build.target))
-        rmDirIfExists(path.join(this.task.dest, this.#appFolder))
-    }
-
-    async #copyCleanModel (buildDirCdsModels) {
-    // copy models again, to revert transpilation thereof.
-    // We only need the index.js files in un-transpiled form.
-        await this.copy(this.#modelDirectoryName).to(buildDirCdsModels)
-        await rmFiles(buildDirCdsModels, ['.ts'])
-    }
-
-    async build() {
-        await this.#runCdsTyper()
-        const buildDirCdsModels = path.join(this.task.dest, this.#modelDirectoryName)
-        // remove the js files generated by the nodejs buildtask,
-        // leaving only json, cds, and other static files
-        await rmFiles(this.task.dest, ['.js', '.ts'])
-
-        try {
-            await (buildConfigExists()
-                ? this.#buildWithConfig()
-                : this.#buildWithoutConfig()
-            )
-        } catch (error) {
-            throw error.stdout
-                ? new Error(error.stdout)
-                : error
+        init() {
+            this.task.dest = path.join(cds.root, cds.env.build.target, cds.env.folders.srv)
         }
-        this.#copyCleanModel(buildDirCdsModels)
-    }
-})
+
+        async #runCdsTyper () {
+            DEBUG?.('running cds-typer')
+            cds.env.typer ??= {}
+            cds.env.typer.outputDirectory ??= this.#modelDirectoryName
+            await typer.compileFromFile('*')
+        }
+
+        async #buildWithConfig () {
+        // possibly referencing their tsconfig.json via "extends", specifying the "compilerOptions.outDir" and
+        // manually adding irrelevant folders (read: gen/ and app/) to the "exclude" array.
+            DEBUG?.(`building with config ${BUILD_CONFIG}`)
+            return exec(`npx tsc --project ${BUILD_CONFIG}`)
+        }
+
+        async #buildWithoutConfig () {
+            DEBUG?.('building without config')
+            // this will include gen/ that was created by the nodejs task
+            // _within_ the project directory. So we need to remove it afterwards.
+            await exec(`npx tsc --outDir "${this.task.dest.replace(/\\/g, '/')}"`) // see https://github.com/cap-js/cds-typer/issues/374
+            rmDirIfExists(path.join(this.task.dest, cds.env.build.target))
+            rmDirIfExists(path.join(this.task.dest, this.#appFolder))
+        }
+
+        async #copyCleanModel (buildDirCdsModels) {
+        // copy models again, to revert transpilation thereof.
+        // We only need the index.js files in un-transpiled form.
+            await this.copy(this.#modelDirectoryName).to(buildDirCdsModels)
+            await rmFiles(buildDirCdsModels, ['.ts'])
+        }
+
+        async build() {
+            await this.#runCdsTyper()
+            const buildDirCdsModels = path.join(this.task.dest, this.#modelDirectoryName)
+            // remove the js files generated by the nodejs buildtask,
+            // leaving only json, cds, and other static files
+            await rmFiles(this.task.dest, ['.js', '.ts'])
+
+            try {
+                await (buildConfigExists()
+                    ? this.#buildWithConfig()
+                    : this.#buildWithoutConfig()
+                )
+            } catch (error) {
+                throw error.stdout
+                    ? new Error(error.stdout)
+                    : error
+            }
+            this.#copyCleanModel(buildDirCdsModels)
+        }
+    })
+})()

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -4,10 +4,10 @@ const cds = require('@sap/cds')
 const util = require('util')
 const exec = util.promisify(require('child_process').exec)
 const typer = require('./lib/compile')
-
 const { fs, path } = cds.utils
 const DEBUG = cds.debug('cli|build')
 const BUILD_CONFIG = 'tsconfig.cdsbuild.json'
+const { configuration } = require('./lib/config')
 
 /**
  * Check if the project is a TypeScript project by looking for a dependency on TypeScript.
@@ -60,7 +60,9 @@ const rmFiles = async (dir, exts) => fs.existsSync(dir)
         return
     }
 
-    if (cds.env.typer?.skipBuildTask) {
+    // by checking configuration instead of cds.env, we make sure the user can set
+    // this configuration in both camelCase and snake_case.
+    if (configuration.buildTask === false) {  // unset is considered true
         DEBUG?.('skipping typescript build task registration based on configuration option')
         return
     }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -196,7 +196,11 @@ const flags = enrichFlagSchema({
         desc: `Output format for generated .js files.${EOL}Setting it to auto tries to derive the module type from${EOL}the package.json and falls back to CJS.`,
         allowed: ['esm', 'cjs', 'auto'],
         default: 'auto'
-    }
+    },
+    skipBuildTask: parameterTypes.boolean({
+        desc: 'If set to true, the typescript build task will not be registered/ executed.',
+        default: 'false'
+    })
 })
 
 const hint = () => 'Missing or invalid parameter(s). Call with --help for more details.'

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -197,9 +197,9 @@ const flags = enrichFlagSchema({
         allowed: ['esm', 'cjs', 'auto'],
         default: 'auto'
     },
-    skipBuildTask: parameterTypes.boolean({
+    buildTask: parameterTypes.boolean({
         desc: `If set to true, the typescript build task will not be registered/ executed.${EOL}This value must be set in cds.env.${EOL}Passing it as parameter to the cds-typer CLI has no effect.`,
-        default: 'false'
+        default: 'true'
     })
 })
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -198,7 +198,7 @@ const flags = enrichFlagSchema({
         default: 'auto'
     },
     buildTask: parameterTypes.boolean({
-        desc: `If set to true, the typescript build task will not be registered/ executed.${EOL}This value must be set in cds.env.${EOL}Passing it as parameter to the cds-typer CLI has no effect.`,
+        desc: `If set to true, the typescript build task will not be registered/ executed.${EOL}This value must be set in your project configuration.${EOL}Passing it as parameter to the cds-typer CLI has no effect.`,
         default: 'true'
     })
 })

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -198,7 +198,7 @@ const flags = enrichFlagSchema({
         default: 'auto'
     },
     skipBuildTask: parameterTypes.boolean({
-        desc: 'If set to true, the typescript build task will not be registered/ executed.',
+        desc: `If set to true, the typescript build task will not be registered/ executed.${EOL}This value must be set in cds.env.${EOL}Passing it as parameter to the cds-typer CLI has no effect.`,
         default: 'false'
     })
 })

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
                 "flat",
                 "structured"
               ],
-              "default": "structured"
+              "default": "flat"
             },
             "properties_optional": {
               "type": "boolean",
@@ -131,6 +131,11 @@
                 "auto"
               ],
               "default": "auto"
+            },
+            "skip_build_task": {
+              "type": "boolean",
+              "description": "If set to true, the typescript build task will not be registered/ executed.",
+              "default": false
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
             },
             "build_task": {
               "type": "boolean",
-              "description": "If set to true, the typescript build task will not be registered/ executed.\nThis value must be set in cds.env.\nPassing it as parameter to the cds-typer CLI has no effect.",
+              "description": "If set to true, the typescript build task will not be registered/ executed.\nThis value must be set in your project configuration.\nPassing it as parameter to the cds-typer CLI has no effect.",
               "default": true
             }
           }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
       "inline_declarations": "flat",
       "target_module_type": "auto",
       "properties_optional": true,
-      "use_entities_proxy": false
+      "use_entities_proxy": false,
+      "build_task": true
     },
     "schema": {
       "buildTaskType": {
@@ -132,10 +133,10 @@
               ],
               "default": "auto"
             },
-            "skip_build_task": {
+            "build_task": {
               "type": "boolean",
               "description": "If set to true, the typescript build task will not be registered/ executed.\nThis value must be set in cds.env.\nPassing it as parameter to the cds-typer CLI has no effect.",
-              "default": false
+              "default": true
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
             },
             "skip_build_task": {
               "type": "boolean",
-              "description": "If set to true, the typescript build task will not be registered/ executed.",
+              "description": "If set to true, the typescript build task will not be registered/ executed.\nThis value must be set in cds.env.\nPassing it as parameter to the cds-typer CLI has no effect.",
               "default": false
             }
           }


### PR DESCRIPTION
Setting `cds.env.typer.skip_build_task` to `true` will now disable the `typescript` build task.
Currently, the only way to achieve this is to explicitly call `cds build --for x --for y --for z` with all build tasks, except for `typescript`.
This was requested by users who would like to perform the required build steps themselves.
PR is best viewed with hidden whitespace changes.