### PR TITLE
fix: Adjust boilerplate for cds10 defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Deprecated
 ### Removed
 ### Fixed
+- properly handle `.texts` properties in combination with `compat_texts_entities=false` (default in cds10) during runtime.
 ### Security
 
 ## [0.40.2] - 2026-07-27

--- a/lib/boilerplate/tsBoilerplate.ts
+++ b/lib/boilerplate/tsBoilerplate.ts
@@ -78,7 +78,7 @@ export const createEntityProxy = function (fqParts: any, opts = {}) {
         get: function (target:any, prop:any) {
             if (cds.entities) {
                 const ns = cds.entities(fqParts[0])
-                let entity = ns[fqParts[1]]
+                let entity: any = ns[fqParts[1]]
                 if (!entity && fqParts[1]?.endsWith('.texts')) {
                     // compat_texts_entities=false (CAP v10 default): texts entities are not
                     // registered as top-level entries, access them via the parent entity instead

--- a/lib/boilerplate/tsBoilerplate.ts
+++ b/lib/boilerplate/tsBoilerplate.ts
@@ -77,7 +77,14 @@ export const createEntityProxy = function (fqParts: any, opts = {}) {
     return new Proxy(target, {
         get: function (target:any, prop:any) {
             if (cds.entities) {
-                target.__proto__ = cds.entities(fqParts[0])[fqParts[1]]
+                const ns = cds.entities(fqParts[0])
+                let entity = ns[fqParts[1]]
+                if (!entity && fqParts[1]?.endsWith('.texts')) {
+                    // compat_texts_entities=false (CAP v10 default): texts entities are not
+                    // registered as top-level entries, access them via the parent entity instead
+                    entity = ns[fqParts[1].slice(0, -'.texts'.length)]?.texts
+                }
+                target.__proto__ = entity
                 // overwrite/simplify getter after cds.entities is accessible
                 this.get = (target, prop) => target[prop]
                 return target[prop]

--- a/lib/boilerplate/tsBoilerplate.ts
+++ b/lib/boilerplate/tsBoilerplate.ts
@@ -1,5 +1,5 @@
 import cds from '@sap/cds'
-import { type } from '@sap/cds'
+import { type, entity } from '@sap/cds'
 
 export type ElementsOf<T> = {[name in keyof Required<T>]: type }
 
@@ -78,7 +78,7 @@ export const createEntityProxy = function (fqParts: any, opts = {}) {
         get: function (target:any, prop:any) {
             if (cds.entities) {
                 const ns = cds.entities(fqParts[0])
-                let entity: any = ns[fqParts[1]]
+                let entity: entity | undefined = ns[fqParts[1]]
                 if (!entity && fqParts[1]?.endsWith('.texts')) {
                     // compat_texts_entities=false (CAP v10 default): texts entities are not
                     // registered as top-level entries, access them via the parent entity instead

--- a/lib/boilerplate/tsBoilerplate.ts
+++ b/lib/boilerplate/tsBoilerplate.ts
@@ -78,11 +78,12 @@ export const createEntityProxy = function (fqParts: any, opts = {}) {
         get: function (target:any, prop:any) {
             if (cds.entities) {
                 const ns = cds.entities(fqParts[0])
+                const textsSuffix = '.texts'
                 let entity: entity | undefined = ns[fqParts[1]]
-                if (!entity && fqParts[1]?.endsWith('.texts')) {
+                if (!entity && fqParts[1]?.endsWith(textsSuffix)) {
                     // compat_texts_entities=false (CAP v10 default): texts entities are not
                     // registered as top-level entries, access them via the parent entity instead
-                    entity = ns[fqParts[1].slice(0, -'.texts'.length)]?.texts
+                    entity = ns[fqParts[1].slice(0, -textsSuffix.length)]?.texts
                 }
                 target.__proto__ = entity
                 // overwrite/simplify getter after cds.entities is accessible

--- a/lib/components/javascript.js
+++ b/lib/components/javascript.js
@@ -8,11 +8,12 @@ const proxyAccessFunction = function (fqParts, opts = {}) {
         get: function (target, prop) {
             if (cds.entities) {
                 const ns = cds.entities(fqParts[0])
+                const textsSuffix = '.texts'
                 let entity = ns[fqParts[1]]
-                if (!entity && fqParts[1]?.endsWith('.texts')) {
+                if (!entity && fqParts[1]?.endsWith(textsSuffix)) {
                     // compat_texts_entities=false (CAP v10 default): texts entities are not
                     // registered as top-level entries, access them via the parent entity instead
-                    entity = ns[fqParts[1].slice(0, -'.texts'.length)]?.texts
+                    entity = ns[fqParts[1].slice(0, -textsSuffix.length)]?.texts
                 }
                 target.__proto__ = entity
                 // overwrite/simplify getter after cds.entities is accessible

--- a/lib/components/javascript.js
+++ b/lib/components/javascript.js
@@ -7,7 +7,14 @@ const proxyAccessFunction = function (fqParts, opts = {}) {
     return new Proxy(target, {
         get: function (target, prop) {
             if (cds.entities) {
-                target.__proto__ = cds.entities(fqParts[0])[fqParts[1]]
+                const ns = cds.entities(fqParts[0])
+                let entity = ns[fqParts[1]]
+                if (!entity && fqParts[1]?.endsWith('.texts')) {
+                    // compat_texts_entities=false (CAP v10 default): texts entities are not
+                    // registered as top-level entries, access them via the parent entity instead
+                    entity = ns[fqParts[1].slice(0, -'.texts'.length)]?.texts
+                }
+                target.__proto__ = entity
                 // overwrite/simplify getter after cds.entities is accessible
                 this.get = (target, prop) => target[prop]
                 return target[prop]


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/646

# Adjust Boilerplate for CAP v10 `compat_texts_entities=false` Default

### Bug Fix

🐛 Fixed entity proxy resolution for `texts` entities to be compatible with the CAP v10 default behavior, where `compat_texts_entities=false` means `.texts` entities are no longer registered as top-level entries in the namespace.

### Changes

Previously, the entity proxy directly accessed `cds.entities(namespace)[entityName]`, which would return `undefined` for `.texts` entities under CAP v10 defaults. The fix adds a fallback to look up the `texts` property via the parent entity instead.

* `lib/boilerplate/tsBoilerplate.ts`: Updated `createEntityProxy` to resolve `.texts` entities via their parent entity's `texts` property when the direct top-level lookup fails.
* `lib/components/javascript.js`: Applied the same fallback logic to the `proxyAccessFunction` used in generated JavaScript types.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.9`

- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `31a13bb0-8cb7-11f1-8da9-bcf87a36df58`
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
</details>
