### PR TITLE
Add schema consistency check

### DIFF
--- a/.github/workflows/check-schema-integrity.yml
+++ b/.github/workflows/check-schema-integrity.yml
@@ -30,6 +30,8 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add .
           if ! git diff --cached --exit-code; then
-            echo "Schema in package.json not consistent with CLI parameters. Run `npm run write:cds-typer-shema` and commit the resulting changes."
+            echo "Schema in package.json not consistent with CLI parameters. Run "npm run write:cds-typer-shema" and commit the resulting changes."
+            echo "Diff:"
+            git diff --cached
             exit 1
           fi

--- a/.github/workflows/check-schema-integrity.yml
+++ b/.github/workflows/check-schema-integrity.yml
@@ -31,7 +31,5 @@ jobs:
           git add .
           if ! git diff --cached --exit-code; then
             echo "Schema in package.json not consistent with CLI parameters. Run "npm run write:cds-typer-shema" and commit the resulting changes."
-            echo "Diff:"
-            git diff --cached
             exit 1
           fi

--- a/.github/workflows/check-schema-integrity.yml
+++ b/.github/workflows/check-schema-integrity.yml
@@ -1,0 +1,35 @@
+name: Check for Inconsistencies in Generated Schema
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-schema:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run script to generate schema
+        run: npm run write:cds-typer-shema
+
+      - name: Check for changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add .
+          if ! git diff --cached --exit-code; then
+            echo "Schema in package.json not consistent with CLI parameters. Run `npm run write:cds-typer-shema` and commit the resulting changes."
+            exit 1
+          fi


### PR DESCRIPTION
cds-typer supports a bunch of [CLI parameters](https://github.com/cap-js/cds-typer/blob/main/lib/cli.js#L146) that can all also be specified via `cds.env`.
To receive code completion for these options when editing a project's _package.json_, these options, default values, and descriptions also have to be maintained [in cds-typer's _package.json_](https://github.com/cap-js/cds-typer/blob/main/package.json#L69).
The latter can be generated automatically using [a utility script](https://github.com/cap-js/cds-typer/blob/main/scripts/write-cds-typer-schema.js). But if anyone adds a new configuration option and forgets to run this script, the code completion will be incorrect.
The workflow introduced in this PR therefore blocks any PR where the author apparently forgot to run the script.