### PR TITLE
fix: Static event kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Deprecated
 ### Removed
 ### Fixed
+- emit `kind` property on events as static member to be properly consumed by `cds-types`.
 ### Security
 
 ## [0.40.1] - 2026-07-21

--- a/lib/printers/typescript.js
+++ b/lib/printers/typescript.js
@@ -481,7 +481,7 @@ class DeclarationPrinter extends TypeScriptPrinter {
         const kindMember = createMember({
             name: 'kind',
             type: stringIdent('event'),
-            isStatic: false,
+            isStatic: true,
             isReadonly: true,
             isDeclare: false,
         })

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -35,7 +35,7 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
             it('should have a top-level event with correct members', async () => {
                 assert.ok(astw.tree.find(cls => cls.name === 'Bar'
                     && cls.members.length === 4
-                    && cls.members[0].name === 'kind' && check.isReadonlyMember(cls.members[0])
+                    && cls.members[0].name === 'kind' && check.isReadonlyMember(cls.members[0]) && check.isStaticMember(cls.members[0])
                     && cls.members[1].name === 'id' && check.isNullable(cls.members[1].type, [check.isNumber])
                     && cls.members[2].name === 'name' && check.isNullable(cls.members[2].type, [check.isIndexedAccessType])
                     && cls.members[3].name === 'createdOn' && check.isNullable(cls.members[3].type, [check.isTypeReference])
@@ -46,7 +46,7 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
                 assert.ok(serviceAstw, 'service namespace file should exist')
                 assert.ok(serviceAstw.tree.find(cls => cls.name === 'OrderPlaced'
                     && cls.members.length === 2
-                    && cls.members[0].name === 'kind' && check.isReadonlyMember(cls.members[0])
+                    && cls.members[0].name === 'kind' && check.isReadonlyMember(cls.members[0]) && check.isStaticMember(cls.members[0])
                     && cls.members[1].name === 'id' && check.isNullable(cls.members[1].type, [check.isNumber])
                 ))
             })
@@ -57,7 +57,7 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
                 assert.ok(ns, 'namespace Scoped should exist')
                 assert.ok(ns.body.find(cls => cls.name === 'OrderPlaced'
                     && cls.members.length === 2
-                    && cls.members[0].name === 'kind' && check.isReadonlyMember(cls.members[0])
+                    && cls.members[0].name === 'kind' && check.isReadonlyMember(cls.members[0]) && check.isStaticMember(cls.members[0])
                     && cls.members[1].name === 'id' && check.isNullable(cls.members[1].type, [check.isNumber])
                 ))
             })
@@ -87,7 +87,7 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
                 assert.ok(innerNs, 'namespace Deeply.Scoped should exist')
                 assert.ok(innerNs.body.find(cls => cls.name === 'OrderPlaced'
                     && cls.members.length === 2
-                    && cls.members[0].name === 'kind' && check.isReadonlyMember(cls.members[0])
+                    && cls.members[0].name === 'kind' && check.isReadonlyMember(cls.members[0]) && check.isStaticMember(cls.members[0])
                     && cls.members[1].name === 'id' && check.isNullable(cls.members[1].type, [check.isNumber])
                 ))
             })


### PR DESCRIPTION
Fixes #642

The `kind` property generally belongs to the class. It was incorrectly emitted as instance property for events. That threw off cds-types, which explicitly looks for a static member of name `kind` to strictly type `.on(MyEvent, ...)` handlers.