### PR TITLE
Fix declare statement for type definitions while optional properties are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Deprecated
 ### Removed
 ### Fixed
-- targeting aspects in compositions now properly resolves them.
-- transitive references to property types of other entities now also work for enums.
+- Added declare statement on type definitions
 ### Security
 
 ## [0.35.0] - 2025-05-23

--- a/lib/components/property.js
+++ b/lib/components/property.js
@@ -1,10 +1,12 @@
 /**
  * Determines the proper modifiers for a property.
- * For most properties, this will be "declare". But for some properties,
- * like fields of a type, we don't want any modifiers.
- * A check for the parents name is necessary to avoid adding declare to
- * properties of a object type reference. These will have the object type as
- * their parent's name.
+ * 
+ * All properties must be modified by `declare`.
+ * The only exception to this is in case of an action return type being defined
+ * as an object. Here `declare` would cause an error.
+ * This case can be identified by checking the parent of the property:
+ * If the parent is a type and has no name, then it is an action return type.
+ * 
  * @param {import('../typedefs').resolver.EntityCSN} element - The element to determine the modifiers for.
  * @returns {import('../typedefs').resolver.PropertyModifier[]} The modifiers for the property.
  */

--- a/lib/components/property.js
+++ b/lib/components/property.js
@@ -2,10 +2,13 @@
  * Determines the proper modifiers for a property.
  * For most properties, this will be "declare". But for some properties,
  * like fields of a type, we don't want any modifiers.
+ * A check for the parents name is necessary to avoid adding declare to
+ * properties of a object type reference. These will have the object type as
+ * their parent's name.
  * @param {import('../typedefs').resolver.EntityCSN} element - The element to determine the modifiers for.
  * @returns {import('../typedefs').resolver.PropertyModifier[]} The modifiers for the property.
  */
-const getPropertyModifiers = element => element?.parent?.kind !== 'type' ? ['declare'] : []
+const getPropertyModifiers = element => element?.parent?.kind === 'type' && element?.parent?.name === undefined ? [] : ['declare']
 
 module.exports = {
     getPropertyModifiers

--- a/lib/components/property.js
+++ b/lib/components/property.js
@@ -1,12 +1,11 @@
 /**
  * Determines the proper modifiers for a property.
- * 
+ *
  * All properties must be modified by `declare`.
  * The only exception to this is in case of an action return type being defined
  * as an object. Here `declare` would cause an error.
  * This case can be identified by checking the parent of the property:
  * If the parent is a type and has no name, then it is an action return type.
- * 
  * @param {import('../typedefs').resolver.EntityCSN} element - The element to determine the modifiers for.
  * @returns {import('../typedefs').resolver.PropertyModifier[]} The modifiers for the property.
  */

--- a/test/ast.js
+++ b/test/ast.js
@@ -603,6 +603,7 @@ const check = {
     isStatic: node => checkKeyword(node, 'static'),
     isStaticMember: node => node?.modifiers?.find(m => checkKeyword(m, 'static')),
     isReadonlyMember: node => node?.modifiers?.find(m => checkKeyword(m, 'readonly')),
+    isDeclare: node => node?.modifiers?.find(m => checkKeyword(m, 'declare')),
     isIndexedAccessType: node => checkKeyword(node, 'indexedaccesstype'),
     isParenthesizedType: (node, of = undefined) => checkKeyword(node, 'parenthesizedtype') && (of === undefined || of(node.type)),
     isNull: node => checkKeyword(node, 'literaltype') && checkKeyword(node.literal, 'null'),
@@ -614,6 +615,7 @@ const check = {
     isOptional: node => node.optional,
     hasDeclareModifier: node => node?.modifiers?.some(mod => checkKeyword(mod, 'declare')),
     isLiteral: (node, literal = undefined) => checkKeyword(node, 'literaltype') && (literal === undefined || node.literal === literal),
+    isTypeLiteral: (node, literal = undefined) => checkKeyword(node, 'typeliteral'),
     isTypeReference: (node, full = undefined) => checkNodeType(node, 'typeReference') && (!full || node.full === full),
     isTypeQuery: node => checkKeyword(node, 'typequery'),  // FIXME: should actually check what is being queried
     isTypeAliasDeclaration: node => checkNodeType(node, 'typeAliasDeclaration'),

--- a/test/smoke/transpilation.test.js
+++ b/test/smoke/transpilation.test.js
@@ -31,6 +31,9 @@ describe('transpilation', () => {
                         transpilationCheck: true,
                         tsCompilerOptions: {
                             skipLibCheck: true,
+                        },
+                        typerOptions: {
+                            propertiesOptional: false
                         }
                     }
                 )

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -210,4 +210,18 @@ describe('Actions', () => {
             parameterCheck: ({members: [fst]}) => !check.isNullable(fst.type)
         })
     })
+
+    it('should validate that properties in action return type objects do not have declare modifiers', async () => {
+        const actions = astwBound.getAspectProperty('_EAspect', 'actions')
+        assert.ok(actions.modifiers.some(check.isStatic))
+        checkFunction(actions.type.members.find(fn => fn.name === 'h'), {
+            callCheck: signature => check.isTypeLiteral(signature),
+            parameterCheck: ({full, args}) => full === 'globalThis.Record'
+                && checkKeyword(args[0], 'never')
+                && checkKeyword(args[1], 'never'),
+            returnTypeCheck: returns => check.isTypeLiteral(returns)
+                && returns.members.every(member => !check.isDeclare(member)),
+            modifiersCheck: (modifiers = []) => !modifiers.some(check.isStatic),
+        })
+    })
 })


### PR DESCRIPTION
Fix for #545.
- Changes the check on adding a declare modifier to properly handle type definitions
- Sets properties as non optional in the transpilation test to avoid future errors