### PR TITLE
Improve CI/CD security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,16 @@ updates:
     include: scope
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 1
   groups:
     production-dependencies:
       dependency-type: "production"
     development-dependencies:
       dependency-type: "development"
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: "weekly"
+  cooldown:
+    default-days: 1

--- a/.github/workflows/check-schema-integrity.yml
+++ b/.github/workflows/check-schema-integrity.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/enforce-changelog.yml
+++ b/.github/workflows/enforce-changelog.yml
@@ -18,6 +18,11 @@ jobs:
   check-changelog:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Check changelog
         uses: cap-js/.github/.github/actions/check-changelog@main
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,11 +17,21 @@ jobs:
   enforce-changelog:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Check changelog
         uses: cap-js/.github/.github/actions/check-changelog@main
 
   check-pr-title:
      runs-on: ubuntu-latest
      steps:
+       - name: Harden Runner
+         uses: step-security/harden-runner@v2
+         with:
+           egress-policy: audit
+
        - name: Check PR title
          uses: cap-js/.github/.github/actions/check-pr-title@main

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -8,6 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,6 +22,11 @@ jobs:
       pull-requests: write
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@v2
+      with:
+        egress-policy: audit
+
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@v2
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
@@ -36,6 +41,11 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@v2
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
@@ -55,6 +65,11 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@v2
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
Add dependabot for NPM and GitHub Actions. Weekly checks with 1 day cooldown to avoid pushing freshly compromised deps.

Add [Harden Runner](https://github.com/step-security/harden-runner) to all GitHub Actions to monitor the processes.