### PR TITLE
fix: Properly generate nested events in index.js files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 ### Deprecated
 ### Removed
 ### Fixed
+- Events with dotted names (e.g. `service S { event X.Y : {...} }`) now generate a properly namespaced class `namespace X { class Y }` instead of producing duplicate top-level identifiers.
+- Event names now use the service-relative name (e.g. `'X.Y'` without preceeding `S`), matching the name the CDS runtime uses when registering and emitting such events.
 ### Security
 
 ## [0.40.0] - 2026-06-22

--- a/lib/file.js
+++ b/lib/file.js
@@ -577,41 +577,43 @@ class SourceFile extends File {
     /**
      * Emits JS export lines for all events in this file.
      * Events without a dotted name (e.g. `OrderPlaced`) are exported directly.
-     * Events with a dotted name (e.g. `Something.Created`) are grouped by their scope prefix.
-     * If the prefix was already declared as an identifier by the printer (e.g. `Something` is an
-     * entity proxy), a dotted assignment is safe. Otherwise an object literal is emitted to avoid
-     * a runtime ReferenceError from assigning to an undefined parent.
+     * Events with a dotted name (e.g. `Something.Created` or `A.B.C`) first lazily initialise
+     * every intermediate segment with `??= {}`, then assign the leaf value. This is safe
+     * regardless of whether the parent identifier was declared earlier or not:
+     *   Something.Nested ??= {}
+     *   Something.Nested.Created = 'Something.Nested.Created'
+     * If `Something` itself was not previously declared, it is exported as an empty object first.
      * @param {import('./printers/javascript').Printer} jsp - printer
      * @returns {string[]}
      */
     #printEventExports(jsp) {
         const lines = []
-        /** @type {Map<string, {tail: string, value: string}[]>} */
-        const grouped = new Map()
+        /** @type {Set<string>} initialised intermediate paths, to avoid duplicate ??= lines */
+        const initialised = new Set()
         for (const { name } of this.events.fqs) {
-            // Use the service-relative name as value (e.g. `Something.Created`, not `MyService.Something.Created`),
-            // because the CDS runtime strips the service prefix before registering/emitting events.
             // Use the service-relative name as value (e.g. `Something.Created`, not `MyService.Something.Created`),
             // because the CDS runtime strips the service prefix before registering/emitting events.
             if (!name.includes('.')) {
                 lines.push(jsp.printExport(name, stringIdent(name)))
-            } else {
-                const dot = name.indexOf('.')
-                const head = name.slice(0, dot)
-                const tail = name.slice(dot + 1)
-                if (!grouped.has(head)) grouped.set(head, [])
-                grouped.get(head)?.push({ tail, value: name })
+                continue
             }
-        }
-        for (const [head, entries] of grouped) {
-            if (this.#declaredIdentifiers.has(head)) {
-                // `head` was already declared — dotted assignment is safe.
-                for (const { tail, value } of entries) lines.push(jsp.printExport(`${head}.${tail}`, stringIdent(value)))
-            } else {
-                // `head` was not declared — emit a plain object literal to avoid a ReferenceError.
-                const kvs = entries.map(({ tail, value }) => `${tail}: '${value}'`).join(', ')
-                lines.push(jsp.printExport(head, `{ ${kvs} }`))
+            const parts = name.split('.')
+            const head = parts[0]
+            // Ensure the top-level identifier exists.
+            if (!this.#declaredIdentifiers.has(head) && !initialised.has(head)) {
+                lines.push(jsp.printExport(head, '{}'))
+                initialised.add(head)
             }
+            // Lazily initialise each intermediate segment.
+            for (let i = 1; i < parts.length - 1; i++) {
+                const path = parts.slice(0, i + 1).join('.')
+                if (!initialised.has(path)) {
+                    lines.push(jsp.printExport(path, '{}', { coalesce: true }))
+                    initialised.add(path)
+                }
+            }
+            // Assign the leaf value.
+            lines.push(jsp.printExport(name, stringIdent(name)))
         }
         return lines
     }

--- a/lib/file.js
+++ b/lib/file.js
@@ -113,6 +113,8 @@ class SourceFile extends File {
     #jsPrinter
     /** @type {import('./printers/typescript').Printer | undefined} */
     #tsPrinter
+    /** @type {Set<string>} */
+    #declaredIdentifiers = new Set()
 
     /**
      * @param {string | Path} path - path to the file
@@ -156,9 +158,13 @@ class SourceFile extends File {
     }
 
     get jsPrinter () {
-        return this.#jsPrinter ??= configuration.targetModuleType === 'esm'
-            ? new ESMPrinter()
-            : new CJSPrinter()
+        if (!this.#jsPrinter) {
+            this.#jsPrinter = configuration.targetModuleType === 'esm'
+                ? new ESMPrinter()
+                : new CJSPrinter()
+            this.#jsPrinter.on('identifier', name => this.#declaredIdentifiers.add(name))
+        }
+        return this.#jsPrinter
     }
 
     /**
@@ -568,6 +574,48 @@ class SourceFile extends File {
         }
     }
 
+    /**
+     * Emits JS export lines for all events in this file.
+     * Events without a dotted name (e.g. `OrderPlaced`) are exported directly.
+     * Events with a dotted name (e.g. `Something.Created`) are grouped by their scope prefix.
+     * If the prefix was already declared as an identifier by the printer (e.g. `Something` is an
+     * entity proxy), a dotted assignment is safe. Otherwise an object literal is emitted to avoid
+     * a runtime ReferenceError from assigning to an undefined parent.
+     * @param {import('./printers/javascript').Printer} jsp - printer
+     * @returns {string[]}
+     */
+    #printEventExports(jsp) {
+        const lines = []
+        /** @type {Map<string, {tail: string, value: string}[]>} */
+        const grouped = new Map()
+        for (const { name } of this.events.fqs) {
+            // Use the service-relative name as value (e.g. `Something.Created`, not `MyService.Something.Created`),
+            // because the CDS runtime strips the service prefix before registering/emitting events.
+            // Use the service-relative name as value (e.g. `Something.Created`, not `MyService.Something.Created`),
+            // because the CDS runtime strips the service prefix before registering/emitting events.
+            if (!name.includes('.')) {
+                lines.push(jsp.printExport(name, stringIdent(name)))
+            } else {
+                const dot = name.indexOf('.')
+                const head = name.slice(0, dot)
+                const tail = name.slice(dot + 1)
+                if (!grouped.has(head)) grouped.set(head, [])
+                grouped.get(head)?.push({ tail, value: name })
+            }
+        }
+        for (const [head, entries] of grouped) {
+            if (this.#declaredIdentifiers.has(head)) {
+                // `head` was already declared — dotted assignment is safe.
+                for (const { tail, value } of entries) lines.push(jsp.printExport(`${head}.${tail}`, stringIdent(value)))
+            } else {
+                // `head` was not declared — emit a plain object literal to avoid a ReferenceError.
+                const kvs = entries.map(({ tail, value }) => `${tail}: '${value}'`).join(', ')
+                lines.push(jsp.printExport(head, `{ ${kvs} }`))
+            }
+        }
+        return lines
+    }
+
     toJSExports() {
         const jsp = this.jsPrinter
         return this.#getJSExportBoilerplate() // boilerplate
@@ -624,9 +672,7 @@ class SourceFile extends File {
                 })
             ) // singular -> plural aliases
             .concat(jsp.printSingleLineComment('events'))
-            // Use the service-relative name as value (e.g. `Something.Created`, not `MyService.Something.Created`),
-            // because the CDS runtime strips the service prefix before registering/emitting events.
-            .concat(this.events.fqs.map(({name}) => jsp.printExport(name, stringIdent(name))))
+            .concat(this.#printEventExports(jsp))
             .concat(jsp.printSingleLineComment('actions'))
             .concat(this.operations.names.map(name => jsp.printExport(name, stringIdent(name))))
             .concat(jsp.printSingleLineComment('enums'))

--- a/lib/file.js
+++ b/lib/file.js
@@ -401,6 +401,16 @@ class SourceFile extends File {
      */
     addEvent(name, fq) {
         this.events.fqs.push({ name, fq })
+        if (name.includes('.')) {
+            // A dotted event name like `Something.Created` gets typed as a nested namespace class.
+            // The entity proxy for `Something` must know about `Created` so its `get` trap can
+            // return the string value instead of throwing for an unknown property.
+            const dotIndex = name.lastIndexOf('.')
+            const entityName = name.slice(0, dotIndex)
+            const propName = name.slice(dotIndex + 1)
+            const entityProxy = this.entityProxies[entityName] ?? (this.entityProxies[entityName] = [])
+            entityProxy.push(propName)
+        }
     }
 
     /**
@@ -614,7 +624,9 @@ class SourceFile extends File {
                 })
             ) // singular -> plural aliases
             .concat(jsp.printSingleLineComment('events'))
-            .concat(this.events.fqs.map(({fq, name}) => jsp.printExport(name, stringIdent(fq))))
+            // Use the service-relative name as value (e.g. `Something.Created`, not `MyService.Something.Created`),
+            // because the CDS runtime strips the service prefix before registering/emitting events.
+            .concat(this.events.fqs.map(({name}) => jsp.printExport(name, stringIdent(name))))
             .concat(jsp.printSingleLineComment('actions'))
             .concat(this.operations.names.map(name => jsp.printExport(name, stringIdent(name))))
             .concat(jsp.printSingleLineComment('enums'))

--- a/lib/printers/javascript.js
+++ b/lib/printers/javascript.js
@@ -1,3 +1,5 @@
+const { EventEmitter } = require('node:events')
+
 /**
  * Forcefully overrides the .name property of a class.
  * See: https://github.com/microsoft/TypeScript/issues/442
@@ -7,6 +9,20 @@
 const overrideNameProperty = (clazz, content) => `Object.defineProperty(${clazz}, 'name', { value: '${content}' })`
 
 class JavaScriptPrinter {
+    #emitter = new EventEmitter()
+
+    /**
+     * @param {string} event - event name
+     * @param {(...args: unknown[]) => void} listener - listener function
+     */
+    on (event, listener) { this.#emitter.on(event, listener); return this }
+
+    /**
+     * @param {string} event - event name
+     * @param {unknown[]} args - event arguments
+     */
+    emit (event, ...args) { return this.#emitter.emit(event, ...args) }
+
     /**
      * @param {string} text - comment text
      */
@@ -19,6 +35,7 @@ class JavaScriptPrinter {
      * @param {string} value - initial assignment to the constant
      */
     printConstant (name, value) {
+        this.emit('identifier', name)
         return `const ${name} = ${value}`
     }
 
@@ -91,16 +108,19 @@ class JavaScriptPrinter {
 class ESMPrinter extends JavaScriptPrinter {
     /** @type {JavaScriptPrinter['printImport']} */
     printImport (alias, from) {
+        this.emit('identifier', alias)
         return `import * as ${alias} from '${from}'`
     }
 
     /** @type {JavaScriptPrinter['printDefaultImport']} */
     printDefaultImport (alias, from) {
+        this.emit('identifier', alias)
         return `import ${alias} from '${from}'`
     }
 
     /** @type {JavaScriptPrinter['printDeconstructedImport']} */
     printDeconstructedImport (imports, from) {
+        for (const name of imports) this.emit('identifier', name)
         return `import { ${imports.join(', ')} } from '${from}/index.js'`
     }
 
@@ -109,9 +129,11 @@ class ESMPrinter extends JavaScriptPrinter {
         const op = options?.coalesce
             ? '??='
             : '='
-        return name.includes('.')
-            ? `${name} ${op} ${value}`
-            : `export const ${name} = ${value}`
+        if (name.includes('.')) {
+            return `${name} ${op} ${value}`
+        }
+        this.emit('identifier', name)
+        return `export const ${name} = ${value}`
     }
 
     /** @type {JavaScriptPrinter['printDefaultExport']} */
@@ -128,16 +150,19 @@ class ESMPrinter extends JavaScriptPrinter {
 class CJSPrinter extends JavaScriptPrinter {
     /** @type {JavaScriptPrinter['printImport']} */
     printImport (alias, from) {
+        this.emit('identifier', alias)
         return `const ${alias} = require('${from}')`
     }
 
     /** @type {JavaScriptPrinter['printDefaultImport']} */
     printDefaultImport (alias, from) {
+        this.emit('identifier', alias)
         return `const ${alias} = require('${from}')`
     }
 
     /** @type {JavaScriptPrinter['printDeconstructedImport']} */
     printDeconstructedImport (imports, from) {
+        for (const name of imports) this.emit('identifier', name)
         return `const { ${imports.join(', ')} } = require('${from}')`
     }
 
@@ -146,6 +171,8 @@ class CJSPrinter extends JavaScriptPrinter {
         const op = options?.coalesce
             ? '??='
             : '='
+        // Emit the top-level segment of the name — module.exports.X makes X reachable as a property.
+        this.emit('identifier', name.includes('.') ? name.slice(0, name.indexOf('.')) : name)
         return `module.exports.${name} ${op} ${value}`
     }
 

--- a/lib/printers/typescript.js
+++ b/lib/printers/typescript.js
@@ -6,12 +6,12 @@ const { asClassIdentifier, asAspectFnIdentifier } = require('../resolution/entit
 const { empty } = require('../components/typescript')
 const { configuration } = require('../config')
 const { stringifyEnumType, csnToEnumPairs } = require('../components/enum')
+const { Identifier } = require('../components/identifier')
 
 /** @typedef {import('../typedefs').printer.PrintContext} PrintContext */
 /** @typedef {import('../csn').EntityCSN} EntityCSN */
 /** @typedef {import('../typedefs').resolver.EnumCSN} EnumCSN */
 /** @typedef {import('../typedefs').resolver.EntityInfo} EntityInfo */
-/** @typedef {import('../components/identifier')} Identifier */
 
 
 /**
@@ -406,12 +406,20 @@ class ImplementationPrinter extends TypeScriptPrinter {
             isDeclare: false,
             isOverride: false,
         })
-        return [
+        const { plain, scope } = new Identifier(entityName)
+        const classLines = [
             this.printSingleLineComment('event'),
-            `export declare class ${entityName} {`,
+            `export declare class ${plain} {`,
             ...indent([kindMember, ...body.parts], 2),
             '}'
         ]
+        // CDS allows dotted event names (`event X.Y`), producing a service-relative name like
+        // `Something.Created`. Wrapping the class in `namespace Something { ... }` avoids duplicate
+        // top-level identifiers when multiple entities each carry the same leaf name (e.g., `Created`).
+        return scope.toReversed().reduce(
+            (inner, ns) => [`export namespace ${ns} {`, ...indent(inner, 2), '}'],
+            classLines
+        )
     }
 }
 
@@ -477,12 +485,20 @@ class DeclarationPrinter extends TypeScriptPrinter {
             isReadonly: true,
             isDeclare: false,
         })
-        return [
+        const { plain, scope } = new Identifier(entityName)
+        const classLines = [
             this.printSingleLineComment('event'),
-            `export declare class ${entityName} {`,
+            `export declare class ${plain} {`,
             ...indent([kindMember, ...body.parts], 2),
             '}'
         ]
+        // CDS allows dotted event names (`event X.Y`), producing a service-relative name like
+        // `Something.Created`. Wrapping the class in `namespace Something { ... }` avoids duplicate
+        // top-level identifiers when multiple entities each carry the same leaf name (e.g., `Created`).
+        return scope.toReversed().reduce(
+            (inner, ns) => [`export namespace ${ns} {`, ...indent(inner, 2), '}'],
+            classLines
+        )
     }
 }
 

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -499,9 +499,10 @@ class Visitor {
      * @param {EntityCSN} event - CSN
      */
     #printEvent(fq, event) {
-        const { namespace, entityName } = this.entityRepository.getByFqOrThrow(fq)
+        const namespace = this.#resolveEventNamespace(fq)
         const file = this.fileRepository.getNamespaceFile(namespace)
-        file.addEvent(entityName, fq)
+        const className = fq.slice(namespace.asNamespace().length + 1)
+        file.addEvent(className, fq)
         const buffer = file.events.buffer
         const body = buffer.createSubBuffer()
         const propOpt = configuration.propertiesOptional
@@ -511,8 +512,29 @@ class Visitor {
             this.visitElement({name: ename, element, file, buffer: body})
         }
         configuration.propertiesOptional = propOpt
-        buffer.add(this.tsPrinter.printEvent({entityName, body}))
+        buffer.add(this.tsPrinter.printEvent({entityName: className, body}))
         file.addImport(baseDefinitions.path)
+    }
+
+    /**
+     * Resolves the namespace for an event FQ by walking up to find the nearest service/context ancestor.
+     * Events can have dotted names (`service S { event X.Y : {...} }`), which produces FQ `S.X.Y`.
+     * The intermediate segment `S.X` is never defined in the CSN, so the generic `resolveNamespace`
+     * would stop there, treating it as a namespace boundary. We must skip such phantom segments and
+     * anchor only on real service/context definitions.
+     * @param {string} fq - fully qualified name of the event
+     * @returns {Path}
+     */
+    #resolveEventNamespace(fq) {
+        const parts = fq.split('.')
+        for (let i = parts.length - 1; i > 0; i--) {
+            const ancestor = parts.slice(0, i).join('.')
+            const kind = this.csn.definitions[ancestor]?.kind
+            if (kind === 'service' || kind === 'context') {
+                return new Path(parts.slice(0, i))
+            }
+        }
+        return this.entityRepository.getByFqOrThrow(fq).namespace
     }
 
     /**

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -3,7 +3,7 @@
 const path = require('path')
 const { before, describe, it } = require('node:test')
 const assert = require('assert')
-const { check } = require('../ast')
+const { check, JSASTWrapper } = require('../ast')
 const { locations, prepareUnitTest } = require('../util')
 const { perEachTestConfig } = require('../config')
 const { configuration } = require('../../lib/config')
@@ -12,6 +12,7 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
     describe(`Events Tests (using output **/*/${outputFile} files)`, () => {
         let astw
         let serviceAstw
+        let serviceJsw
 
         before(async () => {
             configuration.outputDTsFiles = outputDTsFiles
@@ -21,6 +22,7 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
             assert.ok(servicePath, 'MyService namespace path should exist in output')
             const { ASTWrapper } = require('../ast')
             serviceAstw = new ASTWrapper(path.join(servicePath, outputFile))
+            serviceJsw = await JSASTWrapper.initialise(path.join(servicePath, 'index.js'))
         })
 
         describe('Builtin Imports Generation', () => {
@@ -58,6 +60,19 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
                     && cls.members[0].name === 'kind' && check.isReadonlyMember(cls.members[0])
                     && cls.members[1].name === 'id' && check.isNullable(cls.members[1].type, [check.isNumber])
                 ))
+            })
+
+            it('should emit dotted event as object literal in JS when scope prefix has no matching entity', async () => {
+                // `Scoped` is not an entity in MyService, so `Scoped.OrderPlaced = '...'` would throw
+                // at runtime. Instead the output must be `module.exports.Scoped = { OrderPlaced: 'Scoped.OrderPlaced' }`.
+                const node = serviceJsw.program.body.find(n =>
+                    n.type === 'ExpressionStatement' &&
+                    n.expression.left?.property?.name === 'Scoped' &&
+                    n.expression.right?.type === 'ObjectExpression'
+                )
+                assert.ok(node, 'module.exports.Scoped object literal assignment should exist in index.js')
+                const prop = node.expression.right.properties.find(p => p.key.name === 'OrderPlaced')
+                assert.strictEqual(prop?.value?.value, 'Scoped.OrderPlaced')
             })
         })
     })

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -18,10 +18,9 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
             const result = await prepareUnitTest('events/model.cds', locations.testOutput('events_test'))
             astw = result.astw
             const servicePath = result.paths.find(p => p.endsWith(path.join('events', 'MyService')))
-            if (servicePath) {
-                const { ASTWrapper } = require('../ast')
-                serviceAstw = new ASTWrapper(path.join(servicePath, outputFile))
-            }
+            assert.ok(servicePath, 'MyService namespace path should exist in output')
+            const { ASTWrapper } = require('../ast')
+            serviceAstw = new ASTWrapper(path.join(servicePath, outputFile))
         })
 
         describe('Builtin Imports Generation', () => {

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const path = require('path')
 const { before, describe, it } = require('node:test')
 const assert = require('assert')
 const { check } = require('../ast')
@@ -10,10 +11,17 @@ const { configuration } = require('../../lib/config')
 perEachTestConfig(({ outputDTsFiles, outputFile }) => {
     describe(`Events Tests (using output **/*/${outputFile} files)`, () => {
         let astw
+        let serviceAstw
 
         before(async () => {
             configuration.outputDTsFiles = outputDTsFiles
-            astw = (await prepareUnitTest('events/model.cds', locations.testOutput('events_test'))).astw
+            const result = await prepareUnitTest('events/model.cds', locations.testOutput('events_test'))
+            astw = result.astw
+            const servicePath = result.paths.find(p => p.endsWith(path.join('events', 'MyService')))
+            if (servicePath) {
+                const { ASTWrapper } = require('../ast')
+                serviceAstw = new ASTWrapper(path.join(servicePath, outputFile))
+            }
         })
 
         describe('Builtin Imports Generation', () => {
@@ -30,6 +38,26 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
                     && cls.members[1].name === 'id' && check.isNullable(cls.members[1].type, [check.isNumber])
                     && cls.members[2].name === 'name' && check.isNullable(cls.members[2].type, [check.isIndexedAccessType])
                     && cls.members[3].name === 'createdOn' && check.isNullable(cls.members[3].type, [check.isTypeReference])
+                ))
+            })
+
+            it('should generate event defined inside a service in the service namespace file', async () => {
+                assert.ok(serviceAstw, 'service namespace file should exist')
+                assert.ok(serviceAstw.tree.find(cls => cls.name === 'OrderPlaced'
+                    && cls.members.length === 2
+                    && cls.members[0].name === 'kind' && check.isReadonlyMember(cls.members[0])
+                    && cls.members[1].name === 'id' && check.isNullable(cls.members[1].type, [check.isNumber])
+                ))
+            })
+
+            it('should use dot-separated prefix as namespace for dotted event names', async () => {
+                assert.ok(serviceAstw, 'service namespace file should exist')
+                const ns = serviceAstw.getModuleDeclaration('Scoped')
+                assert.ok(ns, 'namespace Scoped should exist')
+                assert.ok(ns.body.find(cls => cls.name === 'OrderPlaced'
+                    && cls.members.length === 2
+                    && cls.members[0].name === 'kind' && check.isReadonlyMember(cls.members[0])
+                    && cls.members[1].name === 'id' && check.isNullable(cls.members[1].type, [check.isNumber])
                 ))
             })
         })

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -63,16 +63,59 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
             })
 
             it('should emit dotted event as object literal in JS when scope prefix has no matching entity', async () => {
-                // `Scoped` is not an entity in MyService, so `Scoped.OrderPlaced = '...'` would throw
-                // at runtime. Instead the output must be `module.exports.Scoped = { OrderPlaced: 'Scoped.OrderPlaced' }`.
-                const node = serviceJsw.program.body.find(n =>
+                // `Scoped` is not an entity — emit `Scoped = {}` first, then `Scoped.OrderPlaced = '...'`.
+                const initNode = serviceJsw.program.body.find(n =>
                     n.type === 'ExpressionStatement' &&
                     n.expression.left?.property?.name === 'Scoped' &&
-                    n.expression.right?.type === 'ObjectExpression'
+                    n.expression.right?.type === 'ObjectExpression' &&
+                    n.expression.right?.properties?.length === 0
                 )
-                assert.ok(node, 'module.exports.Scoped object literal assignment should exist in index.js')
-                const prop = node.expression.right.properties.find(p => p.key.name === 'OrderPlaced')
-                assert.strictEqual(prop?.value?.value, 'Scoped.OrderPlaced')
+                assert.ok(initNode, 'module.exports.Scoped = {} initialiser should exist in index.js')
+                const assignNode = serviceJsw.program.body.find(n =>
+                    n.type === 'ExpressionStatement' &&
+                    n.expression.left?.property?.name === 'OrderPlaced' &&
+                    n.expression.left?.object?.property?.name === 'Scoped'
+                )
+                assert.ok(assignNode, 'module.exports.Scoped.OrderPlaced assignment should exist in index.js')
+                assert.strictEqual(assignNode.expression.right?.value, 'Scoped.OrderPlaced')
+            })
+
+            it('should nest namespaces for events with more than one dot', async () => {
+                const ns = serviceAstw.getModuleDeclaration('Deeply')
+                assert.ok(ns, 'namespace Deeply should exist')
+                const innerNs = ns.body.find(n => n.name === 'Scoped')
+                assert.ok(innerNs, 'namespace Deeply.Scoped should exist')
+                assert.ok(innerNs.body.find(cls => cls.name === 'OrderPlaced'
+                    && cls.members.length === 2
+                    && cls.members[0].name === 'kind' && check.isReadonlyMember(cls.members[0])
+                    && cls.members[1].name === 'id' && check.isNullable(cls.members[1].type, [check.isNumber])
+                ))
+            })
+
+            it('should emit deeply dotted event with lazy intermediate initialisation in JS', async () => {
+                // `Deeply.Scoped.OrderPlaced`: emit `Deeply = {}`, `Deeply.Scoped ??= {}`, then the leaf.
+                const initNode = serviceJsw.program.body.find(n =>
+                    n.type === 'ExpressionStatement' &&
+                    n.expression.left?.property?.name === 'Deeply' &&
+                    n.expression.right?.type === 'ObjectExpression' &&
+                    n.expression.right?.properties?.length === 0
+                )
+                assert.ok(initNode, 'module.exports.Deeply = {} initialiser should exist')
+                const coalesceNode = serviceJsw.program.body.find(n =>
+                    n.type === 'ExpressionStatement' &&
+                    n.expression.operator === '??=' &&
+                    n.expression.left?.property?.name === 'Scoped' &&
+                    n.expression.left?.object?.property?.name === 'Deeply'
+                )
+                assert.ok(coalesceNode, 'module.exports.Deeply.Scoped ??= {} coalesce should exist')
+                const assignNode = serviceJsw.program.body.find(n =>
+                    n.type === 'ExpressionStatement' &&
+                    n.expression.left?.property?.name === 'OrderPlaced' &&
+                    n.expression.left?.object?.property?.name === 'Scoped' &&
+                    n.expression.left?.object?.object?.property?.name === 'Deeply'
+                )
+                assert.ok(assignNode, 'module.exports.Deeply.Scoped.OrderPlaced assignment should exist')
+                assert.strictEqual(assignNode.expression.right?.value, 'Deeply.Scoped.OrderPlaced')
             })
         })
     })

--- a/test/unit/files/events/model.cds
+++ b/test/unit/files/events/model.cds
@@ -10,3 +10,12 @@ event Bar : {
   createdOn : Timestamp;
 };
 
+service MyService {
+  event OrderPlaced : {
+    id : Integer;
+  };
+  event Scoped.OrderPlaced : {
+    id : Integer;
+  };
+}
+

--- a/test/unit/files/events/model.cds
+++ b/test/unit/files/events/model.cds
@@ -17,5 +17,8 @@ service MyService {
   event Scoped.OrderPlaced : {
     id : Integer;
   };
+  event Deeply.Scoped.OrderPlaced : {
+    id : Integer;
+  };
 }
 


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/584

Addresses two related problems:

1. fix name collisions
```cds
service SampleService {

    entity Something {}
    entity SomethingElse {}

    event Something.Created : Something;
    event SomethingElse.Created : SomethingElse;
}
```
would result in two colliding `Created` artefacts in the generated index.js. They now result in `Something.Created = ...` and `SomethingElse.Created = ...`.

2. fix scoping of events
Events were formerly generated with their full qualifier, ie. `MyEvent = 'FooService.MyEvent'`. But the service context is actually given through the service the user connected to during runtime:

```js
const srv = cds.connect.to('FooService')
srv.on('MyEvent', ...)  // no "FooService"
srv.emit('MyEvent')  // same here
```

So they are now generated to be `MyEvent = 'MyEvent'`.
