### PR TITLE
Run typer once before cds watch starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 ### Changed
+- Running `cds watch` will trigger `cds-typer "*"` before the initial startup
 ### Deprecated
 ### Removed
 ### Fixed

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -159,10 +159,10 @@ const rmFiles = async (dir, exts) => fs.existsSync(dir)
 if (cds.watched) {
     if (fs.existsSync(cds.env.typer.output_directory)) return
     try {
-        DEBUG?.('>> running cds-typer before cds watch')
+        DEBUG?.('>> start cds-typer before cds watch')
         module.exports = typer.compileFromFile('*')
-            .then(() => DEBUG?.('<< running cds-typer before cds watch')
-        )
+            .then(() => DEBUG?.('<< end cds-typer before cds watch'))
+            .catch(e => DEBUG?.(e))
     } catch (error) {
         // silently ignore if no (valid) model exists at initial startup
         DEBUG?.(error)

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -55,7 +55,7 @@ const rmFiles = async (dir, exts) => fs.existsSync(dir)
     )
     : undefined
 
-cds.on('on-watch', async () => {
+cds.on('watch', async () => {
     if (fs.existsSync(cds.env.typer.output_directory ?? DEFAULT_MODEL_DIRECTORY_NAME)) return
     try {
         DEBUG?.('running cds-typer before cds watch')

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -55,16 +55,6 @@ const rmFiles = async (dir, exts) => fs.existsSync(dir)
     )
     : undefined
 
-cds.on('watch', async () => {
-    if (fs.existsSync(cds.env.typer.output_directory ?? DEFAULT_MODEL_DIRECTORY_NAME)) return
-    try {
-        DEBUG?.('running cds-typer before cds watch')
-        await typer.compileFromFile('*')
-    } catch  {
-        // silently ignore if no (valid) model exists at initial startup
-    }
-})
-
 // IIFE to be able to return early
 ;(() => {
     // FIXME: remove once cds7 has been phased out
@@ -79,6 +69,17 @@ cds.on('watch', async () => {
         DEBUG?.('skipping typescript build task registration based on configuration option')
         return
     }
+
+    cds.on('watch', async () => {
+        if (fs.existsSync(cds.env.typer.output_directory ?? DEFAULT_MODEL_DIRECTORY_NAME)) return
+        try {
+            DEBUG?.('running cds-typer before cds watch')
+            await typer.compileFromFile('*')
+        } catch (error) {
+            // silently ignore if no (valid) model exists at initial startup
+            DEBUG?.(error)
+        }
+    })
 
     // requires @sap/cds-dk version >= 7.5.0
     cds.build?.register?.('typescript', class extends cds.build.Plugin {

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -52,6 +52,14 @@ const rmFiles = async (dir, exts) => fs.existsSync(dir)
     )
     : undefined
 
+cds.on('before-watch', async () => {
+    try {
+        await typer.compileFromFile('*')
+    } catch {
+        // silently ignore if no (valid) model exists at initial startup
+    }
+})
+
 // IIFE to be able to return early
 ;(() => {
     // FIXME: remove once cds7 has been phased out

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -70,17 +70,6 @@ const rmFiles = async (dir, exts) => fs.existsSync(dir)
         return
     }
 
-    cds.on('watch', async () => {
-        if (fs.existsSync(cds.env.typer.output_directory)) return
-        try {
-            DEBUG?.('running cds-typer before cds watch')
-            await typer.compileFromFile('*')
-        } catch (error) {
-            // silently ignore if no (valid) model exists at initial startup
-            DEBUG?.(error)
-        }
-    })
-
     // requires @sap/cds-dk version >= 7.5.0
     cds.build?.register?.('typescript', class extends cds.build.Plugin {
         static taskDefaults = { src: '.' }
@@ -166,3 +155,16 @@ const rmFiles = async (dir, exts) => fs.existsSync(dir)
         }
     })
 })()
+
+if (cds.watched) {
+    if (fs.existsSync(cds.env.typer.output_directory)) return
+    try {
+        DEBUG?.('>> running cds-typer before cds watch')
+        module.exports = typer.compileFromFile('*')
+            .then(() => DEBUG?.('<< running cds-typer before cds watch')
+        )
+    } catch (error) {
+        // silently ignore if no (valid) model exists at initial startup
+        DEBUG?.(error)
+    }
+}

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -71,7 +71,7 @@ const rmFiles = async (dir, exts) => fs.existsSync(dir)
     }
 
     cds.on('watch', async () => {
-        if (fs.existsSync(cds.env.typer.output_directory ?? DEFAULT_MODEL_DIRECTORY_NAME)) return
+        if (fs.existsSync(cds.env.typer.output_directory)) return
         try {
             DEBUG?.('running cds-typer before cds watch')
             await typer.compileFromFile('*')

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -57,6 +57,15 @@ const rmFiles = async (dir, exts) => fs.existsSync(dir)
 
 // IIFE to be able to return early
 ;(() => {
+    if (cds.watched) {
+        if (fs.existsSync(cds.env.typer.output_directory)) return
+        DEBUG?.('>> start cds-typer before cds watch')
+        module.exports = typer.compileFromFile('*')
+            .then(() => DEBUG?.('<< end cds-typer before cds watch'))
+            .catch(e => DEBUG?.(e))
+        return
+    }
+
     // FIXME: remove once cds7 has been phased out
     if (!cds?.version || cds.version < '8.0.0') {
         DEBUG?.('typescript build task requires @sap/cds-dk version >= 8.0.0, skipping registration')
@@ -155,16 +164,3 @@ const rmFiles = async (dir, exts) => fs.existsSync(dir)
         }
     })
 })()
-
-if (cds.watched) {
-    if (fs.existsSync(cds.env.typer.output_directory)) return
-    try {
-        DEBUG?.('>> start cds-typer before cds watch')
-        module.exports = typer.compileFromFile('*')
-            .then(() => DEBUG?.('<< end cds-typer before cds watch'))
-            .catch(e => DEBUG?.(e))
-    } catch (error) {
-        // silently ignore if no (valid) model exists at initial startup
-        DEBUG?.(error)
-    }
-}


### PR DESCRIPTION
Running `cds w` in your project will now initially run `cds-typer` if no `@cds-models` folder (or to whatever it is configured via `cds.typer.output_directory`) doesn't exist.
It does not run if this directory exists.
This feature is especially useful when you check out a CDS project and immediately dive into `cds w` from the CLI.