### PR TITLE
chore: Add prefix to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
 - package-ecosystem: npm
   directory: /
   versioning-strategy: increase-if-necessary
+  commit-message:
+    prefix: chore
+    prefix-development: chore
+    include: scope
   schedule:
     interval: "weekly"
   groups:


### PR DESCRIPTION
To make sure dependabot PRs are not being blocked by our title verification workflow.