### PR TITLE
Resolve composition aspect targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Deprecated
 ### Removed
 ### Fixed
+- targeting aspects in compositions now properly resolves them.
 ### Security
 
 ## [0.35.0] - 2025-05-23

--- a/lib/resolution/resolver.js
+++ b/lib/resolution/resolver.js
@@ -326,7 +326,7 @@ class Resolver {
                 /** @type { EntityCSN | { type: string } } */
                 const target = element.items
                     ?? getTarget(element, 'target')
-                    ?? getTarget(element, 'targetAspect')
+                    ?? getTarget(element, 'targetAspect')  // Composition of aspects
                 /** set `notNull = true` to avoid repeated `| not null` TS construction */
                 // @ts-expect-error - yes, we know that notNull is not part of the type in some cases
                 target.notNull = true

--- a/lib/resolution/resolver.js
+++ b/lib/resolution/resolver.js
@@ -312,11 +312,21 @@ class Resolver {
                 }[element.constructor.name] ?? []
 
             if (toOne && toMany) {
+                /**
+                 * Resolve a property from a CSN entity. If it is a reference, leave it as is.
+                 * If it is a string, return an object with type set to the string.
+                 * @param {Record<string, any>} el - the element to check
+                 * @param {string} property - the property to check
+                 * @returns {import('../typedefs').resolver.EntityCSN | { type: string }}
+                 */
+                const getTarget = (el, property) => typeof el[property] === 'string'
+                    ? { type: el[property] }
+                    : el[property]
+
                 /** @type { EntityCSN | { type: string } } */
-                // @ts-expect-error - nope, it is not undefined
-                const target = element.items ?? (typeof element.target === 'string'
-                    ? { type: element.target }
-                    : element.target)
+                const target = element.items
+                    ?? getTarget(element, 'target')
+                    ?? getTarget(element, 'targetAspect')
                 /** set `notNull = true` to avoid repeated `| not null` TS construction */
                 // @ts-expect-error - yes, we know that notNull is not part of the type in some cases
                 target.notNull = true

--- a/lib/resolution/resolver.js
+++ b/lib/resolution/resolver.js
@@ -323,10 +323,13 @@ class Resolver {
                     ? { type: el[property] }
                     : el[property]
 
-                /** @type { EntityCSN | { type: string } } */
+                /** @type { EntityCSN | { type: string } | undefined } */
                 const target = element.items
                     ?? getTarget(element, 'target')
                     ?? getTarget(element, 'targetAspect')  // Composition of aspects
+                if (!target) {
+                    throw new Error(`Could not resolve target of ${element}`)
+                }
                 /** set `notNull = true` to avoid repeated `| not null` TS construction */
                 // @ts-expect-error - yes, we know that notNull is not part of the type in some cases
                 target.notNull = true

--- a/test/unit/aspects.test.js
+++ b/test/unit/aspects.test.js
@@ -13,4 +13,8 @@ describe('CDS Aspects', () => {
     it('should validate aspect in singular form', () => {
         assert.ok(astw.tree.find(n => n.name === '_PersonAspect'))
     })
+
+    it('should contain a composition to an aspect', () => {
+        assert.ok(astw.exists('_CatalogAspect', 'persons'))
+    })
 })

--- a/test/unit/files/aspects/model.cds
+++ b/test/unit/files/aspects/model.cds
@@ -3,3 +3,7 @@ namespace aspect_test;
 aspect Persons {}
 
 entity Authors: Persons {}
+entity Catalog {
+    key ID: Integer;
+    persons: Composition of Persons;
+}


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/547

Compositions targeting aspects, instead of entities, would carry this information in a property `targetAspect`, rather than `target`. This PR falls back to resolving `targetAspect` when `target` can not be resolved.