### PR TITLE
Remove use of globals package with mirrored values from sap/cds

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,8 +14,7 @@ module.exports = (async () => [
             ecmaVersion: 'latest',
             sourceType: 'commonjs',
             globals: {
-                ...(await import('@sap/cds/eslint.config.mjs')).defaults.languageOptions.globals,
-                jest: true
+                ...(await import('@sap/cds/eslint.config.mjs')).defaults.languageOptions.globals
             }
         },
         files: ['**/*.js'],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,11 @@
-module.exports = [
-    //
+// aiife to allow dynamic import of cds/eslint.config.mjs
+module.exports = (async () => [
     {
-        ignores: ['**/test/integration/**'],
+        ignores: [
+            '**/test/integration/**',
+            '**/test/**/_out',  // no auto-transpiled test files
+            '**/@cds-models'  // no generated model files
+        ],
     },
     require('@eslint/js').configs.recommended,
     require('eslint-plugin-jsdoc').configs['flat/recommended-typescript-flavor-error'],
@@ -10,7 +14,7 @@ module.exports = [
             ecmaVersion: 'latest',
             sourceType: 'commonjs',
             globals: {
-                ...require('globals').node,
+                ...(await import('@sap/cds/eslint.config.mjs')).defaults.languageOptions.globals,
                 jest: true
             }
         },
@@ -92,4 +96,4 @@ module.exports = [
             'jsdoc/require-returns': 'off', // lsp can infer this most of the time, turn back on for doc extraction
         }
     }
-]
+])()

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "acorn": "^8.10.0",
         "eslint": "^9",
         "eslint-plugin-jsdoc": "^50.2.2",
-        "globals": "^15.0.0",
         "typescript": ">=4.6.4"
       },
       "peerDependencies": {
@@ -1409,19 +1408,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/globals": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "acorn": "^8.10.0",
     "eslint": "^9",
     "eslint-plugin-jsdoc": "^50.2.2",
-    "globals": "^15.0.0",
     "typescript": ">=4.6.4"
   },
   "cds": {


### PR DESCRIPTION
Removes `globals` package and instead uses the globals object shipped with sap/cds' eslint config.