### PR TITLE
fix: Flatten properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Events with dotted names (e.g. `service S { event X.Y : {...} }`) now generate a properly namespaced class `namespace X { class Y }` instead of producing duplicate top-level identifiers.
 - Event names now use the service-relative name (e.g. `'X.Y'` without preceeding `S`), matching the name the CDS runtime uses when registering and emitting such events.
+- Entity elements of named struct types used within CDS aspects are now correctly flattened when using `--inlineDeclarations flat`
 ### Security
 
 ## [0.40.0] - 2026-06-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Events with dotted names (e.g. `service S { event X.Y : {...} }`) now generate a properly namespaced class `namespace X { class Y }` instead of producing duplicate top-level identifiers.
 - Event names now use the service-relative name (e.g. `'X.Y'` without preceeding `S`), matching the name the CDS runtime uses when registering and emitting such events.
-- Entity elements of named struct types used within CDS aspects are now correctly flattened when using `--inlineDeclarations flat`
+- Entity elements of named struct types used within CDS aspects are now correctly flattened when using `--inlineDeclarations flat`.
 ### Security
 
 ## [0.40.0] - 2026-06-22

--- a/lib/csn.js
+++ b/lib/csn.js
@@ -60,6 +60,11 @@ const isType = entity => entity?.kind === 'type'
 const isEntity = entity => entity?.kind === 'entity'
 
 /**
+ * @param {EntityCSN} entity - the entity
+ */
+const isAspect = entity => entity?.kind === 'aspect'
+
+/**
  * @param {EntityCSN | undefined} entity - the entity
  * @returns {entity is import("./typedefs").resolver.EnumCSN}
  */
@@ -362,6 +367,7 @@ function lookUpRefType (csn, ref) {
 
 module.exports = {
     collectDraftEnabledEntities,
+    isAspect,
     isView,
     isProjection,
     isViewOrProjection,

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { propagateForeignKeys, propagateInflectionAnnotations, collectDraftEnabledEntities, isType, getMaxCardinality, isViewOrProjection, isEnum, isEntity } = require('./csn')
+const { propagateForeignKeys, propagateInflectionAnnotations, collectDraftEnabledEntities, isType, getMaxCardinality, isViewOrProjection, isEnum, isEntity, isAspect } = require('./csn')
 const { CsnTraverser } = require('./traverser')
 // eslint-disable-next-line no-unused-vars
 const { SourceFile, FileRepository, Buffer, Path } = require('./file')
@@ -166,7 +166,7 @@ class Visitor {
         /** @type {import('./typedefs').resolver.EnumCSN[]} */
         const enums = []
         /** @type {TypeResolveOptions} */
-        const resolverOptions = { forceInlineStructs: isEntity(entity) && configuration.inlineDeclarations === 'flat'}
+        const resolverOptions = { forceInlineStructs: (isEntity(entity) || isAspect(entity)) && configuration.inlineDeclarations === 'flat'}
 
         for (let [ename, element] of Object.entries(entity.elements ?? [])) {
             if (inheritedElements?.has(ename)) continue

--- a/test/unit/files/inline/named-struct-model.cds
+++ b/test/unit/files/inline/named-struct-model.cds
@@ -1,4 +1,4 @@
-namespace inline;
+espace inline;
 
 // named struct type used as element type (issue #347, user report)
 type Author : {
@@ -11,6 +11,10 @@ type ContentVersionType : {
     Production  : String;
 }
 
+aspect ContentAspect {
+    ContentVersion : ContentVersionType;
+}
+
 entity Books {
     key ID    : UUID;
     title     : String;
@@ -20,4 +24,8 @@ entity Books {
 entity ContentItem {
     key ID             : UUID;
     ContentVersion     : ContentVersionType;
+}
+
+entity ContentItemWithAspect : ContentAspect {
+    key ID : UUID;
 }

--- a/test/unit/files/inline/named-struct-model.cds
+++ b/test/unit/files/inline/named-struct-model.cds
@@ -1,0 +1,23 @@
+namespace inline;
+
+// named struct type used as element type (issue #347, user report)
+type Author : {
+    firstName : String;
+    lastName  : String;
+}
+
+type ContentVersionType : {
+    Development : String;
+    Production  : String;
+}
+
+entity Books {
+    key ID    : UUID;
+    title     : String;
+    author    : Author;
+}
+
+entity ContentItem {
+    key ID             : UUID;
+    ContentVersion     : ContentVersionType;
+}

--- a/test/unit/files/inline/named-struct-model.cds
+++ b/test/unit/files/inline/named-struct-model.cds
@@ -1,4 +1,4 @@
-espace inline;
+namespace inline;
 
 // named struct type used as element type (issue #347, user report)
 type Author : {

--- a/test/unit/inline.test.js
+++ b/test/unit/inline.test.js
@@ -10,60 +10,65 @@ const { configuration } = require('../../lib/config')
 perEachTestConfig(({ outputDTsFiles, outputFile }) => {
     describe(`Named Struct Type Declarations (using output **/*/${outputFile} files)`, () => {
         // Regression tests for https://github.com/cap-js/cds-typer/issues/347
-        // When an entity element uses a named struct type (e.g. author: Author), the typer
-        // must reference the named type directly instead of flattening it inline —
-        // regardless of the inlineDeclarations setting.
+        // Named struct types used as entity elements must be flattened in flat mode because
+        // the CDS runtime (OData/SQL layer) exposes them as flat properties (e.g. author_firstName).
+        // In structured mode they are referenced by their type name.
 
-        it('should reference named struct type by name in structured mode (issue #347)', async () => {
+        it('should reference named struct type by name in structured mode', async () => {
             configuration.outputDTsFiles = outputDTsFiles
             const astw = (await prepareUnitTest(
                 'inline/named-struct-model.cds',
                 locations.testOutput('inline_named_struct_structured')
             )).astw
-            // author: Author  →  author?: Author | null  (no flattening)
+            // structured mode: author: Author  →  author?: Author | null
             assert.ok(astw.exists('_BookAspect', 'author', node =>
                 (outputDTsFiles || check.hasDeclareModifier(node))
                 && check.isNullable(node.type, [t => check.isTypeReference(t, 'Author')])
             ))
-            // ContentVersion: ContentVersionType  →  ContentVersion?: ContentVersionType | null
+            // structured mode: ContentVersion: ContentVersionType  →  ContentVersion?: ContentVersionType | null
             assert.ok(astw.exists('_ContentItemAspect', 'ContentVersion', node =>
                 (outputDTsFiles || check.hasDeclareModifier(node))
                 && check.isNullable(node.type, [t => check.isTypeReference(t, 'ContentVersionType')])
             ))
         })
 
-        it('should reference named struct type by name in flat mode (issue #347)', async () => {
+        it('should flatten named struct type in flat mode (issue #347)', async () => {
             configuration.outputDTsFiles = outputDTsFiles
             const astw = (await prepareUnitTest(
                 'inline/named-struct-model.cds',
                 locations.testOutput('inline_named_struct_flat'),
                 { typerOptions: { inlineDeclarations: 'flat' } }
             )).astw
-            // author: Author  →  must NOT be flattened to author_firstName / author_lastName
-            // The named type must be preserved: author?: Author | null
-            assert.ok(astw.exists('_BookAspect', 'author', node =>
+            // flat mode: author: Author  →  author_firstName, author_lastName (matching OData/SQL runtime)
+            assert.ok(astw.exists('_BookAspect', 'author_firstName', node =>
                 (outputDTsFiles || check.hasDeclareModifier(node))
-                && check.isNullable(node.type, [t => check.isTypeReference(t, 'Author')])
+                && check.isNullable(node.type, [check.isString])
             ))
-            // ContentVersion: ContentVersionType  →  must NOT be flattened to ContentVersion_Development etc.
-            assert.ok(astw.exists('_ContentItemAspect', 'ContentVersion', node =>
+            assert.ok(astw.exists('_BookAspect', 'author_lastName', node =>
                 (outputDTsFiles || check.hasDeclareModifier(node))
-                && check.isNullable(node.type, [t => check.isTypeReference(t, 'ContentVersionType')])
+                && check.isNullable(node.type, [check.isString])
+            ))
+            // flat mode: ContentVersion: ContentVersionType  →  ContentVersion_Development, ContentVersion_Production
+            assert.ok(astw.exists('_ContentItemAspect', 'ContentVersion_Development', node =>
+                (outputDTsFiles || check.hasDeclareModifier(node))
+                && check.isNullable(node.type, [check.isString])
+            ))
+            assert.ok(astw.exists('_ContentItemAspect', 'ContentVersion_Production', node =>
+                (outputDTsFiles || check.hasDeclareModifier(node))
+                && check.isNullable(node.type, [check.isString])
             ))
         })
 
-        it('should not produce flattened properties for named struct type in flat mode (issue #347)', async () => {
+        it('should not produce a named type reference property in flat mode', async () => {
             configuration.outputDTsFiles = outputDTsFiles
             const astw = (await prepareUnitTest(
                 'inline/named-struct-model.cds',
-                locations.testOutput('inline_named_struct_flat_noflat'),
+                locations.testOutput('inline_named_struct_flat_noref'),
                 { typerOptions: { inlineDeclarations: 'flat' } }
             )).astw
-            // Flat properties like author_firstName must NOT appear — they shadow the named type reference
-            assert.throws(() => astw.exists('_BookAspect', 'author_firstName'), /does not feature a property/)
-            assert.throws(() => astw.exists('_BookAspect', 'author_lastName'), /does not feature a property/)
-            assert.throws(() => astw.exists('_ContentItemAspect', 'ContentVersion_Development'), /does not feature a property/)
-            assert.throws(() => astw.exists('_ContentItemAspect', 'ContentVersion_Production'), /does not feature a property/)
+            // flat mode must not emit the parent property pointing to the named type
+            assert.throws(() => astw.exists('_BookAspect', 'author'), /does not feature a property/)
+            assert.throws(() => astw.exists('_ContentItemAspect', 'ContentVersion'), /does not feature a property/)
         })
     })
 

--- a/test/unit/inline.test.js
+++ b/test/unit/inline.test.js
@@ -8,6 +8,65 @@ const { perEachTestConfig } = require('../config')
 const { configuration } = require('../../lib/config')
 
 perEachTestConfig(({ outputDTsFiles, outputFile }) => {
+    describe(`Named Struct Type Declarations (using output **/*/${outputFile} files)`, () => {
+        // Regression tests for https://github.com/cap-js/cds-typer/issues/347
+        // When an entity element uses a named struct type (e.g. author: Author), the typer
+        // must reference the named type directly instead of flattening it inline —
+        // regardless of the inlineDeclarations setting.
+
+        it('should reference named struct type by name in structured mode (issue #347)', async () => {
+            configuration.outputDTsFiles = outputDTsFiles
+            const astw = (await prepareUnitTest(
+                'inline/named-struct-model.cds',
+                locations.testOutput('inline_named_struct_structured')
+            )).astw
+            // author: Author  →  author?: Author | null  (no flattening)
+            assert.ok(astw.exists('_BookAspect', 'author', node =>
+                (outputDTsFiles || check.hasDeclareModifier(node))
+                && check.isNullable(node.type, [t => check.isTypeReference(t, 'Author')])
+            ))
+            // ContentVersion: ContentVersionType  →  ContentVersion?: ContentVersionType | null
+            assert.ok(astw.exists('_ContentItemAspect', 'ContentVersion', node =>
+                (outputDTsFiles || check.hasDeclareModifier(node))
+                && check.isNullable(node.type, [t => check.isTypeReference(t, 'ContentVersionType')])
+            ))
+        })
+
+        it('should reference named struct type by name in flat mode (issue #347)', async () => {
+            configuration.outputDTsFiles = outputDTsFiles
+            const astw = (await prepareUnitTest(
+                'inline/named-struct-model.cds',
+                locations.testOutput('inline_named_struct_flat'),
+                { typerOptions: { inlineDeclarations: 'flat' } }
+            )).astw
+            // author: Author  →  must NOT be flattened to author_firstName / author_lastName
+            // The named type must be preserved: author?: Author | null
+            assert.ok(astw.exists('_BookAspect', 'author', node =>
+                (outputDTsFiles || check.hasDeclareModifier(node))
+                && check.isNullable(node.type, [t => check.isTypeReference(t, 'Author')])
+            ))
+            // ContentVersion: ContentVersionType  →  must NOT be flattened to ContentVersion_Development etc.
+            assert.ok(astw.exists('_ContentItemAspect', 'ContentVersion', node =>
+                (outputDTsFiles || check.hasDeclareModifier(node))
+                && check.isNullable(node.type, [t => check.isTypeReference(t, 'ContentVersionType')])
+            ))
+        })
+
+        it('should not produce flattened properties for named struct type in flat mode (issue #347)', async () => {
+            configuration.outputDTsFiles = outputDTsFiles
+            const astw = (await prepareUnitTest(
+                'inline/named-struct-model.cds',
+                locations.testOutput('inline_named_struct_flat_noflat'),
+                { typerOptions: { inlineDeclarations: 'flat' } }
+            )).astw
+            // Flat properties like author_firstName must NOT appear — they shadow the named type reference
+            assert.throws(() => astw.exists('_BookAspect', 'author_firstName'), /does not feature a property/)
+            assert.throws(() => astw.exists('_BookAspect', 'author_lastName'), /does not feature a property/)
+            assert.throws(() => astw.exists('_ContentItemAspect', 'ContentVersion_Development'), /does not feature a property/)
+            assert.throws(() => astw.exists('_ContentItemAspect', 'ContentVersion_Production'), /does not feature a property/)
+        })
+    })
+
     describe(`Inline Type Declarations (using output **/*/${outputFile} files)`, () => {
         it('should verify structured inline type declarations', async () => {
             configuration.outputDTsFiles = outputDTsFiles

--- a/test/unit/inline.test.js
+++ b/test/unit/inline.test.js
@@ -25,11 +25,16 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
                 (outputDTsFiles || check.hasDeclareModifier(node))
                 && check.isNullable(node.type, [t => check.isTypeReference(t, 'Author')])
             ))
+            // structured mode must not emit flat sub-properties
+            assert.throws(() => astw.exists('_BookAspect', 'author_firstName'), /does not feature a property/)
+            assert.throws(() => astw.exists('_BookAspect', 'author_lastName'), /does not feature a property/)
             // structured mode: ContentVersion: ContentVersionType  →  ContentVersion?: ContentVersionType | null
             assert.ok(astw.exists('_ContentItemAspect', 'ContentVersion', node =>
                 (outputDTsFiles || check.hasDeclareModifier(node))
                 && check.isNullable(node.type, [t => check.isTypeReference(t, 'ContentVersionType')])
             ))
+            assert.throws(() => astw.exists('_ContentItemAspect', 'ContentVersion_Development'), /does not feature a property/)
+            assert.throws(() => astw.exists('_ContentItemAspect', 'ContentVersion_Production'), /does not feature a property/)
         })
 
         it('should flatten named struct type in flat mode (issue #347)', async () => {
@@ -48,6 +53,8 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
                 (outputDTsFiles || check.hasDeclareModifier(node))
                 && check.isNullable(node.type, [check.isString])
             ))
+            // flat mode must not emit the parent property pointing to the named type
+            assert.throws(() => astw.exists('_BookAspect', 'author'), /does not feature a property/)
             // flat mode: ContentVersion: ContentVersionType  →  ContentVersion_Development, ContentVersion_Production
             assert.ok(astw.exists('_ContentItemAspect', 'ContentVersion_Development', node =>
                 (outputDTsFiles || check.hasDeclareModifier(node))
@@ -57,17 +64,6 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
                 (outputDTsFiles || check.hasDeclareModifier(node))
                 && check.isNullable(node.type, [check.isString])
             ))
-        })
-
-        it('should not produce a named type reference property in flat mode', async () => {
-            configuration.outputDTsFiles = outputDTsFiles
-            const astw = (await prepareUnitTest(
-                'inline/named-struct-model.cds',
-                locations.testOutput('inline_named_struct_flat_noref'),
-                { typerOptions: { inlineDeclarations: 'flat' } }
-            )).astw
-            // flat mode must not emit the parent property pointing to the named type
-            assert.throws(() => astw.exists('_BookAspect', 'author'), /does not feature a property/)
             assert.throws(() => astw.exists('_ContentItemAspect', 'ContentVersion'), /does not feature a property/)
         })
 
@@ -87,15 +83,6 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
                 (outputDTsFiles || check.hasDeclareModifier(node))
                 && check.isNullable(node.type, [check.isString])
             ))
-        })
-
-        it('should not produce a named type reference property in aspect in flat mode', async () => {
-            configuration.outputDTsFiles = outputDTsFiles
-            const astw = (await prepareUnitTest(
-                'inline/named-struct-model.cds',
-                locations.testOutput('inline_named_struct_aspect_flat_noref'),
-                { typerOptions: { inlineDeclarations: 'flat' } }
-            )).astw
             assert.throws(() => astw.exists('_ContentAspectAspect', 'ContentVersion'), /does not feature a property/)
         })
     })

--- a/test/unit/inline.test.js
+++ b/test/unit/inline.test.js
@@ -70,6 +70,34 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
             assert.throws(() => astw.exists('_BookAspect', 'author'), /does not feature a property/)
             assert.throws(() => astw.exists('_ContentItemAspect', 'ContentVersion'), /does not feature a property/)
         })
+
+        it('should flatten named struct type in aspect in flat mode', async () => {
+            configuration.outputDTsFiles = outputDTsFiles
+            const astw = (await prepareUnitTest(
+                'inline/named-struct-model.cds',
+                locations.testOutput('inline_named_struct_aspect_flat'),
+                { typerOptions: { inlineDeclarations: 'flat' } }
+            )).astw
+            // flat mode: ContentVersion: ContentVersionType inside an aspect must also flatten
+            assert.ok(astw.exists('_ContentAspectAspect', 'ContentVersion_Development', node =>
+                (outputDTsFiles || check.hasDeclareModifier(node))
+                && check.isNullable(node.type, [check.isString])
+            ))
+            assert.ok(astw.exists('_ContentAspectAspect', 'ContentVersion_Production', node =>
+                (outputDTsFiles || check.hasDeclareModifier(node))
+                && check.isNullable(node.type, [check.isString])
+            ))
+        })
+
+        it('should not produce a named type reference property in aspect in flat mode', async () => {
+            configuration.outputDTsFiles = outputDTsFiles
+            const astw = (await prepareUnitTest(
+                'inline/named-struct-model.cds',
+                locations.testOutput('inline_named_struct_aspect_flat_noref'),
+                { typerOptions: { inlineDeclarations: 'flat' } }
+            )).astw
+            assert.throws(() => astw.exists('_ContentAspectAspect', 'ContentVersion'), /does not feature a property/)
+        })
     })
 
     describe(`Inline Type Declarations (using output **/*/${outputFile} files)`, () => {


### PR DESCRIPTION
# Fix: Flatten Named Struct Type Properties in Flat Mode

### Bug Fix

🐛 Resolved an issue where named struct types used as entity or aspect elements were not being properly flattened in `--inlineDeclarations flat` mode. The CDS runtime (OData/SQL layer) exposes nested struct properties as flat properties (e.g., `author_firstName`, `author_lastName`), but the typer was previously emitting a type reference instead of flattening the struct's fields. The fix also extends this behavior to CDS **aspects**, not just entities.

### Changes

* `lib/csn.js`: Added a new `isAspect` helper function that checks if a CSN entity node is of kind `'aspect'`, and exported it alongside existing helpers.
* `lib/visitor.js`: Updated the `resolverOptions` logic to also trigger inline struct flattening for CDS aspects (`isAspect(entity)`), in addition to the existing entity check, when flat mode is active.
* `test/unit/files/inline/named-struct-model.cds`: Added a new CDS test fixture defining named struct types (`Author`, `ContentVersionType`), a `ContentAspect`, and entities (`Books`, `ContentItem`, `ContentItemWithAspect`) to serve as regression test models for issue #347.
* `test/unit/inline.test.js`: Added three regression tests covering:
  - **Structured mode**: Named struct types are referenced by their type name (e.g., `author?: Author | null`).
  - **Flat mode**: Named struct types are flattened into underscore-separated properties (e.g., `author_firstName`, `author_lastName`), with no parent property emitted.
  - **Flat mode in aspects**: Named struct types inside CDS aspects are also correctly flattened.
* `CHANGELOG.md`: Added a changelog entry documenting the fix under the unreleased section.

### GitHub Issues

* [#347](https://github.com/cap-js/cds-typer/issues/347): [BUG] Entity element with named struct type not correctly reflected in generated types

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.28.0`

- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.edited`
- Correlation ID: `3070fec0-8414-11f1-9436-32565d931398`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- GithubContextProvider: [https://github.com/cap-js/cds-typer/issues/347](https://github.com/cap-js/cds-typer/issues/347)
</details>
