### PR TITLE
Add `__self` meta information to bound actions

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -162,6 +162,7 @@ class SourceFile extends File {
      * @param {string} options.name - name of the lambda
      * @param {import('./typedefs').visitor.ParamInfo[]} [options.parameters] - list of parameters, passed as [name, modifier, type, doc] pairs
      * @param {string} [options.returns] - the return type of the function
+     * @param {string} [options.self] - what is set as "__self", which is used for bound actions
      * @param {'action' | 'function'} options.kind - kind of the lambda
      * @param {string} [options.initialiser] - the initialiser expression
      * @param {boolean} [options.isStatic] - whether the lambda is static
@@ -187,7 +188,7 @@ class SourceFile extends File {
      * stringifyLambda({name: 'f', parameters: [{name:'p',type:'T'}], returns: 'number'})  // { (p: T): number, __parameters: { p: T } }
      * ```
      */
-    static stringifyLambda({name, parameters=[], returns='any', kind, initialiser, isStatic=false, callStyles={positional:true, named:true}, doc}) {
+    static stringifyLambda({name, parameters=[], returns='any', kind, initialiser, self='undefined', isStatic=false, callStyles={positional:true, named:true}, doc}) {
         let docStr = doc?.length ? doc.join('\n')+'\n' : ''
         const parameterTypes = parameters.map(({name, modifier, type, doc}) => `${doc?'\n'+doc:''}${normalise(name)}${modifier}: ${type}`).join(', ')
         const parameterTypeAsObject = parameterTypes.length
@@ -212,7 +213,7 @@ class SourceFile extends File {
 
         return [
             `${prefix} {`,
-            [...callableSignatures, '// metadata (do not use)', `__self: this,  __parameters: ${parameterTypeAsObject}, __returns: ${returns}`, ...kindDef],
+            [...callableSignatures, '// metadata (do not use)', `__self: ${self},  __parameters: ${parameterTypeAsObject}, __returns: ${returns}`, ...kindDef],
             `}${suffix}`,
         ]
     }

--- a/lib/file.js
+++ b/lib/file.js
@@ -212,7 +212,7 @@ class SourceFile extends File {
 
         return [
             `${prefix} {`,
-            [...callableSignatures, '// metadata (do not use)', `__parameters: ${parameterTypeAsObject}, __returns: ${returns}`, ...kindDef],
+            [...callableSignatures, '// metadata (do not use)', `__self: this,  __parameters: ${parameterTypeAsObject}, __returns: ${returns}`, ...kindDef],
             `}${suffix}`,
         ]
     }

--- a/lib/file.js
+++ b/lib/file.js
@@ -188,7 +188,7 @@ class SourceFile extends File {
      * stringifyLambda({name: 'f', parameters: [{name:'p',type:'T'}], returns: 'number'})  // { (p: T): number, __parameters: { p: T } }
      * ```
      */
-    static stringifyLambda({name, parameters=[], returns='any', kind, initialiser, self='undefined', isStatic=false, callStyles={positional:true, named:true}, doc}) {
+    static stringifyLambda({name, parameters=[], returns='any', kind, initialiser, self='null', isStatic=false, callStyles={positional:true, named:true}, doc}) {
         let docStr = doc?.length ? doc.join('\n')+'\n' : ''
         const parameterTypes = parameters.map(({name, modifier, type, doc}) => `${doc?'\n'+doc:''}${normalise(name)}${modifier}: ${type}`).join(', ')
         const parameterTypeAsObject = parameterTypes.length
@@ -213,7 +213,7 @@ class SourceFile extends File {
 
         return [
             `${prefix} {`,
-            [...callableSignatures, '// metadata (do not use)', `__self: ${self},  __parameters: ${parameterTypeAsObject}, __returns: ${returns}`, ...kindDef],
+            [...callableSignatures, '// metadata (do not use)', `__parameters: ${parameterTypeAsObject}, __returns: ${returns}, __self: ${self}`, ...kindDef],
             `}${suffix}`,
         ]
     }

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -94,11 +94,12 @@ class Visitor {
 
     /**
      * @param {EntityCSN} entity - the entity to print the actions for
+     * @param {string} clean - the clean entity name
      * @param {Buffer} buffer - the buffer to write the actions into
      * @param {import('./typedefs').resolver.EntityInfo[]} ancestors - the fully qualified names of the ancestors of the entity
      * @param {SourceFile} file - the file the entity is being printed into
      */
-    #printStaticActions(entity, buffer, ancestors, file) {
+    #printStaticActions(entity, clean, buffer, ancestors, file) {
         // TODO: refactor away! All these printing functionalities need to go
         const actions = Object.entries(entity.actions ?? {})
         const inherited = ancestors.map(a => `typeof ${asIdentifier({info: a, relative: file.path})}.actions`)
@@ -109,6 +110,7 @@ class Visitor {
                 () => {
                     for (const [aname, action] of actions) {
                         const [opener, content, closer] = SourceFile.stringifyLambda({
+                            self: clean,
                             name: aname,
                             parameters: this.#stringifyFunctionParams(action.params, file),
                             returns: action.returns
@@ -293,7 +295,7 @@ class Visitor {
                 }
                 this.#printStaticKeys(buffer, clean, ancestorInfos, file)
                 this.#printStaticElements(buffer, clean)
-                this.#printStaticActions(entity, buffer, ancestorInfos, file)
+                this.#printStaticActions(entity, clean, buffer, ancestorInfos, file)
             }, '};') // end of generated class
         }, '}') // end of aspect
 

--- a/test/ast.js
+++ b/test/ast.js
@@ -569,19 +569,22 @@ class JSASTWrapper {
     }
 }
 
-const checkFunction = (fnNode, {callCheck, parameterCheck, returnTypeCheck, modifiersCheck}) => {
+const checkFunction = (fnNode, {callCheck, parameterCheck, returnTypeCheck, selfTypeCheck, modifiersCheck}) => {
     if (!fnNode) throw new Error('the function does not exist (or was not properly accessed from the AST)')
-    const [callsignature1, callsignature2, parameters, returnType] = fnNode?.type?.members ?? []
+    const [callsignature1, callsignature2, parameters, returnType, selfType] = fnNode?.type?.members ?? []
     if (!callsignature1 || callsignature1.keyword !== 'callsignature') throw new Error('callsignature1 is not present or of wrong type')
     if (!callsignature2 || callsignature2.keyword !== 'callsignature') throw new Error('callsignature2 is not present or of wrong type')
     if (!parameters || ts.unescapeLeadingUnderscores(parameters.name) !== '__parameters') throw new Error('__parameters property is missing or named incorrectly')
     if (!returnType || ts.unescapeLeadingUnderscores(returnType.name) !== '__returns') throw new Error('__returns property is missing or named incorrectly')
+    if (!selfType || ts.unescapeLeadingUnderscores(selfType.name) !== '__self') throw new Error('__self property is missing or named incorrectly')
+
 
     if (callCheck && !callCheck(callsignature1.type)) throw new Error('callsignature is not matching expectations')
     if (callCheck && !callCheck(callsignature2.type)) throw new Error('callsignature is not matching expectations')
     if (parameterCheck && !parameterCheck(parameters.type)) throw new Error('parameter type is not matching expectations')
     if (returnTypeCheck && !returnTypeCheck(returnType.type)) throw new Error('return type is not matching expectations')
     if (modifiersCheck && !modifiersCheck(fnNode?.modifiers)) throw new Error('modifiers did not meet expectations')
+    if (selfTypeCheck && !selfTypeCheck(selfType.type)) throw new Error('self type is not matching expectations')
 
     return true
 }

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -56,8 +56,27 @@ describe('Actions', () => {
                 && check.isNullable(type.subtypes[0].args[0].subtypes[0].members[0].type, [check.isNumber])
                 && type.subtypes[0].args[0].subtypes[0].members[1].name === 'b'
                 && check.isNullable(type.subtypes[0].args[0].subtypes[0].members[1].type, [check.isString]),
+            // unbound actions -> self === null
+            selfTypeCheck: check.isNull
         })
     })
+
+    it('should validate bound actions containing __self', async () => {
+        const actions = astwBound.getAspectProperty('_EAspect', 'actions')
+        assert.ok(actions.modifiers.some(check.isStatic))
+        checkFunction(actions.type.members.find(fn => fn.name === 'f'), {
+            selfTypeCheck: type => check.isTypeReference(type, 'E')
+        })
+
+        checkFunction(actions.type.members.find(fn => fn.name === 'k'), {
+            selfTypeCheck: type => check.isTypeReference(type, 'E')
+        })
+
+        checkFunction(actions.type.members.find(fn => fn.name === 'l'), {
+            selfTypeCheck: type => check.isTypeReference(type, 'E')
+        })
+    })
+
 
     it('should validate bound actions returning external type', async () => {
         const actions = astwBound.getAspectProperty('_EAspect', 'actions')
@@ -65,17 +84,17 @@ describe('Actions', () => {
         checkFunction(actions.type.members.find(fn => fn.name === 'f'), {
             callCheck: signature => check.isAny(signature),
             parameterCheck: ({members: [fst]}) => fst.name === 'x' && check.isNullable(fst.type, [check.isString]),
-            returnTypeCheck: returns => check.isAny(returns)
+            returnTypeCheck: returns => check.isAny(returns),
         })
 
         checkFunction(actions.type.members.find(fn => fn.name === 'k'), {
             callCheck: ({full}) => full === '_elsewhere.ExternalType',
-            returnTypeCheck: ({full}) => full === '_elsewhere.ExternalType'
+            returnTypeCheck: ({full}) => full === '_elsewhere.ExternalType',
         })
 
         checkFunction(actions.type.members.find(fn => fn.name === 'l'), {
             callCheck: ({full}) => full === '_.ExternalInRoot',
-            returnTypeCheck: ({full}) => full === '_.ExternalInRoot'
+            returnTypeCheck: ({full}) => full === '_.ExternalInRoot',
         })
     })
 


### PR DESCRIPTION
Bound actions now carry a reference to the entity they are bound to.
This can then be consumed by cds-types when inferring `req.subject`:

```ts
// in a service
this.on(myBoundAction, req => {
  req.subject  // so far this is cds.req, but could be inferred to a stricter type based on __self
})
```