### PR TITLE
`cds.Binary` → `Buffer`, `cds.LargeBinary` → `Readable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Support new `cds.Map` type, which is emitted as `{[key:string]: unknown}`. The most appropriate type would in fact be `{[key:string]: any}`, which would also allow any and all keys. But would also cause issues with strict project configurations. Therefore, to effectively use `cds.Map`, users will have to cast the `unknown`s to the effective type they expect.
 ### Changed
+- [breaking] The types `cds.Binary` and `cds.LargeBinary` are now generated as `Buffer` and `Readable` respectively to reflect the behaviour of the new database packages `@cap-js/hana` and `@cap-js/sqlite`. You can switch back to the old behaviour by adding `legacy_binary_types: true` to your project configuration.
 - `CHANGELOG.md` and `LICENSE` files are no longer part of the npm package.
 
 ### Deprecated

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -192,6 +192,10 @@ const flags = enrichFlagSchema({
         desc: `If set to true, floating point properties are generated${EOL}as IEEE754 compatible '(number | string)' instead of 'number'.`,
         default: 'false'
     }),
+    legacyBinaryTypes: parameterTypes.boolean({
+        desc: `If set to true, Binary and LargeBinary are generated${EOL}as strings.`,
+        default: 'false'
+    }),
     targetModuleType: {
         desc: `Output format for generated .js files.${EOL}Setting it to auto tries to derive the module type from${EOL}the package.json and falls back to CJS.`,
         allowed: ['esm', 'cjs', 'auto'],

--- a/lib/resolution/builtin.js
+++ b/lib/resolution/builtin.js
@@ -6,9 +6,11 @@ class BuiltinResolver {
     #builtins = {
         UUID: 'string',
         String: 'string',
-        Binary: 'string',
+        Binary: 'Buffer',
         LargeString: 'string',
-        LargeBinary: 'Buffer | string | {value: import("stream").Readable, $mediaContentType: string, $mediaContentDispositionFilename?: string, $mediaContentDispositionType?: string}',
+        // new db: only Readable, old db: anything after |
+        // new db: @cap-js/sqlite | hana in dependencies
+        LargeBinary: 'Readable | Buffer | string | {value: import("stream").Readable, $mediaContentType: string, $mediaContentDispositionFilename?: string, $mediaContentDispositionType?: string}',
         Vector: 'string',
         Integer: 'number',
         UInt8: 'number',

--- a/lib/resolution/builtin.js
+++ b/lib/resolution/builtin.js
@@ -8,9 +8,7 @@ class BuiltinResolver {
         String: 'string',
         Binary: 'Buffer',
         LargeString: 'string',
-        // new db: only Readable, old db: anything after |
-        // new db: @cap-js/sqlite | hana in dependencies
-        LargeBinary: 'Readable | Buffer | string | {value: import("stream").Readable, $mediaContentType: string, $mediaContentDispositionFilename?: string, $mediaContentDispositionType?: string}',
+        LargeBinary: 'import("stream").Readable',
         Vector: 'string',
         Integer: 'number',
         UInt8: 'number',
@@ -37,13 +35,18 @@ class BuiltinResolver {
     /**
      * @param {object} options - additional resolution options
      * @param {boolean} [options.IEEE754Compatible] - if true, the Decimal, DecimalFloat, Float, and Double types are also allowed to be strings
+     * @param {boolean} [options.legacyBinaryTypes] - if true, the Binary and LargeBinary types are strings
      */
-    constructor ({ IEEE754Compatible } = {}) {
+    constructor ({ IEEE754Compatible, legacyBinaryTypes } = {}) {
         if (IEEE754Compatible) {
             this.#builtins.Decimal = '(number | string)'
             this.#builtins.DecimalFloat = '(number | string)'
             this.#builtins.Float = '(number | string)'
             this.#builtins.Double = '(number | string)'
+        }
+        if (legacyBinaryTypes) {
+            this.#builtins.Binary = 'string'
+            this.#builtins.LargeBinary = 'Buffer | string | {value: import("stream").Readable, $mediaContentType: string, $mediaContentDispositionFilename?: string, $mediaContentDispositionType?: string}'
         }
         this.#builtins = Object.freeze(this.#builtins)
     }

--- a/lib/resolution/resolver.js
+++ b/lib/resolution/resolver.js
@@ -32,7 +32,7 @@ class Resolver {
         this.visitor = visitor
 
         /** @type {BuiltinResolver} */
-        this.builtinResolver = new BuiltinResolver({ IEEE754Compatible: configuration.IEEE754Compatible })
+        this.builtinResolver = new BuiltinResolver({ IEEE754Compatible: configuration.IEEE754Compatible, legacyBinaryTypes: configuration.legacyBinaryTypes })
 
         /** @type {Library[]} */
         this.libraries = [new Library(require.resolve('../../library/cds.hana.ts'))]

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -206,6 +206,10 @@ export module config {
          */
         IEEE754Compatible: boolean
         targetModuleType: 'cjs' | 'esm' | 'auto'
+        /**
+         * `legacyBinaryTypes = true` -> Binary and LargeBinary are generated as `string` and a union type respectively
+         */
+        legacyBinaryTypes: boolean
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -123,6 +123,11 @@
               "description": "If set to true, floating point properties are generated\nas IEEE754 compatible '(number | string)' instead of 'number'.",
               "default": false
             },
+            "legacy_binary_types": {
+              "type": "boolean",
+              "description": "If set to true, Binary and LargeBinary are generated\nas strings.",
+              "default": false
+            },
             "target_module_type": {
               "type": "string",
               "description": "Output format for generated .js files.\nSetting it to auto tries to derive the module type from\nthe package.json and falls back to CJS.",

--- a/test/unit/output.test.js
+++ b/test/unit/output.test.js
@@ -104,17 +104,14 @@ describe('Compilation Tests', () => {
     })
 
     describe('Builtin Types Tests', () => {
-        it('should verify primitive types', async () => {
+        it('should verify primitive types with default settings', async () => {
             const astw = (await prepareUnitTest('builtins/model.cds', locations.testOutput('output_test/builtin'))).astw
             assert.ok(astw.exists('_EAspect', 'uuid', m => check.isNullable(m.type, [check.isString])))
             assert.ok(astw.exists('_EAspect', 'str', m => check.isNullable(m.type, [check.isString])))
-            assert.ok(astw.exists('_EAspect', 'bin', m => check.isNullable(m.type, [check.isString])))
+            assert.ok(astw.exists('_EAspect', 'bin', m => check.isNullable(m.type, [st => check.isTypeReference(st, 'Buffer') ])))
             // assert.ok(astw.exists('_EAspect', 'vec', m => check.isNullable(m.type, [check.isString])))
             assert.ok(astw.exists('_EAspect', 'lstr', m => check.isNullable(m.type, [check.isString])))
-            assert.ok(astw.exists('_EAspect', 'lbin', m => check.isUnionType(m.type, [
-                st => st.full === 'Buffer',
-                check.isString
-            ])))
+            assert.ok(astw.exists('_EAspect', 'lbin', m => check.isUnionType(m.type, [check.isLiteral])))  // is actually more complex, but the import('stream').Readable is not feasibly pulled from the AST
             assert.ok(astw.exists('_EAspect', 'integ', m => check.isNullable(m.type, [check.isNumber])))
             assert.ok(astw.exists('_EAspect', 'uint8', m => check.isNullable(m.type, [check.isNumber])))
             assert.ok(astw.exists('_EAspect', 'int16', m => check.isNullable(m.type, [check.isNumber])))
@@ -132,19 +129,9 @@ describe('Compilation Tests', () => {
 
         it('should verify IEEE754 types', async () => {
             const ieee754 = m => check.isParenthesizedType(m, st => check.isUnionType(st, [check.isNumber, check.isString]))
-
             const astw = (await prepareUnitTest('builtins/model.cds', locations.testOutput('output_test/builtin'), {
                 typerOptions: { IEEE754Compatible: true }
             })).astw
-            assert.ok(astw.exists('_EAspect', 'uuid', m => check.isNullable(m.type, [check.isString])))
-            assert.ok(astw.exists('_EAspect', 'str', m => check.isNullable(m.type, [check.isString])))
-            assert.ok(astw.exists('_EAspect', 'bin', m => check.isNullable(m.type, [check.isString])))
-            // assert.ok(astw.exists('_EAspect', 'vec', m => check.isNullable(m.type, [check.isString])))
-            assert.ok(astw.exists('_EAspect', 'lstr', m => check.isNullable(m.type, [check.isString])))
-            assert.ok(astw.exists('_EAspect', 'lbin', m => check.isUnionType(m.type, [
-                st => st.full === 'Buffer',
-                check.isString
-            ])))
             assert.ok(astw.exists('_EAspect', 'integ', m => check.isNullable(m.type, [check.isNumber])))
             assert.ok(astw.exists('_EAspect', 'uint8', m => check.isNullable(m.type, [check.isNumber])))
             assert.ok(astw.exists('_EAspect', 'int16', m => check.isNullable(m.type, [check.isNumber])))
@@ -153,11 +140,17 @@ describe('Compilation Tests', () => {
             assert.ok(astw.exists('_EAspect', 'integer64', m => check.isNullable(m.type, [check.isNumber])))
             assert.ok(astw.exists('_EAspect', 'dec', m => check.isNullable(m.type, [ieee754])))
             assert.ok(astw.exists('_EAspect', 'doub', m => check.isNullable(m.type, [ieee754])))
-            assert.ok(astw.exists('_EAspect', 'd', m => check.isNullable(m.type, [st => check.isTypeReference(st, '___.CdsDate')])))
-            assert.ok(astw.exists('_EAspect', 't', m => check.isNullable(m.type, [st => check.isTypeReference(st, '___.CdsTime')])))
-            assert.ok(astw.exists('_EAspect', 'dt', m => check.isNullable(m.type, [st => check.isTypeReference(st, '___.CdsDateTime')])))
-            assert.ok(astw.exists('_EAspect', 'ts', m => check.isNullable(m.type, [st => check.isTypeReference(st, '___.CdsTimestamp')])))
-            assert.ok(astw.exists('_EAspect', 'map', m => check.isNullable(m.type, [st => check.isTypeReference(st, '___.CdsMap')])))
+        })
+
+        it('should verify legacy binary types', async () => {
+            const astw = (await prepareUnitTest('builtins/model.cds', locations.testOutput('output_test/builtin'), {
+                typerOptions: { legacyBinaryTypes: true }
+            })).astw
+            assert.ok(astw.exists('_EAspect', 'bin', m => check.isNullable(m.type, [check.isString])))
+            assert.ok(astw.exists('_EAspect', 'lbin', m => check.isUnionType(m.type, [
+                st => st.full === 'Buffer',
+                check.isString
+            ])))
         })
     })
 


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/483