### PR TITLE
feat: Add (experimental) CDS env `cds.env.typer.output_d_ts_files`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added (experimental) flag `cds.env.typer.output_d_ts_files` for generating output `*.d.ts` files instead of `*.ts` ones
 ### Changed
 - unbound actions will now assume the `self` type of `never`, instead of the former `null`
 ### Deprecated

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -150,7 +150,7 @@ const flags = enrichFlagSchema({
         type: 'string'
     },
     outputDTsFiles: {
-        desc: '(experimental) If set to true, *.d.ts files will be generated per each *.js files. If set to false (default), *.ts files will be generated per each *.js files.',
+        desc: '(experimental) If set to true, emits .d.ts files for each generated .js file. If set to false (default), emits .ts files instead.',
         default: 'false',
         type: 'boolean'
     },

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -149,6 +149,11 @@ const flags = enrichFlagSchema({
         default: './',
         type: 'string'
     },
+    outputDTsFiles: {
+        desc: '(experimental) If set to true, *.d.ts files will be generated per each *.js files. If set to false (default), *.ts files will be generated per each *.js files.',
+        default: 'false',
+        type: 'boolean'
+    },
     help: {
         desc: 'This text.',
     },

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -149,11 +149,10 @@ const flags = enrichFlagSchema({
         default: './',
         type: 'string'
     },
-    outputDTsFiles: {
-        desc: '(experimental) If set to true, emits .d.ts files for each generated .js file. If set to false (default), emits .ts files instead.',
+    outputDTsFiles: parameterTypes.boolean({
+        desc: '(experimental) If set to true, emits .d.ts files for each generated .js file. If set to false (default), emits .ts files instead. Note: skipLibCheck must be set to true in your tsconfig for this option to work properly.',
         default: 'false',
-        type: 'boolean'
-    },
+    }),
     help: {
         desc: 'This text.',
     },

--- a/lib/file.js
+++ b/lib/file.js
@@ -3,6 +3,7 @@
 const fs = require('fs').promises
 const path = require('path')
 const { readFileSync } = require('fs')
+const cds = require('@sap/cds')
 const { printEnum, propertyToInlineEnumName, stringifyEnumImplementation } = require('./components/enum')
 const { normalise } = require('./components/identifier')
 const { empty } = require('./components/typescript')
@@ -825,10 +826,11 @@ const writeout = async (root, sources) =>
     Promise.all(
         sources.map(async source => {
             const dir = path.join(root, source.path.asDirectory({local: false, posix: false}))
+            const output_file = cds.env.typer.output_d_ts_files ? 'index.d.ts' : 'index.ts'
             try {
                 await fs.mkdir(dir, { recursive: true })
                 await Promise.all([
-                    fs.writeFile(path.join(dir, 'index.ts'), source.toTypeDefs()),
+                    fs.writeFile(path.join(dir, output_file), source.toTypeDefs()),
                     fs.writeFile(path.join(dir, 'index.js'), source.toJSExports()),
                 ])
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -825,7 +825,7 @@ const writeout = async (root, sources) =>
     Promise.all(
         sources.map(async source => {
             const dir = path.join(root, source.path.asDirectory({local: false, posix: false}))
-            const outputFile = configuration.outputDTSFiles ? 'index.d.ts' : 'index.ts'
+            const outputFile = configuration.outputDTsFiles ? 'index.d.ts' : 'index.ts'
             try {
                 await fs.mkdir(dir, { recursive: true })
                 await Promise.all([

--- a/lib/file.js
+++ b/lib/file.js
@@ -3,7 +3,6 @@
 const fs = require('fs').promises
 const path = require('path')
 const { readFileSync } = require('fs')
-const cds = require('@sap/cds')
 const { printEnum, propertyToInlineEnumName, stringifyEnumImplementation } = require('./components/enum')
 const { normalise } = require('./components/identifier')
 const { empty } = require('./components/typescript')
@@ -826,11 +825,11 @@ const writeout = async (root, sources) =>
     Promise.all(
         sources.map(async source => {
             const dir = path.join(root, source.path.asDirectory({local: false, posix: false}))
-            const output_file = cds.env.typer.output_d_ts_files ? 'index.d.ts' : 'index.ts'
+            const outputFile = configuration.outputDTSFiles ? 'index.d.ts' : 'index.ts'
             try {
                 await fs.mkdir(dir, { recursive: true })
                 await Promise.all([
-                    fs.writeFile(path.join(dir, output_file), source.toTypeDefs()),
+                    fs.writeFile(path.join(dir, outputFile), source.toTypeDefs()),
                     fs.writeFile(path.join(dir, 'index.js'), source.toJSExports()),
                 ])
 

--- a/lib/resolution/entity.js
+++ b/lib/resolution/entity.js
@@ -184,7 +184,7 @@ class EntityRepository {
 
 /**
  * Derives an identifier from an entity info.
- * That identifier can be used to refer to a specific entity within an index.ts file.
+ * That identifier can be used to refer to a specific entity within an index.ts / index.d.ts file.
  * By passing a relative file, the identifier will be preceeded with a scope if needed.
  * @param {object} options - the options
  * @param {EntityInfo} options.info - the entity info

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -189,7 +189,7 @@ export module config {
 
     export type Configuration = {
         outputDirectory: string,
-        outputDTSFiles: boolean,
+        outputDTsFiles: boolean,
         cache: 'none' | 'blake2s256'
         logLevel: number,
         /**

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -189,6 +189,7 @@ export module config {
 
     export type Configuration = {
         outputDirectory: string,
+        outputDTSFiles: boolean,
         cache: 'none' | 'blake2s256'
         logLevel: number,
         /**

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
             },
             "output_d_ts_files": {
               "type": "boolean",
-              "description": "(experimental) If set to true, emits .d.ts files for each generated .js file. If set to false (default), emits .ts files instead.",
+              "description": "(experimental) If set to true, emits .d.ts files for each generated .js file. If set to false (default), emits .ts files instead. Note: skipLibCheck must be set to true in your tsconfig for this option to work properly.",
               "default": false
             },
             "log_level": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "cds": {
     "typer": {
       "output_directory": "@cds-models",
+      "output_d_ts_files": false,
       "inline_declarations": "flat",
       "target_module_type": "auto",
       "properties_optional": true,
@@ -83,6 +84,11 @@
               "type": "string",
               "description": "Root directory to write the generated files to.",
               "default": "@cds-models"
+            },
+            "output_d_ts_files": {
+              "type": "boolean",
+              "description": "(experimental) If set to true, *.d.ts files will be generated per each *.js files. If set to false (default), *.ts files will be generated per each *.js files.",
+              "default": false
             },
             "log_level": {
               "type": "string",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
             },
             "output_d_ts_files": {
               "type": "boolean",
-              "description": "(experimental) If set to true, *.d.ts files will be generated per each *.js files. If set to false (default), *.ts files will be generated per each *.js files.",
+              "description": "(experimental) If set to true, emits .d.ts files for each generated .js file. If set to false (default), emits .ts files instead.",
               "default": false
             },
             "log_level": {

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,28 @@
+
+/**
+ * @description the options for CDS config, to be used in the tests
+ * @typedef {object} CdsTestConfigOptions
+ * @property {boolean} output_d_ts_files - whether to emit .d.ts files instead of .ts files
+ * @property {string} output_file - expected output file name (e.g., "index.ts" or "index.d.ts")
+ */
+
+/** @type {CdsTestConfigOptions[]} */
+const CDS_TEST_CONFIG_OPTIONS = [
+    { output_d_ts_files: false, output_file: 'index.ts' },
+    { output_d_ts_files: true, output_file: 'index.d.ts' },
+]
+
+/**
+ * @description
+ *  It calls `callback` per each CDS test config
+ * @param {(options: CdsTestConfigOptions) => void} callback - function to be called per each config
+ *  (it must be `describe(...)` or `it(...)`)
+ * @returns {void}
+ */
+function perEachTestConfig(callback) {
+    for (const options of CDS_TEST_CONFIG_OPTIONS) {
+        callback(options)
+    }
+}
+
+module.exports = { CDS_TEST_CONFIG_OPTIONS, perEachTestConfig }

--- a/test/config.js
+++ b/test/config.js
@@ -2,14 +2,14 @@
 /**
  * @description the options for CDS config, to be used in the tests
  * @typedef {object} CdsTestConfigOptions
- * @property {boolean} output_d_ts_files - whether to emit .d.ts files instead of .ts files
- * @property {string} output_file - expected output file name (e.g., "index.ts" or "index.d.ts")
+ * @property {boolean} outputDTsFiles - whether to emit .d.ts files instead of .ts files
+ * @property {string} outputFile - expected output file name (e.g., "index.ts" or "index.d.ts")
  */
 
 /** @type {CdsTestConfigOptions[]} */
 const CDS_TEST_CONFIG_OPTIONS = [
-    { output_d_ts_files: false, output_file: 'index.ts' },
-    { output_d_ts_files: true, output_file: 'index.d.ts' },
+    { outputDTsFiles: false, outputFile: 'index.ts' },
+    { outputDTsFiles: true, outputFile: 'index.d.ts' },
 ]
 
 /**

--- a/test/smoke/transpilation.test.js
+++ b/test/smoke/transpilation.test.js
@@ -2,10 +2,8 @@
 
 const fs = require('fs')
 const path = require('path')
-const { describe, it, before } = require('node:test')
-const cds = require('@sap/cds')
+const { describe, it } = require('node:test')
 const { locations, prepareUnitTest } = require('../util')
-const { perEachTestConfig } = require('../config')
 
 const modelDirs = fs.readdirSync(locations.smoke.files(''))
     .map(dir => {
@@ -22,68 +20,62 @@ const modelDirs = fs.readdirSync(locations.smoke.files(''))
     })
     .filter(Boolean)
 
-perEachTestConfig(({ output_file, output_d_ts_files }) => {
-    before(() => {
-        cds.env.typer.output_d_ts_files = output_d_ts_files
-    })
-
-    describe(`transpilation (using output **/*/${output_file} files)`, () => {
-        modelDirs.forEach(({ name, rootFile }) => {
-            it(name, async () => {
-                try {
-                    await prepareUnitTest(
-                        rootFile,
-                        locations.testOutput(name),
-                        {
-                            transpilationCheck: true,
-                            tsCompilerOptions: {
-                                skipLibCheck: true,
-                            },
-                            typerOptions: {
-                                propertiesOptional: false
-                            }
+describe('transpilation', () => {
+    modelDirs.forEach(({ name, rootFile }) => {
+        it(name, async () => {
+            try {
+                await prepareUnitTest(
+                    rootFile,
+                    locations.testOutput(name),
+                    {
+                        transpilationCheck: true,
+                        tsCompilerOptions: {
+                            skipLibCheck: true,
+                        },
+                        typerOptions: {
+                            propertiesOptional: false
                         }
-                    )
-                } catch (e) {
-                    // nodejs test runner just shows "x subtests failed" without any details
-                    // so we are artificially showing the error here for now
-                    // eslint-disable-next-line no-console
-                    console.error(e)
-                    throw e
+                    }
+                )
+            } catch (e) {
+                // nodejs test runner just shows "x subtests failed" without any details
+                // so we are artificially showing the error here for now
+                // eslint-disable-next-line no-console
+                console.error(e)
+                throw e
+            }
+        })
+    })
+})
+
+describe('index.js CommonJS', () => {
+    modelDirs.forEach(({ name, rootFile }) => {
+        it(name, async () => {
+            await prepareUnitTest(
+                rootFile,
+                locations.testOutput(name),
+                {
+                    javascriptCheck: true,
+                    javascriptCheckParameters: { ecmaVersion: 'latest'},
+                    typerOptions: { targetModuleType: 'cjs' }
                 }
-            })
+            )
         })
     })
+})
 
-    describe(`index.js CommonJS (using output **/*/${output_file} files)`, () => {
-        modelDirs.forEach(({ name, rootFile }) => {
-            it(name, async () => {
-                await prepareUnitTest(
-                    rootFile,
-                    locations.testOutput(name),
-                    {
-                        javascriptCheck: true,
-                        javascriptCheckParameters: { ecmaVersion: 'latest'},
-                        typerOptions: { targetModuleType: 'cjs' }
-                    }
-                )
-            })
-        })
-    })
-
-    describe(`index.js ESM (using output **/*/${output_file} files)`, () => {
-        modelDirs.forEach(({ name, rootFile }) => {
-            it(name, async () => {
-                await prepareUnitTest(
-                    rootFile,
-                    locations.testOutput(name),
-                    {
-                        javascriptCheck: true,
-                        javascriptCheckParameters: { ecmaVersion: 'latest', sourceType: 'module' },
-                        typerOptions: { targetModuleType: 'esm' },
-                    }
-                )
-            })
+describe('index.js ESM', () => {
+    modelDirs.forEach(({ name, rootFile }) => {
+        it(name, async () => {
+            await prepareUnitTest(
+                rootFile,
+                locations.testOutput(name),
+                {
+                    javascriptCheck: true,
+                    javascriptCheckParameters: { ecmaVersion: 'latest', sourceType: 'module' },
+                    typerOptions: { targetModuleType: 'esm' },
+                }
+            )
         })
     })
 })

--- a/test/smoke/transpilation.test.js
+++ b/test/smoke/transpilation.test.js
@@ -2,8 +2,10 @@
 
 const fs = require('fs')
 const path = require('path')
-const { describe, it } = require('node:test')
+const { describe, it, before } = require('node:test')
+const cds = require('@sap/cds')
 const { locations, prepareUnitTest } = require('../util')
+const { perEachTestConfig } = require('../config')
 
 const modelDirs = fs.readdirSync(locations.smoke.files(''))
     .map(dir => {
@@ -20,62 +22,68 @@ const modelDirs = fs.readdirSync(locations.smoke.files(''))
     })
     .filter(Boolean)
 
-describe('transpilation', () => {
-    modelDirs.forEach(({ name, rootFile }) => {
-        it(name, async () => {
-            try {
+perEachTestConfig(({ output_file, output_d_ts_files }) => {
+    before(() => {
+        cds.env.typer.output_d_ts_files = output_d_ts_files
+    })
+
+    describe(`transpilation (using output **/*/${output_file} files)`, () => {
+        modelDirs.forEach(({ name, rootFile }) => {
+            it(name, async () => {
+                try {
+                    await prepareUnitTest(
+                        rootFile,
+                        locations.testOutput(name),
+                        {
+                            transpilationCheck: true,
+                            tsCompilerOptions: {
+                                skipLibCheck: true,
+                            },
+                            typerOptions: {
+                                propertiesOptional: false
+                            }
+                        }
+                    )
+                } catch (e) {
+                    // nodejs test runner just shows "x subtests failed" without any details
+                    // so we are artificially showing the error here for now
+                    // eslint-disable-next-line no-console
+                    console.error(e)
+                    throw e
+                }
+            })
+        })
+    })
+
+    describe(`index.js CommonJS (using output **/*/${output_file} files)`, () => {
+        modelDirs.forEach(({ name, rootFile }) => {
+            it(name, async () => {
                 await prepareUnitTest(
                     rootFile,
                     locations.testOutput(name),
                     {
-                        transpilationCheck: true,
-                        tsCompilerOptions: {
-                            skipLibCheck: true,
-                        },
-                        typerOptions: {
-                            propertiesOptional: false
-                        }
+                        javascriptCheck: true,
+                        javascriptCheckParameters: { ecmaVersion: 'latest'},
+                        typerOptions: { targetModuleType: 'cjs' }
                     }
                 )
-            } catch (e) {
-                // nodejs test runner just shows "x subtests failed" without any details
-                // so we are artificially showing the error here for now
-                // eslint-disable-next-line no-console
-                console.error(e)
-                throw e
-            }
+            })
         })
     })
-})
 
-describe('index.js CommonJS', () => {
-    modelDirs.forEach(({ name, rootFile }) => {
-        it(name, async () => {
-            await prepareUnitTest(
-                rootFile,
-                locations.testOutput(name),
-                {
-                    javascriptCheck: true,
-                    javascriptCheckParameters: { ecmaVersion: 'latest'},
-                    typerOptions: { targetModuleType: 'cjs' }
-                }
-            )
-        })
-    })
-})
-
-describe('index.js ESM', () => {
-    modelDirs.forEach(({ name, rootFile }) => {
-        it(name, async () => {
-            await prepareUnitTest(
-                rootFile,
-                locations.testOutput(name),
-                {
-                    javascriptCheck: true,
-                    javascriptCheckParameters: { ecmaVersion: 'latest', sourceType: 'module' },
-                    typerOptions: { targetModuleType: 'esm' },
-                }
-            )
+    describe(`index.js ESM (using output **/*/${output_file} files)`, () => {
+        modelDirs.forEach(({ name, rootFile }) => {
+            it(name, async () => {
+                await prepareUnitTest(
+                    rootFile,
+                    locations.testOutput(name),
+                    {
+                        javascriptCheck: true,
+                        javascriptCheckParameters: { ecmaVersion: 'latest', sourceType: 'module' },
+                        typerOptions: { targetModuleType: 'esm' },
+                    }
+                )
+            })
         })
     })
 })

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const cds = require('@sap/cds')
 const path = require('path')
 const { describe, before, it } = require('node:test')
 const assert = require('assert')
 const { checkFunction, check, ASTWrapper, checkKeyword } = require('../ast')
 const { locations, prepareUnitTest } = require('../util')
 const { perEachTestConfig } = require('../config')
+const { configuration } = require('../../lib/config')
 
 perEachTestConfig(options => {
     describe(`Actions (using output **/*/${options.output_file} files)`, () => {
@@ -16,7 +16,7 @@ perEachTestConfig(options => {
         let astwUnbound
 
         before(async () => {
-            cds.env.typer.output_d_ts_files = options.output_d_ts_files
+            configuration.outputDTSFiles = options.output_d_ts_files
 
             sut = await prepareUnitTest('actions/model.cds', locations.testOutput('actions_test'))
             paths = sut.paths

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -1,246 +1,252 @@
 'use strict'
 
+const cds = require('@sap/cds')
 const path = require('path')
 const { describe, before, it } = require('node:test')
 const assert = require('assert')
 const { checkFunction, check, ASTWrapper, checkKeyword } = require('../ast')
 const { locations, prepareUnitTest } = require('../util')
+const { perEachTestConfig } = require('../config')
 
-describe('Actions', () => {
-    let paths
-    let sut
-    let astwBound
-    let astwUnbound
+perEachTestConfig(({ output_file, output_d_ts_files }) => {
+    describe(`Actions (using output **/*/${output_file} files)`, () => {
+        let paths
+        let sut
+        let astwBound
+        let astwUnbound
 
-    before(async () => {
-        sut = await prepareUnitTest('actions/model.cds', locations.testOutput('actions_test'))
-        paths = sut.paths
-        astwBound = new ASTWrapper(path.join(paths.find(p => p.endsWith('S')), 'index.ts'))
-        astwUnbound = new ASTWrapper(path.join(paths.find(p => p.endsWith('actions_test')), 'index.ts'))
-    })
+        before(async () => {
+            cds.env.typer.output_d_ts_files = output_d_ts_files
 
-    it('should add import statement for builtin types', async () => {
-        assert.strictEqual(sut.astw.getImports()[0].module, './../_')
-    })
-
-    it('should validate bound actions', async () => {
-        const actions = astwBound.getAspectProperty('_EAspect', 'actions')
-        assert.ok(actions.modifiers.some(check.isStatic))
-        checkFunction(actions.type.members.find(fn => fn.name === 'f'), {
-            parameterCheck: ({members: [fst]}) => fst.name === 'x' && check.isNullable(fst.type, [check.isString])
-        })
-        checkFunction(actions.type.members.find(fn => fn.name === 'g'), {
-            parameterCheck: ({members: [fst, snd]}) => {
-                const fstCorrect = fst.name === 'a'
-                    && fst.type.subtypes[0].members[0].name === 'x'
-                    && check.isNullable(fst.type.subtypes[0].members[0].type, [check.isNumber])
-                    && fst.type.subtypes[0].members[1].name === 'y' && check.isNullable(fst.type.subtypes[0].members[1].type, [check.isNumber])
-                const sndCorrect = snd.name === 'b' && check.isNullable(snd.type, [check.isNumber])
-                return fstCorrect && sndCorrect
-            }
-        })
-    })
-
-    it('should validate unbound actions', async () => {
-        const ast = astwUnbound.tree
-        checkFunction(ast.find(node => node.name === 'free'), {
-            modifiersCheck: (modifiers = []) => !modifiers.some(check.isStatic),
-            callCheck: type => check.isNullable(type.subtypes[0].args[0])
-                && type.subtypes[0].args[0].subtypes[0].members[0].name === 'a'
-                && check.isNullable(type.subtypes[0].args[0].subtypes[0].members[0].type, [check.isNumber])
-                && type.subtypes[0].args[0].subtypes[0].members[1].name === 'b'
-                && check.isNullable(type.subtypes[0].args[0].subtypes[0].members[1].type, [check.isString]),
-            parameterCheck: ({members: [fst]}) => fst.name === 'param' && check.isNullable(fst.type, [check.isString]),
-            returnTypeCheck: type => check.isNullable(type.subtypes[0].args[0])
-                && type.subtypes[0].args[0].subtypes[0].members[0].name === 'a'
-                && check.isNullable(type.subtypes[0].args[0].subtypes[0].members[0].type, [check.isNumber])
-                && type.subtypes[0].args[0].subtypes[0].members[1].name === 'b'
-                && check.isNullable(type.subtypes[0].args[0].subtypes[0].members[1].type, [check.isString]),
-            // unbound actions -> self === never
-            selfTypeCheck: check.isNever
-        })
-    })
-
-    it('should validate bound actions containing __self', async () => {
-        const actions = astwBound.getAspectProperty('_EAspect', 'actions')
-        assert.ok(actions.modifiers.some(check.isStatic))
-        checkFunction(actions.type.members.find(fn => fn.name === 'f'), {
-            selfTypeCheck: type => check.isTypeReference(type, 'E')
+            sut = await prepareUnitTest('actions/model.cds', locations.testOutput('actions_test'))
+            paths = sut.paths
+            astwBound = new ASTWrapper(path.join(paths.find(p => p.endsWith('S')), output_file))
+            astwUnbound = new ASTWrapper(path.join(paths.find(p => p.endsWith('actions_test')), output_file))
         })
 
-        checkFunction(actions.type.members.find(fn => fn.name === 'k'), {
-            selfTypeCheck: type => check.isTypeReference(type, 'E')
+        it('should add import statement for builtin types', async () => {
+            assert.strictEqual(sut.astw.getImports()[0].module, './../_')
         })
 
-        checkFunction(actions.type.members.find(fn => fn.name === 'l'), {
-            selfTypeCheck: type => check.isTypeReference(type, 'E')
-        })
-    })
-
-
-    it('should validate bound actions returning external type', async () => {
-        const actions = astwBound.getAspectProperty('_EAspect', 'actions')
-        assert.ok(actions.modifiers.some(check.isStatic))
-        checkFunction(actions.type.members.find(fn => fn.name === 'f'), {
-            callCheck: signature => check.isAny(signature),
-            parameterCheck: ({members: [fst]}) => fst.name === 'x' && check.isNullable(fst.type, [check.isString]),
-            returnTypeCheck: returns => check.isAny(returns),
-        })
-
-        checkFunction(actions.type.members.find(fn => fn.name === 'k'), {
-            callCheck: ({full}) => full === '_elsewhere.ExternalType',
-            returnTypeCheck: ({full}) => full === '_elsewhere.ExternalType',
+        it('should validate bound actions', async () => {
+            const actions = astwBound.getAspectProperty('_EAspect', 'actions')
+            assert.ok(actions.modifiers.some(check.isStatic))
+            checkFunction(actions.type.members.find(fn => fn.name === 'f'), {
+                parameterCheck: ({ members: [fst] }) => fst.name === 'x' && check.isNullable(fst.type, [check.isString])
+            })
+            checkFunction(actions.type.members.find(fn => fn.name === 'g'), {
+                parameterCheck: ({ members: [fst, snd] }) => {
+                    const fstCorrect = fst.name === 'a'
+                        && fst.type.subtypes[0].members[0].name === 'x'
+                        && check.isNullable(fst.type.subtypes[0].members[0].type, [check.isNumber])
+                        && fst.type.subtypes[0].members[1].name === 'y' && check.isNullable(fst.type.subtypes[0].members[1].type, [check.isNumber])
+                    const sndCorrect = snd.name === 'b' && check.isNullable(snd.type, [check.isNumber])
+                    return fstCorrect && sndCorrect
+                }
+            })
         })
 
-        checkFunction(actions.type.members.find(fn => fn.name === 'l'), {
-            callCheck: ({full}) => full === '_.ExternalInRoot',
-            returnTypeCheck: ({full}) => full === '_.ExternalInRoot',
+        it('should validate unbound actions', async () => {
+            const ast = astwUnbound.tree
+            checkFunction(ast.find(node => node.name === 'free'), {
+                modifiersCheck: (modifiers = []) => !modifiers.some(check.isStatic),
+                callCheck: type => check.isNullable(type.subtypes[0].args[0])
+                    && type.subtypes[0].args[0].subtypes[0].members[0].name === 'a'
+                    && check.isNullable(type.subtypes[0].args[0].subtypes[0].members[0].type, [check.isNumber])
+                    && type.subtypes[0].args[0].subtypes[0].members[1].name === 'b'
+                    && check.isNullable(type.subtypes[0].args[0].subtypes[0].members[1].type, [check.isString]),
+                parameterCheck: ({ members: [fst] }) => fst.name === 'param' && check.isNullable(fst.type, [check.isString]),
+                returnTypeCheck: type => check.isNullable(type.subtypes[0].args[0])
+                    && type.subtypes[0].args[0].subtypes[0].members[0].name === 'a'
+                    && check.isNullable(type.subtypes[0].args[0].subtypes[0].members[0].type, [check.isNumber])
+                    && type.subtypes[0].args[0].subtypes[0].members[1].name === 'b'
+                    && check.isNullable(type.subtypes[0].args[0].subtypes[0].members[1].type, [check.isString]),
+                // unbound actions -> self === never
+                selfTypeCheck: check.isNever
+            })
         })
-    })
 
-    it('should validate unbound actions returning external type', async () => {
-        const ast = astwUnbound.tree
+        it('should validate bound actions containing __self', async () => {
+            const actions = astwBound.getAspectProperty('_EAspect', 'actions')
+            assert.ok(actions.modifiers.some(check.isStatic))
+            checkFunction(actions.type.members.find(fn => fn.name === 'f'), {
+                selfTypeCheck: type => check.isTypeReference(type, 'E')
+            })
 
-        checkFunction(ast.find(node => node.name === 'free2'), {
-            modifiersCheck: (modifiers = []) => !modifiers.some(check.isStatic),
-            callCheck: type => check.isNullable(type.subtypes[0].args[0], [t => t?.full === '_elsewhere.ExternalType']),
-            returnTypeCheck: type => check.isNullable(type.subtypes[0].args[0], [t => t?.full === '_elsewhere.ExternalType'])
+            checkFunction(actions.type.members.find(fn => fn.name === 'k'), {
+                selfTypeCheck: type => check.isTypeReference(type, 'E')
+            })
+
+            checkFunction(actions.type.members.find(fn => fn.name === 'l'), {
+                selfTypeCheck: type => check.isTypeReference(type, 'E')
+            })
         })
 
-        checkFunction(ast.find(node => node.name === 'free3'), {
-            modifiersCheck: (modifiers = []) => !modifiers.some(check.isStatic),
-            callCheck: type => check.isNullable(type.subtypes[0].args[0], [t => t?.full === '_.ExternalInRoot']),
-            returnTypeCheck: type => check.isNullable(type.subtypes[0].args[0], [t => t?.full === '_.ExternalInRoot'])
-        })
-    })
 
-    it('should validate void action returning void', async () => {
-        checkFunction(astwUnbound.tree.find(node => node.name === 'freevoid'), {
-            modifiersCheck: (modifiers = []) => !modifiers.some(check.isStatic),
-            callCheck: type => check.isNullable(type, [check.isVoid]),
-            returnTypeCheck: type => check.isNullable(type, [check.isVoid])
-        })
-    })
+        it('should validate bound actions returning external type', async () => {
+            const actions = astwBound.getAspectProperty('_EAspect', 'actions')
+            assert.ok(actions.modifiers.some(check.isStatic))
+            checkFunction(actions.type.members.find(fn => fn.name === 'f'), {
+                callCheck: signature => check.isAny(signature),
+                parameterCheck: ({ members: [fst] }) => fst.name === 'x' && check.isNullable(fst.type, [check.isString]),
+                returnTypeCheck: returns => check.isAny(returns)
+            })
 
-    it('should validate bound actions expecting $self arguments', async () => {
-        const actions = astwBound.getAspectProperty('_EAspect', 'actions')
-        assert.ok(actions.modifiers.some(check.isStatic))
-        // mainly make sure $self parameter is not present at all
-        checkFunction(actions.type.members.find(fn => fn.name === 's1'), {
-            callCheck: signature => check.isAny(signature),
-            returnTypeCheck: returns => check.isAny(returns),
-            parameterCheck: ({full, args}) => full === 'globalThis.Record'
-                && checkKeyword(args[0], 'never')
-                && checkKeyword(args[1], 'never')
-        })
-        checkFunction(actions.type.members.find(fn => fn.name === 'sn'), {
-            callCheck: signature => check.isAny(signature),
-            returnTypeCheck: returns => check.isAny(returns),
-            parameterCheck: ({full, args}) => full === 'globalThis.Record'
-                && checkKeyword(args[0], 'never')
-                && checkKeyword(args[1], 'never')
-        })
-        checkFunction(actions.type.members.find(fn => fn.name === 'sx'), {
-            callCheck: signature => check.isAny(signature),
-            returnTypeCheck: returns => check.isAny(returns),
-            parameterCheck: ({members: [fst]}) => check.isNullable(fst.type, [check.isNumber])
-        })
-    })
+            checkFunction(actions.type.members.find(fn => fn.name === 'k'), {
+                callCheck: ({ full }) => full === '_elsewhere.ExternalType',
+                returnTypeCheck: ({ full }) => full === '_elsewhere.ExternalType'
+            })
 
-    it('should validate inflection on external type in function type', async () => {
-        checkFunction(astwBound.tree.find(fn => fn.name === 'getOneExternalType'), {
-            returnTypeCheck: returns => check.isNullable(returns.subtypes[0].args[0], [st => check.isTypeReference(st, '_elsewhere.ExternalType')])
+            checkFunction(actions.type.members.find(fn => fn.name === 'l'), {
+                callCheck: ({ full }) => full === '_.ExternalInRoot',
+                returnTypeCheck: ({ full }) => full === '_.ExternalInRoot'
+            })
         })
-        checkFunction(astwBound.tree.find(fn => fn.name === 'getManyExternalTypes'), {
-            returnTypeCheck: returns => check.isArray(returns.subtypes[0].args[0], ([arg]) => check.isTypeReference(arg, '_elsewhere.ExternalType'))
-        })
-    })
 
-    it('should validate inflection in parameters/return type of functions', async () => {
-        checkFunction(astwBound.tree.find(fn => fn.name === 'fSingleParamSingleReturn'), {
-            parameterCheck: ({members: [fst]}) => check.isNullable(fst.type, [arg => check.isTypeReference(arg, 'E')]),
-            returnTypeCheck: returns => check.isNullable(returns.subtypes[0].args[0], [st => check.isTypeReference(st, 'E')])
-        })
-        checkFunction(astwBound.tree.find(fn => fn.name === 'fSingleParamManyReturn'), {
-            parameterCheck: ({members: [fst]}) => check.isNullable(fst.type, [arg => check.isTypeReference(arg, 'E')]),
-            returnTypeCheck: returns => check.isArray(returns.subtypes[0].args[0], ([arg]) => check.isTypeReference(arg, 'E'))
-        })
-        checkFunction(astwBound.tree.find(fn => fn.name === 'fManyParamSingleReturn'), {
-            parameterCheck: ({members: [fst]}) => check.isArray(fst.type, ([arg]) => check.isTypeReference(arg, 'E')),
-            returnTypeCheck: returns => check.isNullable(returns.subtypes[0].args[0], [st => check.isTypeReference(st, 'E')])
-        })
-        checkFunction(astwBound.tree.find(fn => fn.name === 'fManyParamSingleReturn'), {
-            parameterCheck: ({members: [fst]}) => check.isArray(fst.type, ([arg]) => check.isTypeReference(arg, 'E')),
-            returnTypeCheck: returns => check.isNullable(returns.subtypes[0].args[0], [st => check.isTypeReference(st, 'E')])
-        })
-        checkFunction(astwBound.tree.find(fn => fn.name === 'fManyParamManyReturn'), {
-            parameterCheck: ({members: [fst]}) => check.isArray(fst.type, ([arg]) => check.isTypeReference(arg, 'E')),
-            returnTypeCheck: returns => check.isArray(returns.subtypes[0].args[0], ([arg]) => check.isTypeReference(arg, 'E'))
-        })
-    })
+        it('should validate unbound actions returning external type', async () => {
+            const ast = astwUnbound.tree
 
-    it('should validate inflection in parameters/return type of actions', async () => {
-        checkFunction(astwBound.tree.find(fn => fn.name === 'aSingleParamSingleReturn'), {
-            parameterCheck: ({members: [fst]}) => check.isNullable(fst.type, [arg => check.isTypeReference(arg, 'E')]),
-            returnTypeCheck: returns => check.isNullable(returns.subtypes[0].args[0], [st => check.isTypeReference(st, 'E')])
-        })
-        checkFunction(astwBound.tree.find(fn => fn.name === 'aSingleParamManyReturn'), {
-            parameterCheck: ({members: [fst]}) => check.isNullable(fst.type, [arg => check.isTypeReference(arg, 'E')]),
-            returnTypeCheck: returns => check.isArray(returns.subtypes[0].args[0], ([arg]) => check.isTypeReference(arg, 'E'))
-        })
-        checkFunction(astwBound.tree.find(fn => fn.name === 'aManyParamSingleReturn'), {
-            parameterCheck: ({members: [fst]}) => check.isArray(fst.type, ([arg]) => check.isTypeReference(arg, 'E')),
-            returnTypeCheck: returns => check.isNullable(returns.subtypes[0].args[0], [st => check.isTypeReference(st, 'E')])
-        })
-        checkFunction(astwBound.tree.find(fn => fn.name === 'aManyParamSingleReturn'), {
-            parameterCheck: ({members: [fst]}) => check.isArray(fst.type, ([arg]) => check.isTypeReference(arg, 'E')),
-            returnTypeCheck: returns => check.isNullable(returns.subtypes[0].args[0], [st => check.isTypeReference(st, 'E')])
-        })
-        checkFunction(astwBound.tree.find(fn => fn.name === 'aManyParamManyReturn'), {
-            parameterCheck: ({members: [fst]}) => check.isArray(fst.type, ([arg]) => check.isTypeReference(arg, 'E')),
-            returnTypeCheck: returns => check.isArray(returns.subtypes[0].args[0], ([arg]) => check.isTypeReference(arg, 'E'))
-        })
-    })
+            checkFunction(ast.find(node => node.name === 'free2'), {
+                modifiersCheck: (modifiers = []) => !modifiers.some(check.isStatic),
+                callCheck: type => check.isNullable(type.subtypes[0].args[0], [t => t?.full === '_elsewhere.ExternalType']),
+                returnTypeCheck: type => check.isNullable(type.subtypes[0].args[0], [t => t?.full === '_elsewhere.ExternalType'])
+            })
 
-    it('should validate optional action params', async () => {
-        checkFunction(astwBound.tree.find(fn => fn.name === 'aMandatoryParam'), {
-            parameterCheck: ({members: [p1, p2, p3]}) => !check.isOptional(p1) && !check.isOptional(p2) && check.isOptional(p3),
+            checkFunction(ast.find(node => node.name === 'free3'), {
+                modifiersCheck: (modifiers = []) => !modifiers.some(check.isStatic),
+                callCheck: type => check.isNullable(type.subtypes[0].args[0], [t => t?.full === '_.ExternalInRoot']),
+                returnTypeCheck: type => check.isNullable(type.subtypes[0].args[0], [t => t?.full === '_.ExternalInRoot'])
+            })
         })
-    })
 
-    it('should validate empty .actions typed as empty Record', async () => {
-        const { type } = astwUnbound.getAspectProperty('_NoActionAspect', 'actions')
-        assert.strictEqual(type.full, 'globalThis.Record')
-        assert.ok(checkKeyword(type.args[0], 'never'))
-        assert.ok(checkKeyword(type.args[1], 'never'))
-    })
-
-    it('should validate typeof parameter referring to correct type', async () => {
-        checkFunction(astwUnbound.tree.find(node => node.name === 'freetypeof'), {
-            modifiersCheck: (modifiers = []) => !modifiers.some(check.isStatic),
-            callCheck: type => check.isNullable(type, [check.isVoid]),
-            returnTypeCheck: type => check.isNullable(type, [check.isVoid]),
-            parameterCheck: ({members: [fst]}) => check.isNullable(fst.type, [check.isIndexedAccessType])
+        it('should validate void action returning void', async () => {
+            checkFunction(astwUnbound.tree.find(node => node.name === 'freevoid'), {
+                modifiersCheck: (modifiers = []) => !modifiers.some(check.isStatic),
+                callCheck: type => check.isNullable(type, [check.isVoid]),
+                returnTypeCheck: type => check.isNullable(type, [check.isVoid])
+            })
         })
-    })
 
-    it('should validate mandatory parameters to not be null or undefined', async () => {
-        checkFunction(astwUnbound.tree.find(node => node.name === 'actionWithMandatoryParameter'), {
-            parameterCheck: ({members: [fst]}) => !check.isNullable(fst.type)
+        it('should validate bound actions expecting $self arguments', async () => {
+            const actions = astwBound.getAspectProperty('_EAspect', 'actions')
+            assert.ok(actions.modifiers.some(check.isStatic))
+            // mainly make sure $self parameter is not present at all
+            checkFunction(actions.type.members.find(fn => fn.name === 's1'), {
+                callCheck: signature => check.isAny(signature),
+                returnTypeCheck: returns => check.isAny(returns),
+                parameterCheck: ({ full, args }) => full === 'globalThis.Record'
+                    && checkKeyword(args[0], 'never')
+                    && checkKeyword(args[1], 'never')
+            })
+            checkFunction(actions.type.members.find(fn => fn.name === 'sn'), {
+                callCheck: signature => check.isAny(signature),
+                returnTypeCheck: returns => check.isAny(returns),
+                parameterCheck: ({ full, args }) => full === 'globalThis.Record'
+                    && checkKeyword(args[0], 'never')
+                    && checkKeyword(args[1], 'never')
+            })
+            checkFunction(actions.type.members.find(fn => fn.name === 'sx'), {
+                callCheck: signature => check.isAny(signature),
+                returnTypeCheck: returns => check.isAny(returns),
+                parameterCheck: ({ members: [fst] }) => check.isNullable(fst.type, [check.isNumber])
+            })
         })
-    })
 
-    it('should validate that properties in action return type objects do not have declare modifiers', async () => {
-        const actions = astwBound.getAspectProperty('_EAspect', 'actions')
-        assert.ok(actions.modifiers.some(check.isStatic))
-        checkFunction(actions.type.members.find(fn => fn.name === 'h'), {
-            callCheck: signature => check.isTypeLiteral(signature),
-            parameterCheck: ({full, args}) => full === 'globalThis.Record'
-                && checkKeyword(args[0], 'never')
-                && checkKeyword(args[1], 'never'),
-            returnTypeCheck: returns => check.isTypeLiteral(returns)
-                && returns.members.every(member => !check.isDeclare(member)),
-            modifiersCheck: (modifiers = []) => !modifiers.some(check.isStatic),
+        it('should validate inflection on external type in function type', async () => {
+            checkFunction(astwBound.tree.find(fn => fn.name === 'getOneExternalType'), {
+                returnTypeCheck: returns => check.isNullable(returns.subtypes[0].args[0], [st => check.isTypeReference(st, '_elsewhere.ExternalType')])
+            })
+            checkFunction(astwBound.tree.find(fn => fn.name === 'getManyExternalTypes'), {
+                returnTypeCheck: returns => check.isArray(returns.subtypes[0].args[0], ([arg]) => check.isTypeReference(arg, '_elsewhere.ExternalType'))
+            })
+        })
+
+        it('should validate inflection in parameters/return type of functions', async () => {
+            checkFunction(astwBound.tree.find(fn => fn.name === 'fSingleParamSingleReturn'), {
+                parameterCheck: ({ members: [fst] }) => check.isNullable(fst.type, [arg => check.isTypeReference(arg, 'E')]),
+                returnTypeCheck: returns => check.isNullable(returns.subtypes[0].args[0], [st => check.isTypeReference(st, 'E')])
+            })
+            checkFunction(astwBound.tree.find(fn => fn.name === 'fSingleParamManyReturn'), {
+                parameterCheck: ({ members: [fst] }) => check.isNullable(fst.type, [arg => check.isTypeReference(arg, 'E')]),
+                returnTypeCheck: returns => check.isArray(returns.subtypes[0].args[0], ([arg]) => check.isTypeReference(arg, 'E'))
+            })
+            checkFunction(astwBound.tree.find(fn => fn.name === 'fManyParamSingleReturn'), {
+                parameterCheck: ({ members: [fst] }) => check.isArray(fst.type, ([arg]) => check.isTypeReference(arg, 'E')),
+                returnTypeCheck: returns => check.isNullable(returns.subtypes[0].args[0], [st => check.isTypeReference(st, 'E')])
+            })
+            checkFunction(astwBound.tree.find(fn => fn.name === 'fManyParamSingleReturn'), {
+                parameterCheck: ({ members: [fst] }) => check.isArray(fst.type, ([arg]) => check.isTypeReference(arg, 'E')),
+                returnTypeCheck: returns => check.isNullable(returns.subtypes[0].args[0], [st => check.isTypeReference(st, 'E')])
+            })
+            checkFunction(astwBound.tree.find(fn => fn.name === 'fManyParamManyReturn'), {
+                parameterCheck: ({ members: [fst] }) => check.isArray(fst.type, ([arg]) => check.isTypeReference(arg, 'E')),
+                returnTypeCheck: returns => check.isArray(returns.subtypes[0].args[0], ([arg]) => check.isTypeReference(arg, 'E'))
+            })
+        })
+
+        it('should validate inflection in parameters/return type of actions', async () => {
+            checkFunction(astwBound.tree.find(fn => fn.name === 'aSingleParamSingleReturn'), {
+                parameterCheck: ({ members: [fst] }) => check.isNullable(fst.type, [arg => check.isTypeReference(arg, 'E')]),
+                returnTypeCheck: returns => check.isNullable(returns.subtypes[0].args[0], [st => check.isTypeReference(st, 'E')])
+            })
+            checkFunction(astwBound.tree.find(fn => fn.name === 'aSingleParamManyReturn'), {
+                parameterCheck: ({ members: [fst] }) => check.isNullable(fst.type, [arg => check.isTypeReference(arg, 'E')]),
+                returnTypeCheck: returns => check.isArray(returns.subtypes[0].args[0], ([arg]) => check.isTypeReference(arg, 'E'))
+            })
+            checkFunction(astwBound.tree.find(fn => fn.name === 'aManyParamSingleReturn'), {
+                parameterCheck: ({ members: [fst] }) => check.isArray(fst.type, ([arg]) => check.isTypeReference(arg, 'E')),
+                returnTypeCheck: returns => check.isNullable(returns.subtypes[0].args[0], [st => check.isTypeReference(st, 'E')])
+            })
+            checkFunction(astwBound.tree.find(fn => fn.name === 'aManyParamSingleReturn'), {
+                parameterCheck: ({ members: [fst] }) => check.isArray(fst.type, ([arg]) => check.isTypeReference(arg, 'E')),
+                returnTypeCheck: returns => check.isNullable(returns.subtypes[0].args[0], [st => check.isTypeReference(st, 'E')])
+            })
+            checkFunction(astwBound.tree.find(fn => fn.name === 'aManyParamManyReturn'), {
+                parameterCheck: ({ members: [fst] }) => check.isArray(fst.type, ([arg]) => check.isTypeReference(arg, 'E')),
+                returnTypeCheck: returns => check.isArray(returns.subtypes[0].args[0], ([arg]) => check.isTypeReference(arg, 'E'))
+            })
+        })
+
+        it('should validate optional action params', async () => {
+            checkFunction(astwBound.tree.find(fn => fn.name === 'aMandatoryParam'), {
+                parameterCheck: ({ members: [p1, p2, p3] }) => !check.isOptional(p1) && !check.isOptional(p2) && check.isOptional(p3)
+            })
+        })
+
+        it('should validate empty .actions typed as empty Record', async () => {
+            const { type } = astwUnbound.getAspectProperty('_NoActionAspect', 'actions')
+            assert.strictEqual(type.full, 'globalThis.Record')
+            assert.ok(checkKeyword(type.args[0], 'never'))
+            assert.ok(checkKeyword(type.args[1], 'never'))
+        })
+
+        it('should validate typeof parameter referring to correct type', async () => {
+            checkFunction(astwUnbound.tree.find(node => node.name === 'freetypeof'), {
+                modifiersCheck: (modifiers = []) => !modifiers.some(check.isStatic),
+                callCheck: type => check.isNullable(type, [check.isVoid]),
+                returnTypeCheck: type => check.isNullable(type, [check.isVoid]),
+                parameterCheck: ({ members: [fst] }) => check.isNullable(fst.type, [check.isIndexedAccessType])
+            })
+        })
+
+        it('should validate mandatory parameters to not be null or undefined', async () => {
+            checkFunction(astwUnbound.tree.find(node => node.name === 'actionWithMandatoryParameter'), {
+                parameterCheck: ({ members: [fst] }) => !check.isNullable(fst.type)
+            })
+        })
+
+        it('should validate that properties in action return type objects do not have declare modifiers', async () => {
+            const actions = astwBound.getAspectProperty('_EAspect', 'actions')
+            assert.ok(actions.modifiers.some(check.isStatic))
+            checkFunction(actions.type.members.find(fn => fn.name === 'h'), {
+                callCheck: signature => check.isTypeLiteral(signature),
+                parameterCheck: ({ full, args }) => full === 'globalThis.Record'
+                    && checkKeyword(args[0], 'never')
+                    && checkKeyword(args[1], 'never'),
+                returnTypeCheck: returns => check.isTypeLiteral(returns)
+                    && returns.members.every(member => !check.isDeclare(member)),
+                modifiersCheck: (modifiers = []) => !modifiers.some(check.isStatic)
+            })
         })
     })
 })

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -8,20 +8,20 @@ const { locations, prepareUnitTest } = require('../util')
 const { perEachTestConfig } = require('../config')
 const { configuration } = require('../../lib/config')
 
-perEachTestConfig(options => {
-    describe(`Actions (using output **/*/${options.output_file} files)`, () => {
+perEachTestConfig(({ outputDTsFiles, outputFile }) => {
+    describe(`Actions (using output **/*/${outputFile} files)`, () => {
         let paths
         let sut
         let astwBound
         let astwUnbound
 
         before(async () => {
-            configuration.outputDTsFiles = options.output_d_ts_files
+            configuration.outputDTsFiles = outputDTsFiles
 
             sut = await prepareUnitTest('actions/model.cds', locations.testOutput('actions_test'))
             paths = sut.paths
-            astwBound = new ASTWrapper(path.join(paths.find(p => p.endsWith('S')), options.output_file))
-            astwUnbound = new ASTWrapper(path.join(paths.find(p => p.endsWith('actions_test')), options.output_file))
+            astwBound = new ASTWrapper(path.join(paths.find(p => p.endsWith('S')), outputFile))
+            astwUnbound = new ASTWrapper(path.join(paths.find(p => p.endsWith('actions_test')), outputFile))
         })
 
         it('should add import statement for builtin types', async () => {

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -16,7 +16,7 @@ perEachTestConfig(options => {
         let astwUnbound
 
         before(async () => {
-            configuration.outputDTSFiles = options.output_d_ts_files
+            configuration.outputDTsFiles = options.output_d_ts_files
 
             sut = await prepareUnitTest('actions/model.cds', locations.testOutput('actions_test'))
             paths = sut.paths

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -8,20 +8,20 @@ const { checkFunction, check, ASTWrapper, checkKeyword } = require('../ast')
 const { locations, prepareUnitTest } = require('../util')
 const { perEachTestConfig } = require('../config')
 
-perEachTestConfig(({ output_file, output_d_ts_files }) => {
-    describe(`Actions (using output **/*/${output_file} files)`, () => {
+perEachTestConfig(options => {
+    describe(`Actions (using output **/*/${options.output_file} files)`, () => {
         let paths
         let sut
         let astwBound
         let astwUnbound
 
         before(async () => {
-            cds.env.typer.output_d_ts_files = output_d_ts_files
+            cds.env.typer.output_d_ts_files = options.output_d_ts_files
 
             sut = await prepareUnitTest('actions/model.cds', locations.testOutput('actions_test'))
             paths = sut.paths
-            astwBound = new ASTWrapper(path.join(paths.find(p => p.endsWith('S')), output_file))
-            astwUnbound = new ASTWrapper(path.join(paths.find(p => p.endsWith('actions_test')), output_file))
+            astwBound = new ASTWrapper(path.join(paths.find(p => p.endsWith('S')), options.output_file))
+            astwUnbound = new ASTWrapper(path.join(paths.find(p => p.endsWith('actions_test')), options.output_file))
         })
 
         it('should add import statement for builtin types', async () => {

--- a/test/unit/draft.test.js
+++ b/test/unit/draft.test.js
@@ -11,16 +11,16 @@ const { configuration } = require('../../lib/config')
 const draftable_ = (entity, ast) => ast.find(n => n.name === entity && n.members.find(({name}) => name === 'drafts'))
 const draftable = (entity, ast, plural = e => `${e}_`) => draftable_(entity, ast) && draftable_(plural(entity), ast)
 
-perEachTestConfig(options =>{
-    describe(`Bookshop (using output **/*/${options.output_file} files)`, () => {
+perEachTestConfig(({ outputDTsFiles, outputFile }) =>{
+    describe(`Bookshop (using output **/*/${outputFile} files)`, () => {
         before(() => {
-            configuration.outputDTsFiles = options.output_d_ts_files
+            configuration.outputDTsFiles = outputDTsFiles
         })
 
         it('should validate draft via root and compositions', async () => {
             const paths = (await prepareUnitTest('draft/catalog-service.cds', locations.testOutput('bookshop_projection'))).paths
-            const service = new ASTWrapper(path.join(paths[1], options.output_file)).tree
-            const model = new ASTWrapper(path.join(paths[2], options.output_file)).tree
+            const service = new ASTWrapper(path.join(paths[1], outputFile)).tree
+            const model = new ASTWrapper(path.join(paths[2], outputFile)).tree
 
             // root and composition become draft enabled
             assert.ok(draftable('Book', service, () => 'Books'))

--- a/test/unit/draft.test.js
+++ b/test/unit/draft.test.js
@@ -11,16 +11,16 @@ const { perEachTestConfig } = require('../config')
 const draftable_ = (entity, ast) => ast.find(n => n.name === entity && n.members.find(({name}) => name === 'drafts'))
 const draftable = (entity, ast, plural = e => `${e}_`) => draftable_(entity, ast) && draftable_(plural(entity), ast)
 
-perEachTestConfig(({ output_file, output_d_ts_files }) =>{
-    describe(`Bookshop (using output **/*/${output_file} files)`, () => {
+perEachTestConfig(options =>{
+    describe(`Bookshop (using output **/*/${options.output_file} files)`, () => {
         before(() => {
-            cds.env.typer.output_d_ts_files = output_d_ts_files
+            cds.env.typer.output_d_ts_files = options.output_d_ts_files
         })
 
         it('should validate draft via root and compositions', async () => {
             const paths = (await prepareUnitTest('draft/catalog-service.cds', locations.testOutput('bookshop_projection'))).paths
-            const service = new ASTWrapper(path.join(paths[1], output_file)).tree
-            const model = new ASTWrapper(path.join(paths[2], output_file)).tree
+            const service = new ASTWrapper(path.join(paths[1], options.output_file)).tree
+            const model = new ASTWrapper(path.join(paths[2], options.output_file)).tree
 
             // root and composition become draft enabled
             assert.ok(draftable('Book', service, () => 'Books'))

--- a/test/unit/draft.test.js
+++ b/test/unit/draft.test.js
@@ -3,10 +3,10 @@
 const path = require('path')
 const { describe, it, before } = require('node:test')
 const assert = require('assert')
-const cds = require('@sap/cds')
 const { ASTWrapper } = require('../ast')
 const { locations, prepareUnitTest, createSpy } = require('../util')
 const { perEachTestConfig } = require('../config')
+const { configuration } = require('../../lib/config')
 
 const draftable_ = (entity, ast) => ast.find(n => n.name === entity && n.members.find(({name}) => name === 'drafts'))
 const draftable = (entity, ast, plural = e => `${e}_`) => draftable_(entity, ast) && draftable_(plural(entity), ast)
@@ -14,7 +14,7 @@ const draftable = (entity, ast, plural = e => `${e}_`) => draftable_(entity, ast
 perEachTestConfig(options =>{
     describe(`Bookshop (using output **/*/${options.output_file} files)`, () => {
         before(() => {
-            cds.env.typer.output_d_ts_files = options.output_d_ts_files
+            configuration.outputDTSFiles = options.output_d_ts_files
         })
 
         it('should validate draft via root and compositions', async () => {

--- a/test/unit/draft.test.js
+++ b/test/unit/draft.test.js
@@ -14,7 +14,7 @@ const draftable = (entity, ast, plural = e => `${e}_`) => draftable_(entity, ast
 perEachTestConfig(options =>{
     describe(`Bookshop (using output **/*/${options.output_file} files)`, () => {
         before(() => {
-            configuration.outputDTSFiles = options.output_d_ts_files
+            configuration.outputDTsFiles = options.output_d_ts_files
         })
 
         it('should validate draft via root and compositions', async () => {

--- a/test/unit/draft.test.js
+++ b/test/unit/draft.test.js
@@ -1,49 +1,57 @@
 'use strict'
 
 const path = require('path')
-const { describe, it } = require('node:test')
+const { describe, it, before } = require('node:test')
 const assert = require('assert')
+const cds = require('@sap/cds')
 const { ASTWrapper } = require('../ast')
 const { locations, prepareUnitTest, createSpy } = require('../util')
+const { perEachTestConfig } = require('../config')
 
 const draftable_ = (entity, ast) => ast.find(n => n.name === entity && n.members.find(({name}) => name === 'drafts'))
 const draftable = (entity, ast, plural = e => `${e}_`) => draftable_(entity, ast) && draftable_(plural(entity), ast)
 
-describe('Bookshop', () => {
-    it('should validate draft via root and compositions', async () => {
-        const paths = (await prepareUnitTest('draft/catalog-service.cds', locations.testOutput('bookshop_projection'))).paths
-        const service = new ASTWrapper(path.join(paths[1], 'index.ts')).tree
-        const model = new ASTWrapper(path.join(paths[2], 'index.ts')).tree
+perEachTestConfig(({ output_file, output_d_ts_files }) =>{
+    describe(`Bookshop (using output **/*/${output_file} files)`, () => {
+        before(() => {
+            cds.env.typer.output_d_ts_files = output_d_ts_files
+        })
 
-        // root and composition become draft enabled
-        assert.ok(draftable('Book', service, () => 'Books'))
-        assert.ok(draftable('Publisher', service, () => 'Publishers'))
+        it('should validate draft via root and compositions', async () => {
+            const paths = (await prepareUnitTest('draft/catalog-service.cds', locations.testOutput('bookshop_projection'))).paths
+            const service = new ASTWrapper(path.join(paths[1], output_file)).tree
+            const model = new ASTWrapper(path.join(paths[2], output_file)).tree
 
-        // associated entity will not become draft enabled
-        assert.ok(!draftable('Author', service, () => 'Authors'))
+            // root and composition become draft enabled
+            assert.ok(draftable('Book', service, () => 'Books'))
+            assert.ok(draftable('Publisher', service, () => 'Publishers'))
 
-        // non-service entities will not be draft enabled
-        assert.ok(!draftable('Book', model, () => 'Books'))
-        assert.ok(!draftable('Publisher', model, () => 'Publishers'))
-        assert.ok(!draftable('Author', model, () => 'Authors'))
-    })
+            // associated entity will not become draft enabled
+            assert.ok(!draftable('Author', service, () => 'Authors'))
 
-    it('should produce compiler error for draft-enabled composition', async () => {
-        // eslint-disable-next-line no-console
-        const spyOnConsole = createSpy(console.error)
-        // eslint-disable-next-line no-console
-        console.error = spyOnConsole
+            // non-service entities will not be draft enabled
+            assert.ok(!draftable('Book', model, () => 'Books'))
+            assert.ok(!draftable('Publisher', model, () => 'Publishers'))
+            assert.ok(!draftable('Author', model, () => 'Authors'))
+        })
 
-        await assert.rejects(
-            prepareUnitTest('draft/error-catalog-service.cds', locations.testOutput('bookshop_projection'), {
-                typerOptions: { logLevel: 'ERROR' },
-            }),
-            new Error('Compilation of model failed')
-        )
+        it('should produce compiler error for draft-enabled composition', async () => {
+            // eslint-disable-next-line no-console
+            const spyOnConsole = createSpy(console.error)
+            // eslint-disable-next-line no-console
+            console.error = spyOnConsole
 
-        assert.ok(spyOnConsole.calledWith(
-            '[cds-typer] -',
-            'Composition in draft-enabled entity can\'t lead to another entity with "@odata.draft.enabled" (in entity: "bookshop.service.CatalogService.Books"/element: publishers)!'
-        ))
+            await assert.rejects(
+                prepareUnitTest('draft/error-catalog-service.cds', locations.testOutput('bookshop_projection'), {
+                    typerOptions: { logLevel: 'ERROR' },
+                }),
+                new Error('Compilation of model failed')
+            )
+
+            assert.ok(spyOnConsole.calledWith(
+                '[cds-typer] -',
+                'Composition in draft-enabled entity can\'t lead to another entity with "@odata.draft.enabled" (in entity: "bookshop.service.CatalogService.Books"/element: publishers)!'
+            ))
+        })
     })
 })

--- a/test/unit/enum.test.js
+++ b/test/unit/enum.test.js
@@ -3,10 +3,10 @@
 const path = require('path')
 const { describe, before, it } = require('node:test')
 const assert = require('assert')
-const cds = require('@sap/cds')
 const { check, JSASTWrapper, checkFunction, ASTWrapper } = require('../ast')
 const { locations, prepareUnitTest } = require('../util')
 const { perEachTestConfig } = require('../config')
+const { configuration } = require('../../lib/config')
 
 // FIXME: missing: inline enums (entity Foo { bar: String enum { ... }})
 describe('Enum Action Parameters', () => {
@@ -171,7 +171,7 @@ perEachTestConfig(options => {
         let paths
 
         before(async () => {
-            cds.env.typer.output_d_ts_files = options.output_d_ts_files
+            configuration.outputDTSFiles = options.output_d_ts_files
             paths = (await prepareUnitTest('enums/importing/service.cds', locations.testOutput('enums_test'))).paths
         })
 
@@ -204,7 +204,7 @@ perEachTestConfig(options => {
         let astw
 
         before(async () => {
-            cds.env.typer.output_d_ts_files = options.output_d_ts_files
+            configuration.outputDTSFiles = options.output_d_ts_files
             const paths = (await prepareUnitTest('enums/enumtyperef.cds', locations.testOutput('enums_test'))).paths
             astw = new ASTWrapper(path.join(paths[2], options.output_file))
         })

--- a/test/unit/enum.test.js
+++ b/test/unit/enum.test.js
@@ -166,24 +166,24 @@ describe('Enum Types', () => {
 })
 
 
-perEachTestConfig(options => {
-    describe(`Imported Enums (using output **/*/${options.output_file} files)`, () => {
+perEachTestConfig(({ outputDTsFiles, outputFile }) => {
+    describe(`Imported Enums (using output **/*/${outputFile} files)`, () => {
         let paths
 
         before(async () => {
-            configuration.outputDTsFiles = options.output_d_ts_files
+            configuration.outputDTsFiles = outputDTsFiles
             paths = (await prepareUnitTest('enums/importing/service.cds', locations.testOutput('enums_test'))).paths
         })
 
         it('should validate type alias and constant in service', () => {
-            const service = new ASTWrapper(path.join(paths.find(p => p.endsWith('ExampleService')), options.output_file)).tree
+            const service = new ASTWrapper(path.join(paths.find(p => p.endsWith('ExampleService')), outputFile)).tree
             const decls = service.filter(n => n.name === 'EnumExample')
             assert.ok(decls.some(check.isTypeAliasDeclaration))
             assert.ok(decls.some(check.isVariableDeclaration))
         })
 
         it('should validate enum declaration in schema', () => {
-            const schema = new ASTWrapper(path.join(paths.find(p => p.endsWith('imported_enum')), options.output_file)).tree
+            const schema = new ASTWrapper(path.join(paths.find(p => p.endsWith('imported_enum')), outputFile)).tree
             const enumExampleNodes = schema.filter(n => n.name === 'EnumExample')
             assert.strictEqual(enumExampleNodes.length, 2)
             assert.ok(enumExampleNodes.find(n => n.nodeType === 'variableStatement'))
@@ -192,8 +192,8 @@ perEachTestConfig(options => {
     })
 })
 
-perEachTestConfig(options => {
-    describe(`Enums of typeof (using output **/*/${options.output_file} files)`, () => {
+perEachTestConfig(({ outputDTsFiles, outputFile }) => {
+    describe(`Enums of typeof (using output **/*/${outputFile} files)`, () => {
         /* FIXME: these should actually be inline-defined enums of the referenced type with explicit values
          * ```cds
          * entity X { y: String };
@@ -204,9 +204,9 @@ perEachTestConfig(options => {
         let astw
 
         before(async () => {
-            configuration.outputDTsFiles = options.output_d_ts_files
+            configuration.outputDTsFiles = outputDTsFiles
             const paths = (await prepareUnitTest('enums/enumtyperef.cds', locations.testOutput('enums_test'))).paths
-            astw = new ASTWrapper(path.join(paths[2], options.output_file))
+            astw = new ASTWrapper(path.join(paths[2], outputFile))
         })
 
         it('should validate enum references in parameters', () => {

--- a/test/unit/enum.test.js
+++ b/test/unit/enum.test.js
@@ -166,24 +166,24 @@ describe('Enum Types', () => {
 })
 
 
-perEachTestConfig(({ output_file, output_d_ts_files }) => {
-    describe(`Imported Enums (using output **/*/${output_file} files)`, () => {
+perEachTestConfig(options => {
+    describe(`Imported Enums (using output **/*/${options.output_file} files)`, () => {
         let paths
 
         before(async () => {
-            cds.env.typer.output_d_ts_files = output_d_ts_files
+            cds.env.typer.output_d_ts_files = options.output_d_ts_files
             paths = (await prepareUnitTest('enums/importing/service.cds', locations.testOutput('enums_test'))).paths
         })
 
         it('should validate type alias and constant in service', () => {
-            const service = new ASTWrapper(path.join(paths.find(p => p.endsWith('ExampleService')), output_file)).tree
+            const service = new ASTWrapper(path.join(paths.find(p => p.endsWith('ExampleService')), options.output_file)).tree
             const decls = service.filter(n => n.name === 'EnumExample')
             assert.ok(decls.some(check.isTypeAliasDeclaration))
             assert.ok(decls.some(check.isVariableDeclaration))
         })
 
         it('should validate enum declaration in schema', () => {
-            const schema = new ASTWrapper(path.join(paths.find(p => p.endsWith('imported_enum')), output_file)).tree
+            const schema = new ASTWrapper(path.join(paths.find(p => p.endsWith('imported_enum')), options.output_file)).tree
             const enumExampleNodes = schema.filter(n => n.name === 'EnumExample')
             assert.strictEqual(enumExampleNodes.length, 2)
             assert.ok(enumExampleNodes.find(n => n.nodeType === 'variableStatement'))
@@ -192,8 +192,8 @@ perEachTestConfig(({ output_file, output_d_ts_files }) => {
     })
 })
 
-perEachTestConfig(({ output_file, output_d_ts_files }) => {
-    describe(`Enums of typeof (using output **/*/${output_file} files)`, () => {
+perEachTestConfig(options => {
+    describe(`Enums of typeof (using output **/*/${options.output_file} files)`, () => {
         /* FIXME: these should actually be inline-defined enums of the referenced type with explicit values
          * ```cds
          * entity X { y: String };
@@ -204,9 +204,9 @@ perEachTestConfig(({ output_file, output_d_ts_files }) => {
         let astw
 
         before(async () => {
-            cds.env.typer.output_d_ts_files = output_d_ts_files
+            cds.env.typer.output_d_ts_files = options.output_d_ts_files
             const paths = (await prepareUnitTest('enums/enumtyperef.cds', locations.testOutput('enums_test'))).paths
-            astw = new ASTWrapper(path.join(paths[2], output_file))
+            astw = new ASTWrapper(path.join(paths[2], options.output_file))
         })
 
         it('should validate enum references in parameters', () => {

--- a/test/unit/enum.test.js
+++ b/test/unit/enum.test.js
@@ -3,8 +3,10 @@
 const path = require('path')
 const { describe, before, it } = require('node:test')
 const assert = require('assert')
+const cds = require('@sap/cds')
 const { check, JSASTWrapper, checkFunction, ASTWrapper } = require('../ast')
 const { locations, prepareUnitTest } = require('../util')
+const { perEachTestConfig } = require('../config')
 
 // FIXME: missing: inline enums (entity Foo { bar: String enum { ... }})
 describe('Enum Action Parameters', () => {
@@ -163,49 +165,58 @@ describe('Enum Types', () => {
     })
 })
 
-describe('Imported Enums', () => {
-    let paths
 
-    before(async () => paths = (await prepareUnitTest('enums/importing/service.cds', locations.testOutput('enums_test'))).paths)
+perEachTestConfig(({ output_file, output_d_ts_files }) => {
+    describe(`Imported Enums (using output **/*/${output_file} files)`, () => {
+        let paths
 
-    it('should validate type alias and constant in service', () => {
-        const service = new ASTWrapper(path.join(paths.find(p => p.endsWith('ExampleService')), 'index.ts')).tree
-        const decls = service.filter(n => n.name === 'EnumExample')
-        assert.ok(decls.some(check.isTypeAliasDeclaration))
-        assert.ok(decls.some(check.isVariableDeclaration))
-    })
+        before(async () => {
+            cds.env.typer.output_d_ts_files = output_d_ts_files
+            paths = (await prepareUnitTest('enums/importing/service.cds', locations.testOutput('enums_test'))).paths
+        })
 
-    it('should validate enum declaration in schema', () => {
-        const schema = new ASTWrapper(path.join(paths.find(p => p.endsWith('imported_enum')), 'index.ts')).tree
-        const enumExampleNodes = schema.filter(n => n.name === 'EnumExample')
-        assert.strictEqual(enumExampleNodes.length, 2)
-        assert.ok(enumExampleNodes.find(n => n.nodeType === 'variableStatement'))
-        assert.ok(enumExampleNodes.find(n => n.nodeType === 'typeAliasDeclaration'))
+        it('should validate type alias and constant in service', () => {
+            const service = new ASTWrapper(path.join(paths.find(p => p.endsWith('ExampleService')), output_file)).tree
+            const decls = service.filter(n => n.name === 'EnumExample')
+            assert.ok(decls.some(check.isTypeAliasDeclaration))
+            assert.ok(decls.some(check.isVariableDeclaration))
+        })
+
+        it('should validate enum declaration in schema', () => {
+            const schema = new ASTWrapper(path.join(paths.find(p => p.endsWith('imported_enum')), output_file)).tree
+            const enumExampleNodes = schema.filter(n => n.name === 'EnumExample')
+            assert.strictEqual(enumExampleNodes.length, 2)
+            assert.ok(enumExampleNodes.find(n => n.nodeType === 'variableStatement'))
+            assert.ok(enumExampleNodes.find(n => n.nodeType === 'typeAliasDeclaration'))
+        })
     })
 })
 
-describe('Enums of typeof', () => {
-    /* FIXME: these should actually be inline-defined enums of the referenced type with explicit values
-     * ```cds
-     * entity X { y: String };
-     * type T: X:y { a }  // should produce a string enum with value `a`
-     * ```
-     * but as a first step, they'll be just a value of the referenced type
-     */
-    let astw
+perEachTestConfig(({ output_file, output_d_ts_files }) => {
+    describe(`Enums of typeof (using output **/*/${output_file} files)`, () => {
+        /* FIXME: these should actually be inline-defined enums of the referenced type with explicit values
+         * ```cds
+         * entity X { y: String };
+         * type T: X:y { a }  // should produce a string enum with value `a`
+         * ```
+         * but as a first step, they'll be just a value of the referenced type
+         */
+        let astw
 
-    before(async () => {
-        const paths = (await prepareUnitTest('enums/enumtyperef.cds', locations.testOutput('enums_test'))).paths
-        astw = new ASTWrapper(path.join(paths[2], 'index.ts'))
-    })
+        before(async () => {
+            cds.env.typer.output_d_ts_files = output_d_ts_files
+            const paths = (await prepareUnitTest('enums/enumtyperef.cds', locations.testOutput('enums_test'))).paths
+            astw = new ASTWrapper(path.join(paths[2], output_file))
+        })
 
-    it('should validate enum references in parameters', () => {
-        // FIXME: returntypecheck currently broken: cds-typer can currently only deal with refs
-        // that contain exactly one element. Type refs are of guise { ref: ['n.A', 'p'] }
-        // so right now the property type reference is incorrectly resolved to n.A
-        checkFunction(astw.tree.find(node => node.name === 'EnumInParamAndReturn'), {
-            //returnTypeCheck: type =>  check.isNullable(type, [check.isIndexedAccessType]),
-            parameterCheck: ({members: [fst]}) => check.isNullable(fst.type, [check.isIndexedAccessType])
+        it('should validate enum references in parameters', () => {
+            // FIXME: returntypecheck currently broken: cds-typer can currently only deal with refs
+            // that contain exactly one element. Type refs are of guise { ref: ['n.A', 'p'] }
+            // so right now the property type reference is incorrectly resolved to n.A
+            checkFunction(astw.tree.find(node => node.name === 'EnumInParamAndReturn'), {
+                //returnTypeCheck: type =>  check.isNullable(type, [check.isIndexedAccessType]),
+                parameterCheck: ({members: [fst]}) => check.isNullable(fst.type, [check.isIndexedAccessType])
+            })
         })
     })
 })

--- a/test/unit/enum.test.js
+++ b/test/unit/enum.test.js
@@ -171,7 +171,7 @@ perEachTestConfig(options => {
         let paths
 
         before(async () => {
-            configuration.outputDTSFiles = options.output_d_ts_files
+            configuration.outputDTsFiles = options.output_d_ts_files
             paths = (await prepareUnitTest('enums/importing/service.cds', locations.testOutput('enums_test'))).paths
         })
 
@@ -204,7 +204,7 @@ perEachTestConfig(options => {
         let astw
 
         before(async () => {
-            configuration.outputDTSFiles = options.output_d_ts_files
+            configuration.outputDTsFiles = options.output_d_ts_files
             const paths = (await prepareUnitTest('enums/enumtyperef.cds', locations.testOutput('enums_test'))).paths
             astw = new ASTWrapper(path.join(paths[2], options.output_file))
         })

--- a/test/unit/excluding.test.js
+++ b/test/unit/excluding.test.js
@@ -3,24 +3,29 @@
 const path = require('path')
 const { before, describe, it } = require('node:test')
 const assert = require('assert')
+const cds = require('@sap/cds')
 const { ASTWrapper } = require('../ast')
 const { locations, prepareUnitTest } = require('../util')
+const { perEachTestConfig } = require('../config')
 
-describe('Excluding Clause Tests', () => {
-    let paths
+perEachTestConfig(({ output_file, output_d_ts_files }) => {
+    describe(`Excluding Clause Tests (using output **/*/${output_file} files)`, () => {
+        let paths
 
-    before(async () => {
-        paths = (await prepareUnitTest('excluding/model.cds', locations.testOutput('excluding_test'))).paths
-    })
+        before(async () => {
+            cds.env.typer.output_d_ts_files = output_d_ts_files
+            paths = (await prepareUnitTest('excluding/model.cds', locations.testOutput('excluding_test'))).paths
+        })
 
-    it('should have the element present in the original', async () => {
-        assert.ok(new ASTWrapper(path.join(paths[1], 'index.ts')).exists('_TestObjectAspect', 'dependencies'))
-    })
+        it('should have the element present in the original', async () => {
+            assert.ok(new ASTWrapper(path.join(paths[1], output_file)).exists('_TestObjectAspect', 'dependencies'))
+        })
 
-    it('should have the element gone in the projection', async () => {
-        assert.strictEqual(new ASTWrapper(path.join(paths[2], 'index.ts'))
-            .getAspect('_SlimTestObjectAspect')
-            .members
-            .find(({name}) => name === 'dependencies'), undefined)
+        it('should have the element gone in the projection', async () => {
+            assert.strictEqual(new ASTWrapper(path.join(paths[2], output_file))
+                .getAspect('_SlimTestObjectAspect')
+                .members
+                .find(({name}) => name === 'dependencies'), undefined)
+        })
     })
 })

--- a/test/unit/excluding.test.js
+++ b/test/unit/excluding.test.js
@@ -8,21 +8,21 @@ const { ASTWrapper } = require('../ast')
 const { locations, prepareUnitTest } = require('../util')
 const { perEachTestConfig } = require('../config')
 
-perEachTestConfig(({ output_file, output_d_ts_files }) => {
-    describe(`Excluding Clause Tests (using output **/*/${output_file} files)`, () => {
+perEachTestConfig(options => {
+    describe(`Excluding Clause Tests (using output **/*/${options.output_file} files)`, () => {
         let paths
 
         before(async () => {
-            cds.env.typer.output_d_ts_files = output_d_ts_files
+            cds.env.typer.output_d_ts_files = options.output_d_ts_files
             paths = (await prepareUnitTest('excluding/model.cds', locations.testOutput('excluding_test'))).paths
         })
 
         it('should have the element present in the original', async () => {
-            assert.ok(new ASTWrapper(path.join(paths[1], output_file)).exists('_TestObjectAspect', 'dependencies'))
+            assert.ok(new ASTWrapper(path.join(paths[1], options.output_file)).exists('_TestObjectAspect', 'dependencies'))
         })
 
         it('should have the element gone in the projection', async () => {
-            assert.strictEqual(new ASTWrapper(path.join(paths[2], output_file))
+            assert.strictEqual(new ASTWrapper(path.join(paths[2], options.output_file))
                 .getAspect('_SlimTestObjectAspect')
                 .members
                 .find(({name}) => name === 'dependencies'), undefined)

--- a/test/unit/excluding.test.js
+++ b/test/unit/excluding.test.js
@@ -13,7 +13,7 @@ perEachTestConfig(options => {
         let paths
 
         before(async () => {
-            configuration.outputDTSFiles = options.output_d_ts_files
+            configuration.outputDTsFiles = options.output_d_ts_files
             paths = (await prepareUnitTest('excluding/model.cds', locations.testOutput('excluding_test'))).paths
         })
 

--- a/test/unit/excluding.test.js
+++ b/test/unit/excluding.test.js
@@ -8,21 +8,21 @@ const { locations, prepareUnitTest } = require('../util')
 const { perEachTestConfig } = require('../config')
 const { configuration } = require('../../lib/config')
 
-perEachTestConfig(options => {
-    describe(`Excluding Clause Tests (using output **/*/${options.output_file} files)`, () => {
+perEachTestConfig(({ outputDTsFiles, outputFile }) => {
+    describe(`Excluding Clause Tests (using output **/*/${outputFile} files)`, () => {
         let paths
 
         before(async () => {
-            configuration.outputDTsFiles = options.output_d_ts_files
+            configuration.outputDTsFiles = outputDTsFiles
             paths = (await prepareUnitTest('excluding/model.cds', locations.testOutput('excluding_test'))).paths
         })
 
         it('should have the element present in the original', async () => {
-            assert.ok(new ASTWrapper(path.join(paths[1], options.output_file)).exists('_TestObjectAspect', 'dependencies'))
+            assert.ok(new ASTWrapper(path.join(paths[1], outputFile)).exists('_TestObjectAspect', 'dependencies'))
         })
 
         it('should have the element gone in the projection', async () => {
-            assert.strictEqual(new ASTWrapper(path.join(paths[2], options.output_file))
+            assert.strictEqual(new ASTWrapper(path.join(paths[2], outputFile))
                 .getAspect('_SlimTestObjectAspect')
                 .members
                 .find(({name}) => name === 'dependencies'), undefined)

--- a/test/unit/excluding.test.js
+++ b/test/unit/excluding.test.js
@@ -3,17 +3,17 @@
 const path = require('path')
 const { before, describe, it } = require('node:test')
 const assert = require('assert')
-const cds = require('@sap/cds')
 const { ASTWrapper } = require('../ast')
 const { locations, prepareUnitTest } = require('../util')
 const { perEachTestConfig } = require('../config')
+const { configuration } = require('../../lib/config')
 
 perEachTestConfig(options => {
     describe(`Excluding Clause Tests (using output **/*/${options.output_file} files)`, () => {
         let paths
 
         before(async () => {
-            cds.env.typer.output_d_ts_files = options.output_d_ts_files
+            configuration.outputDTSFiles = options.output_d_ts_files
             paths = (await prepareUnitTest('excluding/model.cds', locations.testOutput('excluding_test'))).paths
         })
 

--- a/test/unit/tsCheckAndRun.test.js
+++ b/test/unit/tsCheckAndRun.test.js
@@ -6,10 +6,10 @@ const { fs } = cds.utils
 const { locations } = require('../util')
 const { perEachTestConfig } = require('../config')
 
-perEachTestConfig(({ output_file, output_d_ts_files }) => {
-    describe(`Generate, TS Check, and Run Tests (using output **/*/${output_file} files)`, () => {
+perEachTestConfig(options => {
+    describe(`Generate, TS Check, and Run Tests (using output **/*/${options.output_file} files)`, () => {
         before(() => {
-            cds.env.typer.output_d_ts_files = output_d_ts_files
+            cds.env.typer.output_d_ts_files = options.output_d_ts_files
         })
 
         const tsDirs = fs.readdirSync(locations.unit.files(''))
@@ -28,7 +28,7 @@ perEachTestConfig(({ output_file, output_d_ts_files }) => {
                 const modelPath = join(base, modelFile)
                 const tsFile = join(base, testFile)
                 const out = join(base, '_out')
-                await runTyperAndTsCheck(modelPath, tsFile, out, output_file)
+                await runTyperAndTsCheck(modelPath, tsFile, out, options.output_file)
 
                 // serve the services in a minimal way (no db, no express)
                 cds.root = base

--- a/test/unit/tsCheckAndRun.test.js
+++ b/test/unit/tsCheckAndRun.test.js
@@ -9,7 +9,7 @@ const { perEachTestConfig } = require('../config')
 perEachTestConfig(options => {
     describe(`Generate, TS Check, and Run Tests (using output **/*/${options.output_file} files)`, () => {
         before(() => {
-            cds.env.typer.output_d_ts_files = options.output_d_ts_files
+            configuration.outputDTSFiles = options.output_d_ts_files
         })
 
         const tsDirs = fs.readdirSync(locations.unit.files(''))

--- a/test/unit/tsCheckAndRun.test.js
+++ b/test/unit/tsCheckAndRun.test.js
@@ -6,10 +6,10 @@ const { fs } = cds.utils
 const { locations } = require('../util')
 const { perEachTestConfig } = require('../config')
 
-perEachTestConfig(options => {
-    describe(`Generate, TS Check, and Run Tests (using output **/*/${options.output_file} files)`, () => {
+perEachTestConfig(({ outputDTsFiles, outputFile }) => {
+    describe(`Generate, TS Check, and Run Tests (using output **/*/${outputFile} files)`, () => {
         before(() => {
-            configuration.outputDTsFiles = options.output_d_ts_files
+            configuration.outputDTsFiles = outputDTsFiles
         })
 
         const tsDirs = fs.readdirSync(locations.unit.files(''))
@@ -28,7 +28,7 @@ perEachTestConfig(options => {
                 const modelPath = join(base, modelFile)
                 const tsFile = join(base, testFile)
                 const out = join(base, '_out')
-                await runTyperAndTsCheck(modelPath, tsFile, out, options.output_file)
+                await runTyperAndTsCheck(modelPath, tsFile, out, outputFile)
 
                 // serve the services in a minimal way (no db, no express)
                 cds.root = base

--- a/test/unit/tsCheckAndRun.test.js
+++ b/test/unit/tsCheckAndRun.test.js
@@ -1,34 +1,40 @@
 const { configuration } = require('../../lib/config')
 const { basename, join } = require('path')
-const { describe, it } = require('node:test')
+const { describe, it, before } = require('node:test')
 const cds = require('@sap/cds')
 const { fs } = cds.utils
 const { locations } = require('../util')
+const { perEachTestConfig } = require('../config')
 
-describe('Generate, TS Check, and Run Tests', () => {
-
-    const tsDirs = fs.readdirSync(locations.unit.files(''))
-        .map(dir => {
-            const absolute = locations.unit.files(dir)
-            const tsFiles = fs.readdirSync(absolute).some(f => f.endsWith('.ts') && !f.endsWith('d.ts'))
-            return tsFiles ? dir : undefined
+perEachTestConfig(({ output_file, output_d_ts_files }) => {
+    describe(`Generate, TS Check, and Run Tests (using output **/*/${output_file} files)`, () => {
+        before(() => {
+            cds.env.typer.output_d_ts_files = output_d_ts_files
         })
-        .filter(Boolean)
 
-    tsDirs.forEach(dir => {
-        it(`should process and run TypeScript files in ${dir}`, async () => {
-            const modelFile = 'model.cds'
-            const testFile = 'model.ts'
-            const base = join(__dirname, 'files', dir, modelFile, '..')
-            const modelPath = join(base, modelFile)
-            const tsFile = join(base, testFile)
-            const out = join(base, '_out')
-            await runTyperAndTsCheck(modelPath, tsFile, out)
+        const tsDirs = fs.readdirSync(locations.unit.files(''))
+            .map(dir => {
+                const absolute = locations.unit.files(dir)
+                const tsFiles = fs.readdirSync(absolute).some(f => f.endsWith('.ts') && !f.endsWith('d.ts'))
+                return tsFiles ? dir : undefined
+            })
+            .filter(Boolean)
 
-            // serve the services in a minimal way (no db, no express)
-            cds.root = base
-            cds.model = cds.linked(await cds.load(join(base, modelFile)))
-            await cds.serve('all').with(join(out, 'model.js')) // as service impl. the tsc-emitted js file is used
+        tsDirs.forEach(dir => {
+            it(`should process and run TypeScript files in ${dir}`, async () => {
+                const modelFile = 'model.cds'
+                const testFile = 'model.ts'
+                const base = join(__dirname, 'files', dir, modelFile, '..')
+                const modelPath = join(base, modelFile)
+                const tsFile = join(base, testFile)
+                const out = join(base, '_out')
+                await runTyperAndTsCheck(modelPath, tsFile, out, output_file)
+
+                // serve the services in a minimal way (no db, no express)
+                cds.root = base
+                cds.model = cds.linked(await cds.load(join(base, modelFile)))
+                await cds.serve('all').with(join(out, 'model.js')) // as service impl. the tsc-emitted js file is used
+            })
         })
     })
 })
@@ -40,9 +46,10 @@ const { checkTranspilation } = require('../tscheck')
  * @param {string} model - the path to the model file to be processed
  * @param {string} testTsFile - the path to a custom test .ts file
  * @param {string} outputDirectory - the path to the output directory
+ * @param {string} outputFile - the name of the output file (e.g. index.ts)
  * @param {PrepareUnitTestParameters} parameters - additional parameters
  */
-async function runTyperAndTsCheck(model, testTsFile, outputDirectory, parameters = {}) {
+async function runTyperAndTsCheck(model, testTsFile, outputDirectory, outputFile, parameters = {}) {
     await fs.promises.rm(outputDirectory, { force: true, recursive: true })
 
     const defaults = {
@@ -53,15 +60,15 @@ async function runTyperAndTsCheck(model, testTsFile, outputDirectory, parameters
 
     configuration.setMany({...{ outputDirectory, inlineDeclarations: 'structured' }, ...parameters.typerOptions})
     const paths = await typer.compileFromFile(model)
-    const tsFiles = paths.map(p => join(p, 'index.ts'))
+    const tsFiles = paths.map(p => join(p, outputFile))
     const emitDir = join(outputDirectory, '__tsc-emit')
     await checkTranspilation([testTsFile, ...tsFiles], {
         noEmit: false, // need to have the model.js file so that we can run it later
         outDir: emitDir,
         skipLibCheck: true,
         paths: {
-            '#cds-models/*': [ join(outputDirectory, '/*/index.ts') ],
-            '#cds-models': [ join(outputDirectory, '/index.ts') ]
+            '#cds-models/*': [ join(outputDirectory, `/*/${outputFile}`) ],
+            '#cds-models': [ join(outputDirectory, `/${outputFile}`) ]
         }
     })
 

--- a/test/unit/tsCheckAndRun.test.js
+++ b/test/unit/tsCheckAndRun.test.js
@@ -9,7 +9,7 @@ const { perEachTestConfig } = require('../config')
 perEachTestConfig(options => {
     describe(`Generate, TS Check, and Run Tests (using output **/*/${options.output_file} files)`, () => {
         before(() => {
-            configuration.outputDTSFiles = options.output_d_ts_files
+            configuration.outputDTsFiles = options.output_d_ts_files
         })
 
         const tsDirs = fs.readdirSync(locations.unit.files(''))

--- a/test/util.js
+++ b/test/util.js
@@ -187,7 +187,7 @@ async function prepareUnitTest(model, outputDirectory, parameters = {}) {
 
     configuration.setMany({...{ outputDirectory: outputDirectory, inlineDeclarations: 'structured' }, ...parameters.typerOptions})
     const paths = await cds2ts(model)
-    const outputFile = configuration.outputDTSFiles ? 'index.d.ts' : 'index.ts'
+    const outputFile = configuration.outputDTsFiles ? 'index.d.ts' : 'index.ts'
 
     if (parameters.transpilationCheck) {
         const tsFiles = paths.map(p => path.join(p, outputFile))

--- a/test/util.js
+++ b/test/util.js
@@ -2,6 +2,7 @@ const { configuration } = require('../lib/config')
 const fs = require('node:fs')
 const path = require('node:path')
 const os = require('node:os')
+const cds = require('@sap/cds')
 const typer = require('../lib/compile')
 const acorn = require('acorn')
 const { ASTWrapper } = require('./ast')
@@ -187,9 +188,10 @@ async function prepareUnitTest(model, outputDirectory, parameters = {}) {
 
     configuration.setMany({...{ outputDirectory: outputDirectory, inlineDeclarations: 'structured' }, ...parameters.typerOptions})
     const paths = await cds2ts(model)
+    const output_file = cds.env.typer.output_d_ts_files ? 'index.d.ts' : 'index.ts'
 
     if (parameters.transpilationCheck) {
-        const tsFiles = paths.map(p => path.join(p, 'index.ts'))
+        const tsFiles = paths.map(p => path.join(p, output_file))
         // create a package.json w/ common dependencies in a higher dir so that they can be reused by many tests
         createProject(path.resolve(outputDirectory, '../..'))
         await checkTranspilation(tsFiles, parameters.tsCompilerOptions)
@@ -214,7 +216,7 @@ async function prepareUnitTest(model, outputDirectory, parameters = {}) {
         }
     }
     configuration.setFrom(configurationBefore)
-    return { astw: new ASTWrapper(path.join(parameters.fileSelector(paths), 'index.ts')), paths }
+    return { astw: new ASTWrapper(path.join(parameters.fileSelector(paths), output_file)), paths }
 }
 
 const createSpy = fn => {

--- a/test/util.js
+++ b/test/util.js
@@ -2,7 +2,6 @@ const { configuration } = require('../lib/config')
 const fs = require('node:fs')
 const path = require('node:path')
 const os = require('node:os')
-const cds = require('@sap/cds')
 const typer = require('../lib/compile')
 const acorn = require('acorn')
 const { ASTWrapper } = require('./ast')
@@ -188,10 +187,10 @@ async function prepareUnitTest(model, outputDirectory, parameters = {}) {
 
     configuration.setMany({...{ outputDirectory: outputDirectory, inlineDeclarations: 'structured' }, ...parameters.typerOptions})
     const paths = await cds2ts(model)
-    const output_file = cds.env.typer.output_d_ts_files ? 'index.d.ts' : 'index.ts'
+    const outputFile = configuration.outputDTSFiles ? 'index.d.ts' : 'index.ts'
 
     if (parameters.transpilationCheck) {
-        const tsFiles = paths.map(p => path.join(p, output_file))
+        const tsFiles = paths.map(p => path.join(p, outputFile))
         // create a package.json w/ common dependencies in a higher dir so that they can be reused by many tests
         createProject(path.resolve(outputDirectory, '../..'))
         await checkTranspilation(tsFiles, parameters.tsCompilerOptions)
@@ -216,7 +215,7 @@ async function prepareUnitTest(model, outputDirectory, parameters = {}) {
         }
     }
     configuration.setFrom(configurationBefore)
-    return { astw: new ASTWrapper(path.join(parameters.fileSelector(paths), output_file)), paths }
+    return { astw: new ASTWrapper(path.join(parameters.fileSelector(paths), outputFile)), paths }
 }
 
 const createSpy = fn => {

--- a/testing.md
+++ b/testing.md
@@ -46,8 +46,8 @@ You can produce such a wrapped AST as follows:
 let astw
 beforeAll(async () => {
     const paths = await cds2ts.compileFromFile(locations.unit.files('X/model.cds'), { ... })
-    astw = new ASTWrapper(path.join(paths[1], 'index.ts'))
-}
+    astw = new ASTWrapper(path.join(paths[1], 'index.ts')) // or 'index.d.ts'
+})
 ```
 
 The downside of this process is that the wrapped AST only contains the nodes that are explicitly visited!
@@ -63,5 +63,5 @@ let ast
 beforeAll(async () => {
     const paths = await cds2ts.compileFromFile(locations.unit.files('X/model.cds'), { ... })
     const jsastw = new JSASTWrapper(code)
-}    
+})
 ```


### PR DESCRIPTION
_It partially completes #546, but not completely implements the `*.d.ts` files generation from the scratch._

---

**TODO**:
- [x] Set up new _boolean-like_ CDS env `output_d_ts_files` (default: false)
- [x] Update `CHANGELOG.md`
- [x] Fix tests (no need to fix - it works as expected with disabled (default: false) option
- [x] Test out in _real_ (production) project — (`*.d.ts` files are working fine with 0 TS errors! 🤠)
- [x] Add new tests