### PR TITLE
fix: Call `JSON.stringify` on structured variables when logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 ### Fixed
 - Entities with name conflicts with any of their ancestors now have their aspect name generated properly again
+- Fixed sporadic occurrence of `[Object object]` in logs
 ### Security
 
 ## [0.39.1] - 2026-05-19

--- a/lib/config.js
+++ b/lib/config.js
@@ -46,7 +46,7 @@ class Config {
             const pjson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
             Config.#defaults = pjson.cds.typer
         } catch (e) {
-            LOG.error(`Failed to load default configuration from package.json: ${e}`)
+            LOG.error(`Failed to load default configuration from package.json: ${JSON.stringify(e)}`)
         }
         return Config.#defaults
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -46,7 +46,7 @@ class Config {
             const pjson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
             Config.#defaults = pjson.cds.typer
         } catch (e) {
-            LOG.error(`Failed to load default configuration from package.json: ${JSON.stringify(e)}`)
+            LOG.error(`Failed to load default configuration from package.json: ${e instanceof Error ? e.stack : JSON.stringify(e)}`)
         }
         return Config.#defaults
     }

--- a/lib/resolution/resolver.js
+++ b/lib/resolution/resolver.js
@@ -509,7 +509,7 @@ class Resolver {
                 // Get the entity info to determine the proper namespace
                 const elementInfo = this.visitor.entityRepository.getByFq(element)
                 let elementName
-                LOG.debug(`propertyAccess: element=${element}, hasInfo=${!!elementInfo}`)
+                LOG.debug(`propertyAccess: element=${JSON.stringify(element)}, hasInfo=${!!elementInfo}`)
                 if (elementInfo) {
                     // Check if the element is from the same file or needs an import
                     const elementNamespace = this.resolveNamespace(elementInfo.namespace.parts)

--- a/lib/traverser.js
+++ b/lib/traverser.js
@@ -58,7 +58,7 @@ class CsnTraverser {
     #emit(event, fq, definition) {
         const handlers = this.handlers.get(event)
         if (!handlers) {
-            LOG.debug(`No handlers registered for event '${event}'.`)
+            LOG.debug(`No handlers registered for event '${JSON.stringify(event)}'.`)
             return
         }
         for (const handler of handlers) {

--- a/lib/traverser.js
+++ b/lib/traverser.js
@@ -58,7 +58,7 @@ class CsnTraverser {
     #emit(event, fq, definition) {
         const handlers = this.handlers.get(event)
         if (!handlers) {
-            LOG.debug(`No handlers registered for event '${JSON.stringify(event)}'.`)
+            LOG.debug(`No handlers registered for event '${event}'.`)
             return
         }
         for (const handler of handlers) {

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -389,7 +389,7 @@ class Visitor {
         // part of the name, so "A.B" and "A.Bs" just become "B" and "Bs" to be compared.
         if (last(plural?.normalised.plain) === `${last(singular?.normalised.plain ?? '')}_`) {
             LOG.warn(
-                `Derived singular and plural forms for '${singular}' are the same. This usually happens when your CDS entities are named following singular flexion. Consider naming your entities in plural or providing '@singular:'/ '@plural:' annotations to have a clear distinction between the two. Plural form will be renamed to '${plural}' to avoid compilation errors within the output.`
+                `Derived singular and plural forms for '${fq}' are the same. This usually happens when your CDS entities are named following singular flexion. Consider naming your entities in plural or providing '@singular:'/ '@plural:' annotations to have a clear distinction between the two. Plural form will be renamed to '${plural}' to avoid compilation errors within the output.`
             )
         }
 


### PR DESCRIPTION
This was only visible when explicitly setting `cds.typer.log_level` to `INFO` and broke during a recent refactor.