### PR TITLE
chore: add workflow for issue management

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,0 +1,47 @@
+name: Issue Management
+
+permissions:
+  issues: write
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  label_new_issues:
+    if: github.event.action == 'opened'
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: New
+
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `👋 Hello @${context.payload.issue.user.login}, thank you for submitting this issue. Our team is reviewing your report and will follow up with you as soon as possible.`
+            })
+
+  remove_manual_new_label:
+    if: |
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'New' &&
+      github.event.sender.login != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove "New" label if applied by non-bot user
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --remove-label "New"


### PR DESCRIPTION
# Add GitHub Actions Workflow for Issue Management

### Chore

🔧 Introduces a GitHub Actions workflow to automate issue management, improving the triaging process for newly opened issues.

### Changes

* `.github/workflows/issue.yml`: Adds a new workflow with two jobs:
  - **`label_new_issues`**: Automatically applies the `New` label to any newly opened issue and posts a welcome comment thanking the reporter and notifying them that the team is reviewing their submission.
  - **`remove_manual_new_label`**: Prevents manual misuse of the `New` label by removing it if a non-bot user (i.e., anyone other than `github-actions[bot]`) manually applies it, ensuring the label is only set programmatically.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.2`

- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `5161b0c0-8a8b-11f1-9c46-b8a73d87063d`
</details>
