### PR TITLE
feat: Allow using remote inline enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 ### Fixed
 - properly handle `.texts` properties in combination with `compat_texts_entities=false` (default in cds10) during runtime.
+- emit correct import and namespace-qualified type reference for inline enum companion types when the parent type is defined in a different namespace.
 ### Security
 
 ## [0.40.2] - 2026-07-27

--- a/lib/resolution/resolver.js
+++ b/lib/resolution/resolver.js
@@ -726,12 +726,14 @@ class Resolver {
                     }
                 } else {
                     const parentNamespace = this.resolveNamespace(element.parent.name)
-                    const parentPath = new Path(parentNamespace.split('.'))
-                    if (!parentPath.isCwd(file.path.asDirectory())) {
-                        file.addImport(parentPath)
-                        const parentIdent = parentPath.asIdentifier()
-                        result.type = `${parentIdent}.${enumName}`
-                        result.plainName = `${parentIdent}.${enumName}`
+                    if (parentNamespace) {
+                        const parentPath = new Path(parentNamespace.split('.'))
+                        if (!parentPath.isCwd(file.path.asDirectory())) {
+                            file.addImport(parentPath)
+                            const parentIdent = parentPath.asIdentifier()
+                            result.type = `${parentIdent}.${enumName}`
+                            result.plainName = `${parentIdent}.${enumName}`
+                        }
                     }
                 }
             } else {

--- a/lib/resolution/resolver.js
+++ b/lib/resolution/resolver.js
@@ -711,6 +711,8 @@ class Resolver {
 
                 // When the parent entity is a projection of an entity from a different namespace,
                 // the enum is declared in the source namespace — qualify the reference accordingly.
+                // When the parent is a plain type/entity defined in a different namespace (not a projection),
+                // similarly qualify the reference so the companion types are imported and properly namespaced.
                 const parentDef = element.parent.name ? this.csn.definitions[element.parent.name] : undefined
                 const sourceRef = parentDef?.query?.from?.ref?.[0] ?? parentDef?.projection?.from?.ref?.[0]
                 if (sourceRef) {
@@ -721,6 +723,15 @@ class Resolver {
                         const sourceIdent = sourcePath.asIdentifier()
                         result.type = `${sourceIdent}.${enumName}`
                         result.plainName = `${sourceIdent}.${enumName}`
+                    }
+                } else {
+                    const parentNamespace = this.resolveNamespace(element.parent.name)
+                    const parentPath = new Path(parentNamespace.split('.'))
+                    if (!parentPath.isCwd(file.path.asDirectory())) {
+                        file.addImport(parentPath)
+                        const parentIdent = parentPath.asIdentifier()
+                        result.type = `${parentIdent}.${enumName}`
+                        result.plainName = `${parentIdent}.${enumName}`
                     }
                 }
             } else {

--- a/test/unit/enum.test.js
+++ b/test/unit/enum.test.js
@@ -238,7 +238,6 @@ describe('Inline Enum in Association Key referenced from Service', () => {
 
 describe('Inline Enum from cross-namespace type reference', () => {
     const fs = require('node:fs')
-    let schemaNsAstw
     let serviceAstw
     let schemaNsSource
     let serviceSource
@@ -248,7 +247,6 @@ describe('Inline Enum from cross-namespace type reference', () => {
         // paths[0] = _, paths[1] = TestService, paths[2] = inline_enum_type_schema
         const schemaNsFile = path.join(paths[2], 'index.ts')
         const serviceFile  = path.join(paths[1], 'index.ts')
-        schemaNsAstw  = new ASTWrapper(schemaNsFile)
         serviceAstw   = new ASTWrapper(serviceFile)
         schemaNsSource = fs.readFileSync(schemaNsFile, 'utf-8')
         serviceSource  = fs.readFileSync(serviceFile, 'utf-8')

--- a/test/unit/enum.test.js
+++ b/test/unit/enum.test.js
@@ -236,6 +236,69 @@ describe('Inline Enum in Association Key referenced from Service', () => {
     })
 })
 
+describe('Inline Enum from cross-namespace type reference', () => {
+    const fs = require('node:fs')
+    let schemaNsAstw
+    let serviceAstw
+    let schemaNsSource
+    let serviceSource
+
+    before(async () => {
+        const paths = (await prepareUnitTest('enums/inline-in-type/service.cds', locations.testOutput('enums_inline_in_type'), { typerOptions: { outputDTsFiles: false, inlineDeclarations: 'flat' } })).paths
+        // paths[0] = _, paths[1] = TestService, paths[2] = inline_enum_type_schema
+        const schemaNsFile = path.join(paths[2], 'index.ts')
+        const serviceFile  = path.join(paths[1], 'index.ts')
+        schemaNsAstw  = new ASTWrapper(schemaNsFile)
+        serviceAstw   = new ASTWrapper(serviceFile)
+        schemaNsSource = fs.readFileSync(schemaNsFile, 'utf-8')
+        serviceSource  = fs.readFileSync(serviceFile, 'utf-8')
+    })
+
+    it('should export first inline enum companion from the schema namespace', () => {
+        assert.ok(
+            schemaNsSource.includes('export const NumberRestriction_restrictionType'),
+            'NumberRestriction_restrictionType const must be exported from schema namespace'
+        )
+        assert.ok(
+            schemaNsSource.includes('export type NumberRestriction_restrictionType'),
+            'NumberRestriction_restrictionType type must be exported from schema namespace'
+        )
+    })
+
+    it('should export second inline enum companion from the schema namespace', () => {
+        assert.ok(
+            schemaNsSource.includes('export const NumberRestriction_unit'),
+            'NumberRestriction_unit const must be exported from schema namespace'
+        )
+        assert.ok(
+            schemaNsSource.includes('export type NumberRestriction_unit'),
+            'NumberRestriction_unit type must be exported from schema namespace'
+        )
+    })
+
+    it('should import the schema namespace in the service namespace', () => {
+        assert.ok(
+            serviceSource.includes('inline_enum_type_schema'),
+            'service index.ts must import the schema namespace'
+        )
+    })
+
+    it('should reference inline enum companion types with namespace prefix in service', () => {
+        assert.ok(
+            serviceAstw.exists('_QuestionAspect', 'numberRestriction_restrictionType',
+                ({type}) => check.isNullable(type, [t => check.isTypeReference(t, '_inline_enum_type_schema.NumberRestriction_restrictionType')])
+            ),
+            '_QuestionAspect.numberRestriction_restrictionType should be typed as _inline_enum_type_schema.NumberRestriction_restrictionType | null'
+        )
+        assert.ok(
+            serviceAstw.exists('_QuestionAspect', 'numberRestriction_unit',
+                ({type}) => check.isNullable(type, [t => check.isTypeReference(t, '_inline_enum_type_schema.NumberRestriction_unit')])
+            ),
+            '_QuestionAspect.numberRestriction_unit should be typed as _inline_enum_type_schema.NumberRestriction_unit | null'
+        )
+    })
+})
+
 perEachTestConfig(({ outputDTsFiles, outputFile }) => {
     describe(`Enums of typeof (using output **/*/${outputFile} files)`, () => {
         /* FIXME: these should actually be inline-defined enums of the referenced type with explicit values

--- a/test/unit/files/enums/inline-in-type/schema.cds
+++ b/test/unit/files/enums/inline-in-type/schema.cds
@@ -1,0 +1,12 @@
+namespace inline_enum_type_schema;
+
+type NumberRestriction {
+    restrictionType : String enum {
+        Number = 'NU';
+        Between = 'BT';
+    };
+    unit : String enum {
+        None = 'NONE';
+        Currency = 'CURR';
+    };
+}

--- a/test/unit/files/enums/inline-in-type/service.cds
+++ b/test/unit/files/enums/inline-in-type/service.cds
@@ -1,0 +1,7 @@
+using { inline_enum_type_schema } from './schema';
+
+service TestService {
+    entity Questions {
+        numberRestriction : inline_enum_type_schema.NumberRestriction;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-typer/issues/588

# Allow Using Remote Inline Enums Across Namespaces

### Bug Fix / New Feature

✨ Extends support for inline enum resolution to handle types and entities defined in a **different namespace** (not just projections). Previously, when a service referenced a type with inline enums from a foreign namespace, the generated TypeScript would not correctly qualify the enum companion type references or add the required imports. This change ensures the schema namespace is imported and enum types are properly prefixed in the generated output.

### Changes

* `lib/resolution/resolver.js`: Added an `else` branch to the inline enum resolution logic. When the parent entity/type is **not** a projection (i.e., no `sourceRef` via `query.from` or `projection.from`), the resolver now resolves the parent's own namespace, adds the necessary import, and qualifies the enum type reference with the namespace identifier (e.g., `_inline_enum_type_schema.NumberRestriction_restrictionType`). A clarifying comment was also added explaining both cases.

* `test/unit/enum.test.js`: Added a new test suite `Inline Enum from cross-namespace type reference` that:
  - Verifies inline enum companion types (`const` and `type`) are exported from the schema namespace.
  - Checks that the service namespace imports the schema namespace.
  - Asserts that flattened inline enum properties in the service entity are typed with the correct namespace-qualified references (e.g., `_inline_enum_type_schema.NumberRestriction_restrictionType | null`).

* `test/unit/files/enums/inline-in-type/schema.cds`: New CDS fixture defining a `NumberRestriction` type with two inline string enums (`restrictionType` and `unit`) in the `inline_enum_type_schema` namespace.

* `test/unit/files/enums/inline-in-type/service.cds`: New CDS fixture defining a `TestService` that references `inline_enum_type_schema.NumberRestriction` as a flat property on a `Questions` entity, driving the cross-namespace inline enum scenario.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.30`

- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- Correlation ID: `a5ffcb10-9ad2-11f1-8a4a-6b68e913af72`
</details>
