### PR TITLE
fix: export inline enums so they are accessible cross-namespace in service projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Deprecated
 ### Removed
 ### Fixed
+- Association keys pointing to entities with inline enum types are now correctly typed in service projections across namespace boundaries
 ### Security
 
 ## [0.38.0] - 2025-09-24

--- a/lib/file.js
+++ b/lib/file.js
@@ -326,9 +326,8 @@ class SourceFile extends File {
         entityProxy.push(propertyName)
 
         // REVISIT: find a better way to do this???
-        const printEnumToBuffer = (/** @type {Buffer} */buffer) => printEnum(buffer, propertyToInlineEnumName(entityCleanName, propertyName), kvs, {export: false}, doc)
-
         if (buffer?.namespace) {
+            const printEnumToBuffer = (/** @type {Buffer} */buffer) => printEnum(buffer, propertyToInlineEnumName(entityCleanName, propertyName), kvs, {export: false}, doc)
             const tempBuffer = new Buffer()
             // we want to put the enums on class level
             tempBuffer.indent()
@@ -338,6 +337,9 @@ class SourceFile extends File {
             const [first,...rest] = buffer.parts
             buffer.parts = [first, ...tempBuffer.parts, ...rest]
         } else {
+            // top-level inline enums must be exported so they can be referenced cross-namespace
+            // (e.g. when a service projects an entity whose key has an inline enum type)
+            const printEnumToBuffer = (/** @type {Buffer} */buffer) => printEnum(buffer, propertyToInlineEnumName(entityCleanName, propertyName), kvs, {export: true}, doc)
             printEnumToBuffer(this.inlineEnums.buffer)
         }
     }

--- a/lib/resolution/resolver.js
+++ b/lib/resolution/resolver.js
@@ -383,6 +383,26 @@ class Resolver {
 
         if (typeInfo.isInlineDeclaration === true) {
             typeInfo.inflection = this.inflect(typeInfo)
+            
+            // Handle inline enums that originate from a different entity's namespace
+            // (e.g., foreign keys from associations to entities with inline enum keys)
+            // In such cases, we need to import the namespace and prepend the identifier
+            const targetEntity = element.__targetEntity
+            if (targetEntity) {
+                const namespace = this.resolveNamespace(targetEntity)
+                const parent = new Path(namespace.split('.'))
+                
+                if (!parent.isCwd(file.path.asDirectory())) {
+                    // Add import for the target entity's namespace
+                    file.addImport(parent)
+                    const parentNamespaceIdent = parent.asIdentifier()
+                    
+                    // Update typeName to include the namespace
+                    typeName = [parentNamespaceIdent, typeName].filter(Boolean).join('.')
+                    typeInfo.inflection.singular = [parentNamespaceIdent, typeInfo.inflection.singular].filter(Boolean).join('.')
+                    typeInfo.inflection.plural = [parentNamespaceIdent, typeInfo.inflection.plural].filter(Boolean).join('.')
+                }
+            }
         }
 
         // handle typeof (unless it has already been handled above)

--- a/lib/resolution/resolver.js
+++ b/lib/resolution/resolver.js
@@ -458,7 +458,7 @@ class Resolver {
             // Handle inline enums that originate from a different entity's namespace
             // (e.g., foreign keys from associations to entities with inline enum keys)
             // In such cases, we need to import the namespace and prepend the identifier
-            const targetEntity = element.__targetEntity
+            const targetEntity = element._targetEntity
             if (targetEntity) {
                 const namespace = this.resolveNamespace(targetEntity)
                 const parent = new Path(namespace.split('.'))

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -33,6 +33,7 @@ export module resolver {
         '@odata.draft.enabled'?: boolean // custom!
         _unresolved?: boolean
         isRefNotNull?: boolean // custom!
+        _targetEntity?: string // custom! Name of the target entity when this element is a composition or association
     }
 
     export type OperationCSN = EntityCSN & {

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -261,7 +261,7 @@ class Visitor {
                                     const kelement = Object.assign(Object.create(originalKeyElement), {
                                         isRefNotNull: !!element.notNull || !!element.key,
                                         key: element.key,
-                                        __targetEntity: element.target  // Track the target entity for inline enum resolution
+                                        _targetEntity: element.target  // Track the target entity for inline enum resolution
                                     })
                                     this.visitElement({name: foreignKey, element: kelement, file, buffer, resolverOptions})
                                 }

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -255,7 +255,8 @@ class Visitor {
                                 } else {
                                     const kelement = Object.assign(Object.create(originalKeyElement), {
                                         isRefNotNull: !!element.notNull || !!element.key,
-                                        key: element.key
+                                        key: element.key,
+                                        __targetEntity: element.target  // Track the target entity for inline enum resolution
                                     })
                                     this.visitElement({name: foreignKey, element: kelement, file, buffer, resolverOptions})
                                 }

--- a/test/unit/enum.test.js
+++ b/test/unit/enum.test.js
@@ -192,6 +192,50 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
     })
 })
 
+describe('Inline Enum in Association Key referenced from Service', () => {
+    const fs = require('node:fs')
+    let schemaNsAstw
+    let serviceAstw
+    let schemaNsSource
+
+    before(async () => {
+        const paths = (await prepareUnitTest('enums/association-key/service.cds', locations.testOutput('enums_association_key'))).paths
+        // paths[0] = _, paths[1] = CatalogService, paths[2] = enum_association_key
+        const schemaNsFile = path.join(paths[2], 'index.ts')
+        schemaNsAstw  = new ASTWrapper(schemaNsFile)
+        serviceAstw   = new ASTWrapper(path.join(paths[1], 'index.ts'))
+        schemaNsSource = fs.readFileSync(schemaNsFile, 'utf-8')
+    })
+
+    it('should export the inline enum from the source namespace', () => {
+        // The enum must carry the export modifier so it is accessible via namespace imports
+        assert.ok(
+            schemaNsSource.includes('export const BookID_ID'),
+            'BookID_ID const must be exported so it is accessible cross-namespace'
+        )
+        assert.ok(
+            schemaNsSource.includes('export type BookID_ID'),
+            'BookID_ID type must be exported so it is accessible cross-namespace'
+        )
+    })
+
+    it('should type the foreign key in the source entity using the inline enum', () => {
+        assert.ok(
+            schemaNsAstw.exists('_BookIDAspect', 'ID', ({type}) => check.isKeyOf(type, t => check.isTypeReference(t, 'BookID_ID'))),
+            '_BookIDAspect.ID should be typed as Key<BookID_ID>'
+        )
+    })
+
+    it('should type the foreign key in the service projection using the namespaced inline enum', () => {
+        assert.ok(
+            serviceAstw.exists('_BookAspect', 'ID_ID', ({type}) =>
+                check.isKeyOf(type, t => check.isTypeReference(t, '_enum_association_key.BookID_ID'))
+            ),
+            '_BookAspect.ID_ID should be typed as Key<_enum_association_key.BookID_ID>'
+        )
+    })
+})
+
 perEachTestConfig(({ outputDTsFiles, outputFile }) => {
     describe(`Enums of typeof (using output **/*/${outputFile} files)`, () => {
         /* FIXME: these should actually be inline-defined enums of the referenced type with explicit values

--- a/test/unit/files/enums/association-key/schema.cds
+++ b/test/unit/files/enums/association-key/schema.cds
@@ -1,0 +1,13 @@
+namespace enum_association_key;
+
+entity BookIDs {
+    key ID : String enum {
+        ID1;
+        ID2;
+    };
+}
+
+entity Books {
+    key ID : Association to BookIDs;
+    title  : String;
+}

--- a/test/unit/files/enums/association-key/service.cds
+++ b/test/unit/files/enums/association-key/service.cds
@@ -1,0 +1,5 @@
+using { enum_association_key } from './schema';
+
+service CatalogService {
+    entity Books as projection on enum_association_key.Books;
+}

--- a/test/unit/utf8.test.js
+++ b/test/unit/utf8.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it, before } = require('node:test')
 const assert = require('assert')
-const { check, checkFunction } = require('../ast')
+const { check } = require('../ast')
 const { locations, prepareUnitTest } = require('../util')
 
 const dir = locations.testOutput('utf8_test')


### PR DESCRIPTION
When an entity has a key with an inline enum type (e.g. `key ID : String enum { ID1; ID2; }`) and that entity is the target of an `Association` in another entity that is then projected in a service, the generated code breaks.

The service file correctly received a namespaced reference like `_my_bookshop.BookID_ID` for the foreign key type, but `BookID_ID` was never exported from `my/bookshop/index.ts` so the reference resolved to `undefined` at runtime and produced a TypeScript compile error

Closes #518