### PR TITLE
Add hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Introduced `cache` option to cache CDS model between runs. If set to `blake2s256`, typer will only regenerate the files if the model has changed between runs.
 ### Changed
 - [breaking] The config `use_entities_proxy` (allowing for static imports) is now set to `true` as default. You can set it to `false` to revert to the old behaviour.
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Introduced `cache` option to cache CDS model between runs. If set to `blake2s256`, typer will only regenerate the files if the model has changed between runs.
+- Improved performance of repeated `cds-typer` runs by introducing an option to cache CDS model between runs. By default, typer will only regenerate the files if the model has changed between runs, using `blake2s256` as algorithm.
 ### Changed
 - [breaking] The config `use_entities_proxy` (allowing for static imports) is now set to `true` as default. You can set it to `false` to revert to the old behaviour.
 ### Deprecated

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -204,7 +204,12 @@ const flags = enrichFlagSchema({
     buildTask: parameterTypes.boolean({
         desc: `If set to true, the typescript build task will not be registered/ executed.${EOL}This value must be set in your project configuration.${EOL}Passing it as parameter to the cds-typer CLI has no effect.`,
         default: 'true'
-    })
+    }),
+    cache: {
+        desc: `How to cache typer runs.${EOL}none: fully run cds-typer whenever it is called${EOL}blake2s256: only run if the blake2s256-hash of the model has changed. Hash is stored in a file between runs.`,
+        allowed: ['none', 'blake2s256'],
+        default: 'none'
+    }
 })
 
 const hint = () => 'Missing or invalid parameter(s). Call with --help for more details.'

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fs = require('fs')
-const { normalize } = require('path')
+const { normalize, join } = require('path')
 const cds = require(require.resolve('@sap/cds', { paths: [process.cwd(), __dirname] }))
 const util = require('./util')
 const { writeout } = require('./file')
@@ -44,6 +44,24 @@ const compileFromCSN = async csn => {
     if (configuration.jsConfigPath) {
         writeJsConfig(configuration.jsConfigPath)
     }
+
+    if (configuration.cache === 'blake2s256') {
+        const crypto = require('crypto')
+        const hashFile = join(configuration.outputDirectory, '.hash')
+        const modelHash = crypto
+            .createHash('blake2s256')
+            .update(JSON.stringify(csn))
+            .digest('hex')
+        if (fs.existsSync(hashFile)) {
+            const oldHash = fs.readFileSync(hashFile, 'utf8')
+            if (oldHash === modelHash) {
+                LOG.info('Model has not changed. Skipping generation.')
+                return
+            }
+        }
+        fs.writeFileSync(hashFile, modelHash)
+    }
+
     return writeout(
         configuration.outputDirectory,
         Object.values(new Visitor(csn).getWriteoutFiles())

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -57,24 +57,19 @@ const compileFromCSN = async csn => {
 const compileFromFile = async inputFile => {
     const hashFile = join(configuration.outputDirectory, '.hash')
     const paths = typeof inputFile === 'string' ? normalize(inputFile) : inputFile.map(f => normalize(f))
-    const xtended = await cds.linked(await cds.load(paths, { docs: true, flavor: 'xtended' }))
+    const xtendedPlain = await cds.load(paths, { docs: true, flavor: 'xtended' })
     let modelHash
 
     if (configuration.cache === 'blake2s256') {
-        const crypto = require('crypto')
-        modelHash = crypto
-            .createHash('blake2s256')
-            .update(JSON.stringify(xtended))
-            .digest('hex')
-        if (fs.existsSync(hashFile)) {
-            const oldHash = fs.readFileSync(hashFile, 'utf8')
-            if (oldHash === modelHash) {
-                LOG.info('Model has not changed. Skipping generation.')
-                return
-            }
+        const [shouldCompile, hash] = checkHash(xtendedPlain, hashFile)
+        if (!shouldCompile) {
+            LOG.info('Model has not changed. Skipping generation.')
+            return
         }
+        modelHash = hash
     }
 
+    const xtended = await cds.linked(xtendedPlain)
     const inferred = await cds.linked(await cds.load(paths, { docs: true }))
     const result = await compileFromCSN({xtended, inferred})
 
@@ -85,6 +80,26 @@ const compileFromFile = async inputFile => {
         fs.writeFileSync(hashFile, modelHash)
     }
     return result
+}
+
+/**
+ * @param {JSON} csn - the model
+ * @param {string} hashFile - path to the hash file
+ * @returns {[boolean, string]}
+ */
+const checkHash = (csn, hashFile) => {
+    const crypto = require('crypto')
+    const currentHash = crypto
+        .createHash('blake2s256')
+        .update(JSON.stringify(csn))
+        .digest('hex')
+    if (fs.existsSync(hashFile)) {
+        const oldHash = fs.readFileSync(hashFile, 'utf8')
+        if (oldHash === currentHash) {
+            return [false, currentHash]
+        }
+    }
+    return [true, currentHash]
 }
 
 module.exports = {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -39,27 +39,9 @@ const writeJsConfig = path => {
  * @param {{xtended: import('./typedefs').resolver.CSN, inferred: import('./typedefs').resolver.CSN}} csn - csn tuple
  */
 const compileFromCSN = async csn => {
-
     setLevel(configuration.logLevel)
     if (configuration.jsConfigPath) {
         writeJsConfig(configuration.jsConfigPath)
-    }
-
-    if (configuration.cache === 'blake2s256') {
-        const crypto = require('crypto')
-        const hashFile = join(configuration.outputDirectory, '.hash')
-        const modelHash = crypto
-            .createHash('blake2s256')
-            .update(JSON.stringify(csn))
-            .digest('hex')
-        if (fs.existsSync(hashFile)) {
-            const oldHash = fs.readFileSync(hashFile, 'utf8')
-            if (oldHash === modelHash) {
-                LOG.info('Model has not changed. Skipping generation.')
-                return
-            }
-        }
-        fs.writeFileSync(hashFile, modelHash)
     }
 
     return writeout(
@@ -75,6 +57,24 @@ const compileFromCSN = async csn => {
 const compileFromFile = async inputFile => {
     const paths = typeof inputFile === 'string' ? normalize(inputFile) : inputFile.map(f => normalize(f))
     const xtended = await cds.linked(await cds.load(paths, { docs: true, flavor: 'xtended' }))
+
+    if (configuration.cache === 'blake2s256') {
+        const crypto = require('crypto')
+        const hashFile = join(configuration.outputDirectory, '.hash')
+        const modelHash = crypto
+            .createHash('blake2s256')
+            .update(JSON.stringify(xtended))
+            .digest('hex')
+        if (fs.existsSync(hashFile)) {
+            const oldHash = fs.readFileSync(hashFile, 'utf8')
+            if (oldHash === modelHash) {
+                LOG.info('Model has not changed. Skipping generation.')
+                return
+            }
+        }
+        fs.writeFileSync(hashFile, modelHash)
+    }
+
     const inferred = await cds.linked(await cds.load(paths, { docs: true }))
     return compileFromCSN({xtended, inferred})
 }

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -55,13 +55,14 @@ const compileFromCSN = async csn => {
  * @param {string | string[]} inputFile - path to input .cds file
  */
 const compileFromFile = async inputFile => {
+    const hashFile = join(configuration.outputDirectory, '.hash')
     const paths = typeof inputFile === 'string' ? normalize(inputFile) : inputFile.map(f => normalize(f))
     const xtended = await cds.linked(await cds.load(paths, { docs: true, flavor: 'xtended' }))
+    let modelHash
 
     if (configuration.cache === 'blake2s256') {
         const crypto = require('crypto')
-        const hashFile = join(configuration.outputDirectory, '.hash')
-        const modelHash = crypto
+        modelHash = crypto
             .createHash('blake2s256')
             .update(JSON.stringify(xtended))
             .digest('hex')
@@ -72,11 +73,18 @@ const compileFromFile = async inputFile => {
                 return
             }
         }
-        fs.writeFileSync(hashFile, modelHash)
     }
 
     const inferred = await cds.linked(await cds.load(paths, { docs: true }))
-    return compileFromCSN({xtended, inferred})
+    const result = await compileFromCSN({xtended, inferred})
+
+    if (modelHash) {
+        // write hash as last thing before returning,
+        // so that we don't write it if an error occurs,
+        // which would block the next run although the model has changed
+        fs.writeFileSync(hashFile, modelHash)
+    }
+    return result
 }
 
 module.exports = {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -10,6 +10,26 @@ const { LOG, setLevel } = require('./logging')
 const { configuration } = require('./config')
 
 /**
+ * @param {JSON} csn - the model
+ * @param {string} hashFile - path to the hash file
+ * @returns {[boolean, string]}
+ */
+const checkHash = (csn, hashFile) => {
+    const crypto = require('crypto')
+    const currentHash = crypto
+        .createHash('blake2s256')
+        .update(JSON.stringify(csn))
+        .digest('hex')
+    if (fs.existsSync(hashFile)) {
+        const oldHash = fs.readFileSync(hashFile, 'utf8')
+        if (oldHash === currentHash) {
+            return [false, currentHash]
+        }
+    }
+    return [true, currentHash]
+}
+
+/**
  * Writes the accompanying jsconfig.json file to the specified paths.
  * Tries to merge nicely if an existing file is found.
  * @param {string} path - filepath to jsconfig.json.
@@ -80,26 +100,6 @@ const compileFromFile = async inputFile => {
         fs.writeFileSync(hashFile, modelHash)
     }
     return result
-}
-
-/**
- * @param {JSON} csn - the model
- * @param {string} hashFile - path to the hash file
- * @returns {[boolean, string]}
- */
-const checkHash = (csn, hashFile) => {
-    const crypto = require('crypto')
-    const currentHash = crypto
-        .createHash('blake2s256')
-        .update(JSON.stringify(csn))
-        .digest('hex')
-    if (fs.existsSync(hashFile)) {
-        const oldHash = fs.readFileSync(hashFile, 'utf8')
-        if (oldHash === currentHash) {
-            return [false, currentHash]
-        }
-    }
-    return [true, currentHash]
 }
 
 module.exports = {

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -188,6 +188,7 @@ export module config {
 
     export type Configuration = {
         outputDirectory: string,
+        cache: 'none' | 'blake2s256'
         logLevel: number,
         /**
          * `useEntitiesProxy = true` will wrap the `module.exports.<entityName>` in `Proxy` objects

--- a/package.json
+++ b/package.json
@@ -71,6 +71,15 @@
           "type": "object",
           "description": "Configuration for CDS Typer",
           "properties": {
+            "cache": {
+              "type": "string",
+              "description": "How to cache typer runs.\nnone: fully run cds-typer whenever it is called\nblake2s256: only run if the blake2s256-hash of the model has changed. Hash is stored in a file between runs.",
+              "enum": [
+                "none",
+                "blake2s256"
+              ],
+              "default": "none"
+            },
             "output_directory": {
               "type": "string",
               "description": "Root directory to write the generated files to.",


### PR DESCRIPTION
Setting `cds.typer.cache = 'blake2s256'` hashes the extended model and compares it to the hash of the previous run read from disk (if it exists). If the model has not changed, cds-typer will end the run immediately at this point.

cds-typer currently needs the inferred and xtended flavour of a model for a complete run. So when actually running, it performs `cds.load` twice, considerably increasing runtime.
With the `cache` setting active, it loads the xtended model first, checks the hash, and if the hash has not changed, does not perform the second `cds.load`. So we should see a runtime improvement of about 50% for the initial model loading when the cache is hit.

File IO is also cut down in case of a cache hit, as no files have to be written.

A quick test with a model of ~8MB in size showed that the time went from ~13s on the initial run when no `@cds-models` existed, down to ~5s when cds-typer would stop immediately after finding there was nothing to do.

```
➜ time cds-typer "*"
cds-typer "*"  13.03s user 1.12s system 133% cpu 10.613 total
➜ time cds-typer "*"
cds-typer "*"  5.35s user 0.32s system 136% cpu 4.159 total
```

The currently used algorithm [blake2](https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2) is, to my knowledge, the fastest hash algorithm available in the `crypto` module. I deliberately left the config option open to using a different algorithm in the future. 