### PR TITLE
fix: Do not cut namespaces from top-level events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 ### Fixed
 - emit `kind` property on events as static member to be properly consumed by `cds-types`.
+- do not cut off leading namespaces from top-level events, but only leading service names from events nested therein.
 ### Security
 
 ## [0.40.1] - 2026-07-21

--- a/lib/file.js
+++ b/lib/file.js
@@ -402,11 +402,12 @@ class SourceFile extends File {
     /**
      * Adds an event to this file.
      * are supposed to be present in this file.
-     * @param {string} name - cleaned name of the event
+     * @param {string} name - cleaned name of the event (relative to file namespace, used as TS class name and JS export key)
      * @param {string} fq - fully qualified name, including the namespace
+     * @param {string} [runtimeName] - event name as seen by the CDS runtime (FQ minus service prefix; defaults to name)
      */
-    addEvent(name, fq) {
-        this.events.fqs.push({ name, fq })
+    addEvent(name, fq, runtimeName = name) {
+        this.events.fqs.push({ name, fq, runtimeName })
         if (name.includes('.')) {
             // A dotted event name like `Something.Created` gets typed as a nested namespace class.
             // The entity proxy for `Something` must know about `Created` so its `get` trap can
@@ -590,11 +591,11 @@ class SourceFile extends File {
         const lines = []
         /** @type {Set<string>} initialised intermediate paths, to avoid duplicate ??= lines */
         const initialised = new Set()
-        for (const { name } of this.events.fqs) {
-            // Use the service-relative name as value (e.g. `Something.Created`, not `MyService.Something.Created`),
-            // because the CDS runtime strips the service prefix before registering/emitting events.
+        for (const { name, runtimeName } of this.events.fqs) {
+            // Use the runtime name as string value: the CDS runtime strips the service prefix when
+            // registering/emitting events, but explicit namespaces and contexts are NOT stripped.
             if (!name.includes('.')) {
-                lines.push(jsp.printExport(name, stringIdent(name)))
+                lines.push(jsp.printExport(name, stringIdent(runtimeName)))
                 continue
             }
             const parts = name.split('.')
@@ -613,7 +614,7 @@ class SourceFile extends File {
                 }
             }
             // Assign the leaf value.
-            lines.push(jsp.printExport(name, stringIdent(name)))
+            lines.push(jsp.printExport(name, stringIdent(runtimeName)))
         }
         return lines
     }

--- a/lib/file.js
+++ b/lib/file.js
@@ -129,7 +129,7 @@ class SourceFile extends File {
         this.imports = {}
         /** @type {Buffer} */
         this.preamble = new Buffer()
-        /** @type {{ buffer: Buffer, fqs: {name: string, fq: string}[]}} */
+        /** @type {{ buffer: Buffer, fqs: {name: string, fq: string, runtimeName: string}[]}} */
         this.events = { buffer: new Buffer(), fqs: []}
         /** @type {Buffer} */
         this.types = new Buffer()

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -499,10 +499,18 @@ class Visitor {
      * @param {EntityCSN} event - CSN
      */
     #printEvent(fq, event) {
-        const namespace = this.#resolveEventNamespace(fq)
+        const serviceAncestor = this.#findServiceAncestor(fq)
+        // File placement: use the generic resolver which stops at the nearest service or context.
+        // For events inside a service with dotted names (e.g. `S.X.Y`), `S.X` is a phantom segment
+        // not in the CSN, so we use the service ancestor directly when present.
+        const namespace = serviceAncestor ?? this.entityRepository.getByFqOrThrow(fq).namespace
         const file = this.fileRepository.getNamespaceFile(namespace)
         const className = fq.slice(namespace.asNamespace().length + 1)
-        file.addEvent(className, fq)
+        // The runtime event name strips only the service prefix; explicit namespaces/contexts are kept.
+        const runtimeName = serviceAncestor
+            ? fq.slice(serviceAncestor.asNamespace().length + 1)
+            : fq
+        file.addEvent(className, fq, runtimeName)
         const buffer = file.events.buffer
         const body = buffer.createSubBuffer()
         const propOpt = configuration.propertiesOptional
@@ -517,24 +525,24 @@ class Visitor {
     }
 
     /**
-     * Resolves the namespace for an event FQ by walking up to find the nearest service/context ancestor.
-     * Events can have dotted names (`service S { event X.Y : {...} }`), which produces FQ `S.X.Y`.
-     * The intermediate segment `S.X` is never defined in the CSN, so the generic `resolveNamespace`
-     * would stop there, treating it as a namespace boundary. We must skip such phantom segments and
-     * anchor only on real service/context definitions.
+     * Finds the nearest service ancestor of an event FQ, skipping phantom intermediate segments.
+     * Events can have dotted names (`service S { event X.Y : {...} }`), producing FQ `S.X.Y`.
+     * `S.X` is never defined in the CSN, so we must skip undefined segments and only anchor
+     * on real service definitions. Contexts are intentionally NOT stripped — their name is part
+     * of the runtime event identity.
      * @param {string} fq - fully qualified name of the event
-     * @returns {Path}
+     * @returns {Path | null} Path of the enclosing service, or null if none
      */
-    #resolveEventNamespace(fq) {
+    #findServiceAncestor(fq) {
         const parts = fq.split('.')
         for (let i = parts.length - 1; i > 0; i--) {
             const ancestor = parts.slice(0, i).join('.')
             const kind = this.csn.definitions[ancestor]?.kind
-            if (kind === 'service' || kind === 'context') {
+            if (kind === 'service') {
                 return new Path(parts.slice(0, i))
             }
         }
-        return this.entityRepository.getByFqOrThrow(fq).namespace
+        return null
     }
 
     /**

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -13,6 +13,8 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
         let astw
         let serviceAstw
         let serviceJsw
+        let contextAstw
+        let contextJsw
 
         before(async () => {
             configuration.outputDTsFiles = outputDTsFiles
@@ -20,9 +22,13 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
             astw = result.astw
             const servicePath = result.paths.find(p => p.endsWith(path.join('events', 'MyService')))
             assert.ok(servicePath, 'MyService namespace path should exist in output')
+            const contextPath = result.paths.find(p => p.endsWith(path.join('events', 'ExplicitContext')))
+            assert.ok(contextPath, 'ExplicitContext namespace path should exist in output')
             const { ASTWrapper } = require('../ast')
             serviceAstw = new ASTWrapper(path.join(servicePath, outputFile))
             serviceJsw = await JSASTWrapper.initialise(path.join(servicePath, 'index.js'))
+            contextAstw = new ASTWrapper(path.join(contextPath, outputFile))
+            contextJsw = await JSASTWrapper.initialise(path.join(contextPath, 'index.js'))
         })
 
         describe('Builtin Imports Generation', () => {
@@ -116,6 +122,29 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
                 )
                 assert.ok(assignNode, 'module.exports.Deeply.Scoped.OrderPlaced assignment should exist')
                 assert.strictEqual(assignNode.expression.right?.value, 'Deeply.Scoped.OrderPlaced')
+            })
+        })
+
+        describe('Explicit Context Namespace', () => {
+            it('should generate event defined inside a context in the context namespace file', async () => {
+                assert.ok(contextAstw, 'context namespace file should exist')
+                assert.ok(contextAstw.tree.find(cls => cls.name === 'ContextEvent'
+                    && cls.members.length === 2
+                    && cls.members[0].name === 'kind' && check.isReadonlyMember(cls.members[0]) && check.isStaticMember(cls.members[0])
+                    && cls.members[1].name === 'id' && check.isNullable(cls.members[1].type, [check.isNumber])
+                ))
+            })
+
+            it('should retain the context name in the JS string value', async () => {
+                // The CDS runtime does NOT strip context names — only service names.
+                // So `events.ExplicitContext.ContextEvent` must emit 'events.ExplicitContext.ContextEvent',
+                // not just 'ContextEvent'.
+                const assignNode = contextJsw.program.body.find(n =>
+                    n.type === 'ExpressionStatement' &&
+                    n.expression.left?.property?.name === 'ContextEvent'
+                )
+                assert.ok(assignNode, 'module.exports.ContextEvent assignment should exist in index.js')
+                assert.strictEqual(assignNode.expression.right?.value, 'events.ExplicitContext.ContextEvent')
             })
         })
     })

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -11,6 +11,7 @@ const { configuration } = require('../../lib/config')
 perEachTestConfig(({ outputDTsFiles, outputFile }) => {
     describe(`Events Tests (using output **/*/${outputFile} files)`, () => {
         let astw
+        let topLevelJsw
         let serviceAstw
         let serviceJsw
         let contextAstw
@@ -20,11 +21,14 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
             configuration.outputDTsFiles = outputDTsFiles
             const result = await prepareUnitTest('events/model.cds', locations.testOutput('events_test'))
             astw = result.astw
+            const topLevelPath = result.paths.find(p => p.endsWith('events') && !p.endsWith(path.join('events', 'MyService')) && !p.endsWith(path.join('events', 'ExplicitContext')))
+            assert.ok(topLevelPath, 'top-level events namespace path should exist in output')
             const servicePath = result.paths.find(p => p.endsWith(path.join('events', 'MyService')))
             assert.ok(servicePath, 'MyService namespace path should exist in output')
             const contextPath = result.paths.find(p => p.endsWith(path.join('events', 'ExplicitContext')))
             assert.ok(contextPath, 'ExplicitContext namespace path should exist in output')
             const { ASTWrapper } = require('../ast')
+            topLevelJsw = await JSASTWrapper.initialise(path.join(topLevelPath, 'index.js'))
             serviceAstw = new ASTWrapper(path.join(servicePath, outputFile))
             serviceJsw = await JSASTWrapper.initialise(path.join(servicePath, 'index.js'))
             contextAstw = new ASTWrapper(path.join(contextPath, outputFile))
@@ -48,6 +52,17 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
                 ))
             })
 
+            it('should retain the namespace prefix in the JS string value for top-level events', async () => {
+                // `Bar` is defined directly in `namespace events` — no service ancestor, so the
+                // full FQ `events.Bar` must be used as the string value.
+                const assignNode = topLevelJsw.program.body.find(n =>
+                    n.type === 'ExpressionStatement' &&
+                    n.expression.left?.property?.name === 'Bar'
+                )
+                assert.ok(assignNode, 'module.exports.Bar assignment should exist in index.js')
+                assert.strictEqual(assignNode.expression.right?.value, 'events.Bar')
+            })
+
             it('should generate event defined inside a service in the service namespace file', async () => {
                 assert.ok(serviceAstw, 'service namespace file should exist')
                 assert.ok(serviceAstw.tree.find(cls => cls.name === 'OrderPlaced'
@@ -55,6 +70,19 @@ perEachTestConfig(({ outputDTsFiles, outputFile }) => {
                     && cls.members[0].name === 'kind' && check.isReadonlyMember(cls.members[0]) && check.isStaticMember(cls.members[0])
                     && cls.members[1].name === 'id' && check.isNullable(cls.members[1].type, [check.isNumber])
                 ))
+            })
+
+            it('should strip the service prefix from the JS string value for service events', async () => {
+                // The CDS runtime strips the service prefix when registering/emitting events, so
+                // `events.MyService.OrderPlaced` must emit 'OrderPlaced', not 'events.MyService.OrderPlaced'.
+                const assignNode = serviceJsw.program.body.find(n =>
+                    n.type === 'ExpressionStatement' &&
+                    n.expression.left?.property?.name === 'OrderPlaced' &&
+                    n.expression.left?.object?.type === 'MemberExpression' && // module.exports, not a nested path
+                    n.expression.left?.object?.property?.name === 'exports'
+                )
+                assert.ok(assignNode, 'module.exports.OrderPlaced assignment should exist in index.js')
+                assert.strictEqual(assignNode.expression.right?.value, 'OrderPlaced')
             })
 
             it('should use dot-separated prefix as namespace for dotted event names', async () => {

--- a/test/unit/files/events/model.cds
+++ b/test/unit/files/events/model.cds
@@ -22,3 +22,9 @@ service MyService {
   };
 }
 
+context ExplicitContext {
+  event ContextEvent : {
+    id : Integer;
+  };
+}
+


### PR DESCRIPTION
# Fix: Preserve Namespace Prefixes in Generated Event String Values

### Bug Fix

🐛 Previously, the CDS type generator incorrectly stripped explicit context/namespace prefixes from event string values in generated JavaScript exports. The fix ensures only the *service* prefix is removed at runtime (as the CDS runtime does), while explicit `context` and namespace segments are preserved in the emitted string identifiers.

**Example:** An event `events.ExplicitContext.ContextEvent` was incorrectly exported as `'ContextEvent'` instead of the correct `'events.ExplicitContext.ContextEvent'`.

### Changes

* `lib/visitor.js`: Renamed `#resolveEventNamespace` to `#findServiceAncestor` to better reflect its purpose. Updated `#printEvent` to compute a separate `runtimeName` — stripping only the service prefix, not context/namespace segments. The ancestor search now stops only at `service` definitions, intentionally skipping `context` kinds so their names remain part of the runtime event identity.

* `lib/file.js`: Updated `addEvent` to accept an optional `runtimeName` parameter (defaults to `name`). Updated `#printEventExports` to use `runtimeName` as the string value in JS exports instead of `name`, correctly preserving namespace context in the emitted string literals.

* `test/unit/events.test.js`: Added a new `Explicit Context Namespace` test suite verifying that:
  - Events defined inside a CDS `context` are emitted to the correct namespace file.
  - The generated JS export retains the full context-qualified name as the string value.

* `test/unit/files/events/model.cds`: Added a new `ExplicitContext` context with a `ContextEvent` to cover the fixed scenario.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.2`

- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `1af95d20-898d-11f1-9da1-957b1fdbb63c`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
